### PR TITLE
Issue 61: Support external connectivity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
 - '1.10'
+- '1.11'
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- '1.11'
+- '1.10'
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-- '1.10'
 - '1.11'
 
 sudo: required

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -33,6 +33,17 @@ rules:
 
 ---
 
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pravega-operator
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "watch", "list"]
+
+---
+
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -42,5 +53,19 @@ subjects:
   name: default
 roleRef:
   kind: Role
+  name: pravega-operator
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-pravega-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: ClusterRole
   name: pravega-operator
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/apis/pravega/v1alpha1/types.go
+++ b/pkg/apis/pravega/v1alpha1/types.go
@@ -33,9 +33,10 @@ type PravegaCluster struct {
 }
 
 type PravegaClusterSpec struct {
-	ZookeeperUri string         `json:"zookeeperUri"`
-	Bookkeeper   BookkeeperSpec `json:"bookkeeper"`
-	Pravega      PravegaSpec    `json:"pravega"`
+	ZookeeperUri   string         `json:"zookeeperUri"`
+	ExternalAccess bool           `json:"externalAccess"`
+	Bookkeeper     BookkeeperSpec `json:"bookkeeper"`
+	Pravega        PravegaSpec    `json:"pravega"`
 }
 
 type ImageSpec struct {

--- a/pkg/apis/pravega/v1alpha1/types.go
+++ b/pkg/apis/pravega/v1alpha1/types.go
@@ -34,9 +34,14 @@ type PravegaCluster struct {
 
 type PravegaClusterSpec struct {
 	ZookeeperUri   string         `json:"zookeeperUri"`
-	ExternalAccess bool           `json:"externalAccess"`
+	ExternalAccess ExternalAccess `json:"externalAccess"`
 	Bookkeeper     BookkeeperSpec `json:"bookkeeper"`
 	Pravega        PravegaSpec    `json:"pravega"`
+}
+
+type ExternalAccess struct {
+	Enabled bool           `json:"enabled"`
+	Type    v1.ServiceType `json:"type,omitempty"`
 }
 
 type ImageSpec struct {

--- a/pkg/pravega/bookie.go
+++ b/pkg/pravega/bookie.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/utils/k8sutil"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,11 +84,11 @@ func makeBookieHeadlessService(pravegaCluster *v1alpha1.PravegaCluster) *corev1.
 	}
 }
 
-func makeBookieStatefulSet(pravegaCluster *v1alpha1.PravegaCluster) *v1beta1.StatefulSet {
-	return &v1beta1.StatefulSet{
+func makeBookieStatefulSet(pravegaCluster *v1alpha1.PravegaCluster) *v1beta2.StatefulSet {
+	return &v1beta2.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
-			APIVersion: "apps/v1beta1",
+			APIVersion: "apps/v1beta2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sutil.StatefulSetNameForBookie(pravegaCluster.Name),
@@ -98,11 +98,14 @@ func makeBookieStatefulSet(pravegaCluster *v1alpha1.PravegaCluster) *v1beta1.Sta
 				*k8sutil.AsOwnerRef(pravegaCluster),
 			},
 		},
-		Spec: v1beta1.StatefulSetSpec{
-			ServiceName:          k8sutil.HeadlessServiceNameForBookie(pravegaCluster.Name),
-			Replicas:             &pravegaCluster.Spec.Bookkeeper.Replicas,
-			PodManagementPolicy:  v1beta1.ParallelPodManagement,
-			Template:             makeBookieStatefulTemplate(pravegaCluster),
+		Spec: v1beta2.StatefulSetSpec{
+			ServiceName:         k8sutil.HeadlessServiceNameForBookie(pravegaCluster.Name),
+			Replicas:            &pravegaCluster.Spec.Bookkeeper.Replicas,
+			PodManagementPolicy: v1beta2.ParallelPodManagement,
+			Template:            makeBookieStatefulTemplate(pravegaCluster),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: k8sutil.LabelsForBookie(pravegaCluster),
+			},
 			VolumeClaimTemplates: makeBookieVolumeClaimTemplates(&pravegaCluster.Spec.Bookkeeper),
 		},
 	}

--- a/pkg/pravega/bookie.go
+++ b/pkg/pravega/bookie.go
@@ -205,6 +205,7 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 
 func makeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
 	configData := map[string]string{
+		"PRAVEGA_OPERATOR":         "true",
 		"BK_BOOKIE_EXTRA_OPTS":     "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB",
 		"ZK_URL":                   pravegaCluster.Spec.ZookeeperUri,
 		"BK_useHostNameAsBookieID": "true",

--- a/pkg/pravega/bookie.go
+++ b/pkg/pravega/bookie.go
@@ -160,29 +160,6 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 				},
 			},
 		},
