### PR TITLE
Issue 22: Allow blank watch namespace

### DIFF
--- a/cmd/pravega-operator/main.go
+++ b/cmd/pravega-operator/main.go
@@ -5,9 +5,9 @@ import (
 	"runtime"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
-	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/pravega/pravega-operator/pkg/stub"
+	"github.com/pravega/pravega-operator/pkg/utils/k8sutil"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,7 +22,7 @@ func main() {
 
 	resource := "pravega.pravega.io/v1alpha1"
 	kind := "PravegaCluster"
-	namespace, err := k8sutil.GetWatchNamespace()
+	namespace, err := k8sutil.GetWatchNamespaceAllowBlank()
 	if err != nil {
 		logrus.Fatalf("Failed to get watch namespace: %v", err)
 	}

--- a/pkg/utils/k8sutil/k8sutil.go
+++ b/pkg/utils/k8sutil/k8sutil.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
+	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
 )
 
 func AsOwnerRef(pravegaCluster *api.PravegaCluster) *metav1.OwnerReference {
@@ -28,4 +30,13 @@ func DeleteCollection(apiVersion string, kind string, namespace string, labels s
 	return resourceClient.DeleteCollection(nil, metav1.ListOptions{
 		LabelSelector: labels,
 	})
+}
+
+// GetWatchNamespaceAllowBlank returns the namespace the operator should be watching for changes
+func GetWatchNamespaceAllowBlank() (string, error) {
+	ns, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s must be set", k8sutil.WatchNamespaceEnvVar)
+	}
+	return ns, nil
 }


### PR DESCRIPTION
This allows a blank Watch namespace to be passed in that signifies the operator should watch ALL namespaces for PravegaCluster resources.