### PR TITLE
[issue-33] Use Docker image from Pravega organization

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: pravega-operator
-          image: maddisondavid/pravega-operator:latest
+          image: pravega/pravega-operator:latest
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Fixes #33 

I've pushed the current operator image to [`docker.io/pravega/pravega-operator`](https://hub.docker.com/r/pravega/pravega-operator/) and updated the image reference in the Yaml file.