-		Affinity: &corev1.Affinity{
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					{
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{
-									Key:      "component",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{"bookie"},
-								},
-								{
-									Key:      "pravega_cluster",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{clusterName},
-								},
-							},
-						},
-						TopologyKey: "kubernetes.io/hostname",
-					},
-				},
-			},
-		},
 	}
 }
 

--- a/pkg/pravega/bookie.go
+++ b/pkg/pravega/bookie.go
@@ -205,7 +205,6 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 
 func makeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
 	configData := map[string]string{
-		"PRAVEGA_OPERATOR":         "true",
 		"BK_BOOKIE_EXTRA_OPTS":     "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB",
 		"ZK_URL":                   pravegaCluster.Spec.ZookeeperUri,
 		"BK_useHostNameAsBookieID": "true",

--- a/pkg/pravega/bookie.go
+++ b/pkg/pravega/bookie.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/utils/k8sutil"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,11 +84,11 @@ func makeBookieHeadlessService(pravegaCluster *v1alpha1.PravegaCluster) *corev1.
 	}
 }
 
-func makeBookieStatefulSet(pravegaCluster *v1alpha1.PravegaCluster) *v1beta2.StatefulSet {
-	return &v1beta2.StatefulSet{
+func makeBookieStatefulSet(pravegaCluster *v1alpha1.PravegaCluster) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
-			APIVersion: "apps/v1beta2",
+			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sutil.StatefulSetNameForBookie(pravegaCluster.Name),
@@ -98,10 +98,10 @@ func makeBookieStatefulSet(pravegaCluster *v1alpha1.PravegaCluster) *v1beta2.Sta
 				*k8sutil.AsOwnerRef(pravegaCluster),
 			},
 		},
-		Spec: v1beta2.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			ServiceName:         k8sutil.HeadlessServiceNameForBookie(pravegaCluster.Name),
 			Replicas:            &pravegaCluster.Spec.Bookkeeper.Replicas,
-			PodManagementPolicy: v1beta2.ParallelPodManagement,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Template:            makeBookieStatefulTemplate(pravegaCluster),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: k8sutil.LabelsForBookie(pravegaCluster),

--- a/pkg/pravega/bookie.go
+++ b/pkg/pravega/bookie.go
@@ -160,6 +160,29 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 				},
 			},
 		},
