### PR TITLE
Issue 74: Handle Go errors correctly

### DIFF
--- a/pkg/pravega/sync.go
+++ b/pkg/pravega/sync.go
@@ -22,22 +22,22 @@ import (
 
 func ReconcilePravegaCluster(pravegaCluster *api.PravegaCluster) (err error) {
 
-	deployBookie(pravegaCluster)
+	err = deployBookie(pravegaCluster)
 	if err != nil {
 		return err
 	}
 
-	deployController(pravegaCluster)
+	err = deployController(pravegaCluster)
 	if err != nil {
 		return err
 	}
 
-	deploySegmentStore(pravegaCluster)
+	err = deploySegmentStore(pravegaCluster)
 	if err != nil {
 		return err
 	}
 
-	syncClusterSize(pravegaCluster)
+	err = syncClusterSize(pravegaCluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The Go errors in the `ReconcilePravegaCluster()` function were never handled correctly. That is, upon receiving an error by one of the called functions, the `err` variable would never be set.

This PR fixes this by explicitly setting the `err` variable every time a new call is made.