### PR TITLE
[WiP] Issue 79: Ability to configure non-default service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ The project is currently alpha. While no breaking API changes are currently plan
     * [Deploy a sample Pravega Cluster](#deploy-a-sample-pravega-cluster)
     * [Uninstall the Pravega Cluster](#uninstall-the-pravega-cluster)
     * [Uninstall the Operator](#uninstall-the-operator)
+ * [Configuration](#configuration)
+    * [Use non-default service accounts](#use-non-default-service-accounts)
+    * [Tier 2: Google Filestore Storage](#use-google-filestore-storage-as-tier-2)
+    * [Tune Pravega Configurations](#tune-pravega-configuration)
  * [Development](#development)
     * [Build the Operator Image](#build-the-operator-image)
-    * [Tier 2: Google Filestore Storage](#using-google-filestore-storage-as-tier-2)
-    * [Tuning Pravega Configurations](#tuning-pravega-configuration)
     * [Installation on GKE](#installation-on-google-kubernetes-engine)
     * [Direct Access to Cluster](#direct-access-to-the-cluster)
     * [Run the Operator Locally](#run-the-operator-locally)
@@ -256,41 +258,34 @@ To delete all clusters, delete all cluster CR objects before uninstalling the op
 $ kubectl delete -f deploy
 ```
 
-## Development
+## Configuration
 
-### Build the operator image
+### Use non-default service accounts
 
-Requirements:
-  - Go 1.10+
-  - [Operator SDK](https://github.com/operator-framework/operator-sdk#quick-start)
+You can optionally configure non-default service accounts for the Bookkeeper, Pravega Controller, and Pravega Segment Store pods.
 
-Use the `operator-sdk` command to build the Pravega operator image.
+For BookKeeper, set the `serviceAccountName` field under the `bookkeeper` block.
 
 ```
-$ operator-sdk build pravega/pravega-operator
+...
+spec:
+  bookkeeper:
+    serviceAccountName: bk-service-account
+...
 ```
 
-The Pravega operator image will be available in your Docker environment.
+For Pravega, set the `controllerServiceAccountName` and `segmentStoreServiceAccountName` fields under the `pravega` block.
 
 ```
-$ docker images pravega/pravega-operator
-REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
-pravega/pravega-operator   latest              625dab6fe470        54 seconds ago      37.2MB
+...
+spec:
+  pravega:
+    controllerServiceAccountName: ctrl-service-account
+    segmentStoreServiceAccountName: ss-service-account
+...
 ```
 
-Optionally push it to a Docker registry.
-
-```
-docker tag pravega/pravega-operator [REGISTRY_HOST]:[REGISTRY_PORT]/pravega/pravega-operator
-docker push [REGISTRY_HOST]:[REGISTRY_PORT]/pravega/pravega-operator
-```
-
-where:
-
-- `[REGISTRY_HOST]` is your registry host or IP (e.g. `registry.example.com`)
-- `[REGISTRY_PORT]` is your registry port (e.g. `5000`)
-
-### Using Google Filestore Storage as Tier 2
+### Use Google Filestore Storage as Tier 2
 
 1. [Create a Google Filestore](https://console.cloud.google.com/filestore/instances).
 
@@ -349,7 +344,7 @@ $ kubectl create -f pvc.yaml
 Use the same `pravega.yaml` above to deploy the Pravega cluster.
 
 
-### Tuning Pravega configuration
+### Tune Pravega configuration
 
 Pravega has many configuration options for setting up metrics, tuning, etc. The available options can be found
 [here](https://github.com/pravega/pravega/blob/master/config/config.properties) and are
@@ -365,6 +360,40 @@ spec:
       metrics.statsdPort: "8125"
 ...
 ```
+
+## Development
+
+### Build the operator image
+
+Requirements:
+  - Go 1.10+
+  - [Operator SDK](https://github.com/operator-framework/operator-sdk#quick-start)
+
+Use the `operator-sdk` command to build the Pravega operator image.
+
+```
+$ operator-sdk build pravega/pravega-operator
+```
+
+The Pravega operator image will be available in your Docker environment.
+
+```
+$ docker images pravega/pravega-operator
+REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
+pravega/pravega-operator   latest              625dab6fe470        54 seconds ago      37.2MB
+```
+
+Optionally push it to a Docker registry.
+
+```
+docker tag pravega/pravega-operator [REGISTRY_HOST]:[REGISTRY_PORT]/pravega/pravega-operator
+docker push [REGISTRY_HOST]:[REGISTRY_PORT]/pravega/pravega-operator
+```
+
+where:
+
+- `[REGISTRY_HOST]` is your registry host or IP (e.g. `registry.example.com`)
+- `[REGISTRY_PORT]` is your registry port (e.g. `5000`)
 
 ### Installation on Google Kubernetes Engine
 

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -15,10 +15,11 @@ import (
 )
 
 type BookkeeperSpec struct {
-	Image        ImageSpec             `json:"image"`
-	Replicas     int32                 `json:"replicas"`
-	Storage      BookkeeperStorageSpec `json:"storage"`
-	AutoRecovery bool                  `json:"autoRecovery"`
+	Image              ImageSpec             `json:"image"`
+	Replicas           int32                 `json:"replicas"`
+	Storage            BookkeeperStorageSpec `json:"storage"`
+	AutoRecovery       bool                  `json:"autoRecovery"`
+	ServiceAccountName string                `json:"serviceAccountName,omitempty"`
 }
 
 type BookkeeperStorageSpec struct {

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -15,14 +15,16 @@ import (
 )
 
 type PravegaSpec struct {
-	ControllerReplicas       int32                        `json:"controllerReplicas"`
-	SegmentStoreReplicas     int32                        `json:"segmentStoreReplicas"`
-	DebugLogging             bool                         `json:"debugLogging"`
-	Image                    ImageSpec                    `json:"image"`
-	Metrics                  MetricsSpec                  `json:"metrics"`
-	Options                  map[string]string            `json:"options"`
-	CacheVolumeClaimTemplate v1.PersistentVolumeClaimSpec `json:"cacheVolumeClaimTemplate"`
-	Tier2                    Tier2Spec                    `json:"tier2"`
+	ControllerReplicas             int32                        `json:"controllerReplicas"`
+	SegmentStoreReplicas           int32                        `json:"segmentStoreReplicas"`
+	DebugLogging                   bool                         `json:"debugLogging"`
+	Image                          ImageSpec                    `json:"image"`
+	Metrics                        MetricsSpec                  `json:"metrics"`
+	Options                        map[string]string            `json:"options"`
+	CacheVolumeClaimTemplate       v1.PersistentVolumeClaimSpec `json:"cacheVolumeClaimTemplate"`
+	Tier2                          Tier2Spec                    `json:"tier2"`
+	ControllerServiceAccountName   string                       `json:"controllerServiceAccountName,omitempty"`
+	SegmentStoreServiceAccountName string                       `json:"segmentStoreServiceAccountName,omitempty"`
 }
 
 type MetricsSpec struct {

--- a/pkg/pravega/bookie.go
+++ b/pkg/pravega/bookie.go
@@ -118,7 +118,7 @@ func makeBookieStatefulTemplate(pravegaCluster *v1alpha1.PravegaCluster) corev1.
 }
 
 func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSpec) *corev1.PodSpec {
-	return &corev1.PodSpec{
+	podSpec := &corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
 				Name:            "bookie",
@@ -158,6 +158,12 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 			},
 		},
 	}
+
+	if bookkeeperSpec.ServiceAccountName != "" {
+		podSpec.ServiceAccountName = bookkeeperSpec.ServiceAccountName
+	}
+
+	return podSpec
 }
 
 func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.PersistentVolumeClaim {

--- a/pkg/pravega/pravega_controller.go
+++ b/pkg/pravega/pravega_controller.go
@@ -69,7 +69,7 @@ func makeControllerDeployment(pravegaCluster *api.PravegaCluster) *v1beta1.Deplo
 }
 
 func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.PodSpec {
-	return &corev1.PodSpec{
+	podSpec := &corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
 				Name:            "pravega-controller",
@@ -100,6 +100,12 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 			},
 		},
 	}
+
+	if pravegaSpec.ControllerServiceAccountName != "" {
+		podSpec.ServiceAccountName = pravegaSpec.ControllerServiceAccountName
+	}
+
+	return podSpec
 }
 
 func makeControllerConfigMap(pravegaCluster *api.PravegaCluster) *corev1.ConfigMap {

--- a/pkg/pravega/pravega_segmentstore.go
+++ b/pkg/pravega/pravega_segmentstore.go
@@ -125,6 +125,10 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 		},
 	}
 
+	if pravegaSpec.SegmentStoreServiceAccountName != "" {
+		podSpec.ServiceAccountName = pravegaSpec.SegmentStoreServiceAccountName
+	}
+
 	configureTier2Filesystem(&podSpec, &pravegaSpec)
 
 	return podSpec


### PR DESCRIPTION
## Change log description
- Update PravegaCluster API spec to allow users to optionally set service account names for BookKeeper, Pravega Controller, and Pravega Segmentstore.
- Update Pod spec in StatefulSet and Deployment pod templates to include the service account names if they are set.
- Update README file with instructions on how to configure the non-default service accounts.
- Refactor README structure. Create a new "Configuration" section that includes existing configuration information.

## Purpose of the change
- Fix #79 

Signed-off-by: Adrian Moreno <adrian@morenomartinez.com>