+		Affinity: &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "component",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"bookie"},
+								},
+								{
+									Key:      "pravega_cluster",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{clusterName},
+								},
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/pravega/pravega_controller.go
+++ b/pkg/pravega/pravega_controller.go
@@ -115,6 +115,7 @@ func makeControllerConfigMap(pravegaCluster *api.PravegaCluster) *corev1.ConfigM
 	}
 
 	configData := map[string]string{
+		"PRAVEGA_OPERATOR":       "true",
 		"CLUSTER_NAME":           pravegaCluster.Name,
 		"ZK_URL":                 pravegaCluster.Spec.ZookeeperUri,
 		"JAVA_OPTS":              strings.Join(javaOpts, " "),
@@ -163,6 +164,7 @@ func makeControllerService(pravegaCluster *api.PravegaCluster) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
 			Ports: []corev1.ServicePort{
 				{
 					Name: "rest",

--- a/pkg/pravega/pravega_controller.go
+++ b/pkg/pravega/pravega_controller.go
@@ -18,7 +18,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/utils/k8sutil"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +43,11 @@ func deployController(pravegaCluster *api.PravegaCluster) (err error) {
 	return nil
 }
 
-func makeControllerDeployment(pravegaCluster *api.PravegaCluster) *v1beta2.Deployment {
-	return &v1beta2.Deployment{
+func makeControllerDeployment(pravegaCluster *api.PravegaCluster) *appsv1.Deployment {
+	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
-			APIVersion: "apps/v1beta2",
+			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sutil.DeploymentNameForController(pravegaCluster.Name),
@@ -56,7 +56,7 @@ func makeControllerDeployment(pravegaCluster *api.PravegaCluster) *v1beta2.Deplo
 				*k8sutil.AsOwnerRef(pravegaCluster),
 			},
 		},
-		Spec: v1beta2.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: &pravegaCluster.Spec.Pravega.ControllerReplicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/pravega/pravega_controller.go
+++ b/pkg/pravega/pravega_controller.go
@@ -115,7 +115,6 @@ func makeControllerConfigMap(pravegaCluster *api.PravegaCluster) *corev1.ConfigM
 	}
 
 	configData := map[string]string{
-		"PRAVEGA_OPERATOR":       "true",
 		"CLUSTER_NAME":           pravegaCluster.Name,
 		"ZK_URL":                 pravegaCluster.Spec.ZookeeperUri,
 		"JAVA_OPTS":              strings.Join(javaOpts, " "),
@@ -150,6 +149,12 @@ func makeControllerConfigMap(pravegaCluster *api.PravegaCluster) *corev1.ConfigM
 }
 
 func makeControllerService(pravegaCluster *api.PravegaCluster) *corev1.Service {
+
+	serviceType := corev1.ServiceTypeClusterIP
+	if pravegaCluster.Spec.ExternalAccess {
+		serviceType = corev1.ServiceTypeLoadBalancer
+	}
+
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -164,7 +169,7 @@ func makeControllerService(pravegaCluster *api.PravegaCluster) *corev1.Service {
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
+			Type: serviceType,
 			Ports: []corev1.ServicePort{
 				{
 					Name: "rest",

--- a/pkg/pravega/pravega_controller.go
+++ b/pkg/pravega/pravega_controller.go
@@ -151,8 +151,8 @@ func makeControllerConfigMap(pravegaCluster *api.PravegaCluster) *corev1.ConfigM
 func makeControllerService(pravegaCluster *api.PravegaCluster) *corev1.Service {
 
 	serviceType := corev1.ServiceTypeClusterIP
-	if pravegaCluster.Spec.ExternalAccess {
-		serviceType = corev1.ServiceTypeLoadBalancer
+	if pravegaCluster.Spec.ExternalAccess.Enabled {
+		serviceType = pravegaCluster.Spec.ExternalAccess.Type
 	}
 
 	return &corev1.Service{

--- a/pkg/pravega/pravega_controller.go
+++ b/pkg/pravega/pravega_controller.go
@@ -18,7 +18,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/utils/k8sutil"
-	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +43,11 @@ func deployController(pravegaCluster *api.PravegaCluster) (err error) {
 	return nil
 }
 
-func makeControllerDeployment(pravegaCluster *api.PravegaCluster) *v1beta1.Deployment {
-	return &v1beta1.Deployment{
+func makeControllerDeployment(pravegaCluster *api.PravegaCluster) *v1beta2.Deployment {
+	return &v1beta2.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
-			APIVersion: "apps/v1beta1",
+			APIVersion: "apps/v1beta2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sutil.DeploymentNameForController(pravegaCluster.Name),
@@ -56,13 +56,16 @@ func makeControllerDeployment(pravegaCluster *api.PravegaCluster) *v1beta1.Deplo
 				*k8sutil.AsOwnerRef(pravegaCluster),
 			},
 		},
-		Spec: v1beta1.DeploymentSpec{
+		Spec: v1beta2.DeploymentSpec{
 			Replicas: &pravegaCluster.Spec.Pravega.ControllerReplicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: k8sutil.LabelsForController(pravegaCluster),
 				},
 				Spec: *makeControllerPodSpec(pravegaCluster.Name, &pravegaCluster.Spec.Pravega),
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: k8sutil.LabelsForController(pravegaCluster),
 			},
 		},
 	}

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -320,7 +320,7 @@ func makeSegmentStoreExternalServices(pravegaCluster *api.PravegaCluster) []*cor
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Type:                  pravegaCluster.Spec.ExternalAccess.Type,
+				Type: pravegaCluster.Spec.ExternalAccess.Type,
 				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
 				Ports: []corev1.ServicePort{
 					{

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -224,7 +224,7 @@ func makeSegmentstoreConfigMap(pravegaCluster *api.PravegaCluster) *corev1.Confi
 	}
 
 	if pravegaCluster.Spec.ExternalAccess {
-		configData["PRAVEGA_OPERATOR"] = "true"
+		configData["K8_EXTERNAL_ACCESS"] = "true"
 	}
 
 	if pravegaCluster.Spec.Pravega.DebugLogging {

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -332,7 +332,7 @@ func makeSegmentStoreHeadlessService(pravegaCluster *api.PravegaCluster) *corev1
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      k8sutil.HeadlessServiceNameForBookie(pravegaCluster.Name),
+			Name:      k8sutil.HeadlessServiceNameForSegmentStore(pravegaCluster.Name),
 			Namespace: pravegaCluster.Namespace,
 			Labels:    k8sutil.LabelsForSegmentStore(pravegaCluster),
 			OwnerReferences: []metav1.OwnerReference{

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -35,8 +35,6 @@ const (
 )
 
 func deploySegmentStore(pravegaCluster *api.PravegaCluster) (err error) {
-	configMap := makeSegmentstoreConfigMap(pravegaCluster)
-
 	err = sdk.Create(makeSegmentStoreHeadlessService(pravegaCluster))
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
@@ -50,7 +48,7 @@ func deploySegmentStore(pravegaCluster *api.PravegaCluster) (err error) {
 		}
 	}
 
-	err = sdk.Create(configMap)
+	err = sdk.Create(makeSegmentstoreConfigMap(pravegaCluster))
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -40,8 +40,8 @@ func deploySegmentStore(pravegaCluster *api.PravegaCluster) (err error) {
 		return err
 	}
 
-	if pravegaCluster.Spec.ExternalAccess {
-		services := makeSegmentStoreLoadBalancerServices(pravegaCluster)
+	if pravegaCluster.Spec.ExternalAccess.Enabled {
+		services := makeSegmentStoreExternalServices(pravegaCluster)
 		for _, service := range services {
 			err = sdk.Create(service)
 			if err != nil && !errors.IsAlreadyExists(err) {
@@ -353,7 +353,7 @@ func makeSegmentStoreHeadlessService(pravegaCluster *api.PravegaCluster) *corev1
 	}
 }
 
-func makeSegmentStoreLoadBalancerServices(pravegaCluster *api.PravegaCluster) []*corev1.Service {
+func makeSegmentStoreExternalServices(pravegaCluster *api.PravegaCluster) []*corev1.Service {
 	var service *corev1.Service
 	services := make([]*corev1.Service, pravegaCluster.Spec.Pravega.SegmentStoreReplicas)
 
@@ -372,7 +372,7 @@ func makeSegmentStoreLoadBalancerServices(pravegaCluster *api.PravegaCluster) []
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Type:                  corev1.ServiceTypeLoadBalancer,
+				Type:                  pravegaCluster.Spec.ExternalAccess.Type,
 				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
 				Ports: []corev1.ServicePort{
 					{

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -137,6 +137,29 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 				},
 			},
 		},
+		Affinity: &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "component",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"pravega-segmentstore"},
+								},
+								{
+									Key:      "pravega_cluster",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{pravegaCluster.Name},
+								},
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
 	}
 
 	configureTier2Filesystem(&podSpec, &pravegaSpec)

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -140,11 +140,6 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 				Env:     k8sutil.DownwardAPIEnv(),
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "podinfo",
-						MountPath: "/etc/podinfo",
-						ReadOnly:  false,
-					},
-					{
 						Name:      cacheVolumeName,
 						MountPath: cacheVolumeMountPoint,
 					},

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -137,6 +137,7 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 					},
 				},
 				EnvFrom: environment,
+				Env:     k8sutil.DownwardAPIEnv(),
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "podinfo",
@@ -169,31 +170,6 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 							},
 						},
 						TopologyKey: "kubernetes.io/hostname",
-					},
-				},
-			},
-		},
-		Volumes: []corev1.Volume{
-			{
-				Name: "podinfo",
-				VolumeSource: corev1.VolumeSource{
-					DownwardAPI: &corev1.DownwardAPIVolumeSource{
-						Items: []corev1.DownwardAPIVolumeFile{
-							{
-								Path: "podname",
-								FieldRef: &corev1.ObjectFieldSelector{
-									APIVersion: "v1",
-									FieldPath:  "metadata.name",
-								},
-							},
-							{
-								Path: "namespace",
-								FieldRef: &corev1.ObjectFieldSelector{
-									APIVersion: "v1",
-									FieldPath:  "metadata.namespace",
-								},
-							},
-						},
 					},
 				},
 			},

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -146,29 +146,6 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 				},
 			},
 		},
