### PR TITLE
Issue 74: Handle Go errors correctly

### DIFF
--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -36,13 +36,11 @@ const (
 func deploySegmentStore(pravegaCluster *api.PravegaCluster) (err error) {
 	err = sdk.Create(makeSegmentstoreConfigMap(pravegaCluster))
 	if err != nil && !errors.IsAlreadyExists(err) {
-		logrus.Error(err)
 		return err
 	}
 
 	err = sdk.Create(makeSegmentStoreStatefulSet(pravegaCluster))
 	if err != nil && !errors.IsAlreadyExists(err) {
-		logrus.Error(err)
 		return err
 	}
 

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -37,12 +37,16 @@ func deploySegmentStore(pravegaCluster *api.PravegaCluster) (err error) {
 	err = sdk.Create(makeSegmentstoreConfigMap(pravegaCluster))
 	if err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Error(err)
+		return err
 	}
 
 	err = sdk.Create(makeSegmentStoreStatefulSet(pravegaCluster))
 	if err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Error(err)
+		return err
 	}
+
+	return nil
 }
 
 func destroySegmentstoreCacheVolumes(metadata metav1.ObjectMeta) {

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -33,8 +33,8 @@ const (
 	segmentStoreKind      = "pravega-segmentstore"
 )
 
-func deploySegmentStore(pravegaCluster *api.PravegaCluster) {
-	err := sdk.Create(makeSegmentstoreConfigMap(pravegaCluster))
+func deploySegmentStore(pravegaCluster *api.PravegaCluster) (err error) {
+	err = sdk.Create(makeSegmentstoreConfigMap(pravegaCluster))
 	if err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Error(err)
 	}

--- a/pkg/pravega/sync.go
+++ b/pkg/pravega/sync.go
@@ -21,23 +21,22 @@ import (
 )
 
 func ReconcilePravegaCluster(pravegaCluster *api.PravegaCluster) (err error) {
-
-	deployBookie(pravegaCluster)
+	err = deployBookie(pravegaCluster)
 	if err != nil {
 		return err
 	}
 
-	deployController(pravegaCluster)
+	err = deployController(pravegaCluster)
 	if err != nil {
 		return err
 	}
 
-	deploySegmentStore(pravegaCluster)
+	err = deploySegmentStore(pravegaCluster)
 	if err != nil {
 		return err
 	}
 
-	syncClusterSize(pravegaCluster)
+	err = syncClusterSize(pravegaCluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/pravega/sync.go
+++ b/pkg/pravega/sync.go
@@ -45,8 +45,16 @@ func ReconcilePravegaCluster(pravegaCluster *api.PravegaCluster) (err error) {
 }
 
 func syncClusterSize(pravegaCluster *api.PravegaCluster) (err error) {
-	syncBookieSize(pravegaCluster)
-	syncSegmentStoreSize(pravegaCluster)
+	err = syncBookieSize(pravegaCluster)
+	if err != nil {
+		return err
+	}
+
+	err = syncSegmentStoreSize(pravegaCluster)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/pravega"
+	"github.com/sirupsen/logrus"
 )
 
 func NewHandler() sdk.Handler {
@@ -26,7 +27,7 @@ type Handler struct {
 	// Fill me
 }
 
-func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
+func (h *Handler) Handle(ctx context.Context, event sdk.Event) (err error) {
 	if event.Deleted {
 		// K8s will garbage collect and resources until pravega cluster delete
 		return nil
@@ -34,7 +35,12 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 
 	switch o := event.Object.(type) {
 	case *api.PravegaCluster:
-		pravega.ReconcilePravegaCluster(o)
+		err = pravega.ReconcilePravegaCluster(o)
+		if err != nil {
+			logrus.Error(err)
+			return err
+		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
The Go errors in the `ReconcilePravegaCluster()` function were never handled correctly. That is, upon receiving an error by one of the called functions, the `err` variable would never be set.

This PR fixes this by explicitly setting the `err` variable every time a new call is made.

Signed-off-by: Olivier Bourgeois <olivier.bourgeois@emc.com>