-		Affinity: &corev1.Affinity{
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					{
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{
-									Key:      "component",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{"pravega-segmentstore"},
-								},
-								{
-									Key:      "pravega_cluster",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{pravegaCluster.Name},
-								},
-							},
-						},
-						TopologyKey: "kubernetes.io/hostname",
-					},
-				},
-			},
-		},
 	}
 
 	configureTier2Filesystem(&podSpec, &pravegaSpec)

--- a/pkg/utils/k8sutil/k8sutil.go
+++ b/pkg/utils/k8sutil/k8sutil.go
@@ -18,6 +18,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
 	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -50,4 +51,27 @@ func GetWatchNamespaceAllowBlank() (string, error) {
 		return "", fmt.Errorf("%s must be set", k8sutil.WatchNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+func DownwardAPIEnv() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.namespace",
+				},
+			},
+		},
+	}
 }

--- a/pkg/utils/k8sutil/pravega.go
+++ b/pkg/utils/k8sutil/pravega.go
@@ -32,6 +32,10 @@ func ServiceNameForController(clusterName string) string {
 	return fmt.Sprintf("%s-pravega-controller", clusterName)
 }
 
+func ServiceNameForSegmentStore(clusterName string, index int32) string {
+	return fmt.Sprintf("%s-pravega-segmentstore-%d", clusterName, index)
+}
+
 func HeadlessServiceNameForBookie(clusterName string) string {
 	return fmt.Sprintf("%s-bookie-headless", clusterName)
 }

--- a/pkg/utils/k8sutil/pravega.go
+++ b/pkg/utils/k8sutil/pravega.go
@@ -36,6 +36,10 @@ func ServiceNameForSegmentStore(clusterName string, index int32) string {
 	return fmt.Sprintf("%s-pravega-segmentstore-%d", clusterName, index)
 }
 
+func HeadlessServiceNameForSegmentStore(clusterName string) string {
+	return fmt.Sprintf("%s-pravega-segmentstore-headless", clusterName)
+}
+
 func HeadlessServiceNameForBookie(clusterName string) string {
 	return fmt.Sprintf("%s-bookie-headless", clusterName)
 }

--- a/pkg/utils/k8sutil/pravega.go
+++ b/pkg/utils/k8sutil/pravega.go
@@ -17,7 +17,7 @@ import (
 )
 
 func ConfigMapNameForBookie(clusterName string) string {
-	return fmt.Sprintf("%s-bookie-config", clusterName)
+	return fmt.Sprintf("%s-bookie", clusterName)
 }
 
 func StatefulSetNameForBookie(clusterName string) string {
@@ -25,7 +25,7 @@ func StatefulSetNameForBookie(clusterName string) string {
 }
 
 func ConfigMapNameForController(clusterName string) string {
-	return fmt.Sprintf("%s-controller-config", clusterName)
+	return fmt.Sprintf("%s-pravega-controller", clusterName)
 }
 
 func ServiceNameForController(clusterName string) string {
@@ -45,11 +45,11 @@ func DeploymentNameForController(clusterName string) string {
 }
 
 func ConfigMapNameForSegmentstore(clusterName string) string {
-	return fmt.Sprintf("%s-segmentstore", clusterName)
+	return fmt.Sprintf("%s-pravega-segmentstore", clusterName)
 }
 
 func StatefulSetNameForSegmentstore(clusterName string) string {
-	return fmt.Sprintf("%s-segmentstore", clusterName)
+	return fmt.Sprintf("%s-pravega-segmentstore", clusterName)
 }
 
 func LabelsForBookie(pravegaCluster *v1alpha1.PravegaCluster) map[string]string {


### PR DESCRIPTION
## Change log description

This PR adds support for external connectivity (i.e. connectivity from outside the Kubernetes cluster). Below is a detailed description of the changes made and the reason why they were made.

#### Create a headless service for the Segmentstore set
As with the Bookies, Segmentstores are managed by a `StatefulSet`. Headless services provide DNS records for the Segmentstore set that can be used for intra-cluster communication, i.e., segmentstore pods can be access using the `<statefulset_name>-<ordinal>.<headless_service_name>` hostname (e.g. `pravega-segmentstore-1.pravega-segmentstore-headless` would resolve to the IP of second pod in the set).

#### Create an external service per Segmentstore pod
Pravega clients need to be able to directly reach every Segmentstore instance. We found multiple ways to achieve this:
- Using `NodePort` services. `NodePort` services allocate a free port (within the 30000-32767 range) in each Kubernetes node and forwards the traffic to the backend pod. However, this requires extra configuration on the external networking layer to allocate IP addresses, and allow and forward external traffic to the service. In addition, `NodePort` services are not yet supported on PKS w/ vSphere and NSX-T, which is our main platform.
- Using the `Ingress` resource. Ingress configures an HTTP server with routing rules to allow external communication with a service. However, most Ingress implementations do not support non-HTTP traffic, making it not an option for our HTTP2-gRPC traffic.
- Using `LoadBalancer` services. A `LoadBalancer` service configures an external load balancer (e.g. NSX-T in our platform) to allow external communication and provides an external IP once it's allocated by the external load balancer. It can handle any TCP connections or UDP flows, so it works for our use case.

This PR implements support for `LoadBalancer` and `NodePort` service types. Configured in `externalAccess.type`. The operator creates one external service per Segment Store instance.

In addition, these services are created with the `externalTrafficPolicy` option enabled. By default, `LoadBalancer` services route traffic to any backend pod in the cluster, however, with this option, services route traffic only to node-local pods.

#### Create `ClusterRole` permissions
When external access is enabled and configured with `NodePort`, the pod needs to find the node IP using the Kubernetes API. To achieve this, the service account needs to have `ClusterNode` read permissions on the `node` resource.

#### Segmentstore instance to advertise external address
By default, a Segmentstore instance uses it's local address when it registers with the Controller. However, the local pod address is only reachable from within the cluster (or namespace, depending on the environment). 

We need to initialize each Segmentstore instance with the external address allocated by the corresponding `LoadBalancer` service. To achieve this, the Pravega Docker image `entrypoint.sh` needs to modified to obtain the external service IP and port and configure it as system properties before starting the segmentstore process. 

The Segmentstore container needs to know the service name and the namespace to introspect and find its external IP. By naming convention, the `LoadBalancing` service name is the same as the pod name. So this is information can be easily made available to the pod by leveraging the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/). Two environment variables (`POD_NAME` and `POD_NAMESPACE`) are passed to the pod to allow the pods to find their information via the Kubernetes API. How the container uses this information is being addressed in the Pravega project PR https://github.com/pravega/pravega/pull/3062.

#### Ability to configure external access
Exposing the Pravega cluster to the outside is a possibility for users, but it's not enforced. For security reasons, by default a Pravega cluster will still be accessible only within the Kubernetes cluster. To enable external access, users need to explicitly create the `externalAccess` structure and set the `enabled` field to `true`, otherwise the cluster will not be exposed. E.g.:

```
apiVersion: "pravega.pravega.io/v1alpha1"
kind: "PravegaCluster"
metadata:
  name: "pravega1"
spec:
  zookeeperUri: 10.59.240.7:2181
  externalAccess:
    enabled: true
    type: LoadBalancer
...
```

## Purpose of the change
- Fix #61

## How to test the change

Assuming you already have access to a Kubernetes environment (GKE, PKS, Minikube...), follow the instructions in the README file to deploy ZooKeeper, the NFS server provisioner, and the Pravega Tier 2 PVC. Skip the deployment of the Pravega operator.

Check out this branch.
```
git checkout issue-61-external-traffic
```

Update the Pravega operator image to use an image built with the PR changes. Open the `deploy/operator.yaml` file and replace the container image from `pravega/pravega-operator:latest` to `adrianmo/pravega-operator:v0.1.0-23-dirty`. 

Deploy the operator.
```
kubectl create -f deploy/operator.yaml
```
Create a `pravega.yaml` that will use the updated images that contain the changes made to obtain and advertise the external service IP (ref: https://github.com/pravega/pravega/pull/3062) and the new `externalAccess` field.

```
apiVersion: "pravega.pravega.io/v1alpha1"                                                                                                                       
kind: "PravegaCluster"                                                                                                                                          
metadata:                                                                                                                                                       
  name: "pravega"                                                                                                                                               
spec:                                                                                                                                                           
  zookeeperUri: zk-client:2181                                                                                                                                  

  externalAccess:
    enabled: true
    type: LoadBalancer
                                                                                                                                                                
  bookkeeper:                                                                                                                                                                                                                                                                        
    image:
      repository: adrianmo/bookkeeper
      tag: 0.5.0-2023.5353487-SNAPSHOT
      pullPolicy: IfNotPresent

    replicas: 3

    storage:
      ledgerVolumeClaimTemplate:
        accessModes: [ "ReadWriteOnce" ]
        storageClassName: "standard"
        resources:
          requests:
            storage: 10Gi

      journalVolumeClaimTemplate:
        accessModes: [ "ReadWriteOnce" ]
        storageClassName: "standard"
        resources:
          requests:
            storage: 10Gi

    autoRecovery: true

  pravega:
    controllerReplicas: 1
    segmentStoreReplicas: 3

    cacheVolumeClaimTemplate:
      accessModes: [ "ReadWriteOnce" ]
      storageClassName: "standard"
      resources:
        requests:
          storage: 20Gi

    image:
      repository: adrianmo/pravega
      tag: 0.5.0-2023.5353487-SNAPSHOT
      pullPolicy: IfNotPresent

    tier2:
      filesystem:
        persistentVolumeClaim:
          claimName: pravega-tier2
```

Copy the contents above to a `pravega.yaml` file and deploy the Pravega cluster:

```
kubectl create -f pravega.yaml
```
Watch the Pravega cluster being created...
```
watch kubectl get all -l pravega_cluster=pravega
```

Until the Controller and all Segmentstore services have been allocated an external address in the `EXTERNAL-IP` column. 

```
NAME                                              READY     STATUS    RESTARTS   AGE
pod/pravega-bookie-0                              1/1       Running   0          4m
pod/pravega-bookie-1                              1/1       Running   0          4m
pod/pravega-bookie-2                              1/1       Running   0          4m
pod/pravega-pravega-controller-76f6d74c55-kkwgb   1/1       Running   0          4m
pod/pravega-pravega-segmentstore-0                1/1       Running   0          4m
pod/pravega-pravega-segmentstore-1                1/1       Running   0          4m
pod/pravega-pravega-segmentstore-2                1/1       Running   0          4m

NAME                                            TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                          AGE
service/pravega-bookie-headless                 ClusterIP      None            <none>           3181/TCP                         4m
service/pravega-pravega-controller              LoadBalancer   10.59.243.23    35.240.18.191    10080:31356/TCP,9090:32287/TCP   4m
service/pravega-pravega-segmentstore-0          LoadBalancer   10.59.248.137   35.241.234.206   12345:31849/TCP                  4m
service/pravega-pravega-segmentstore-1          LoadBalancer   10.59.243.10    35.189.250.112   12345:30177/TCP                  4m
service/pravega-pravega-segmentstore-2          LoadBalancer   10.59.252.97    35.240.48.116    12345:32460/TCP                  4m
service/pravega-pravega-segmentstore-headless   ClusterIP      None            <none>           12345/TCP                        4m

NAME                                               DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deployment.extensions/pravega-pravega-controller   1         1         1            1           4m

NAME                                                          DESIRED   CURRENT   READY     AGE
replicaset.extensions/pravega-pravega-controller-76f6d74c55   1         1         1         4m

NAME                                         DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/pravega-pravega-controller   1         1         1            1           4m

NAME                                                    DESIRED   CURRENT   READY     AGE
replicaset.apps/pravega-pravega-controller-76f6d74c55   1         1         1         4m

NAME                                            DESIRED   CURRENT   AGE
statefulset.apps/pravega-bookie                 3         3         4m
statefulset.apps/pravega-pravega-segmentstore   3         3         4m
```

Then, copy the Controller External IP and connect to it with the Pravega client. You can use the samples in the [Pravega samples repositories](https://github.com/pravega/pravega-samples).

---
Signed-off-by: Adrian Moreno <adrian@morenomartinez.com>