### PR TITLE
Issue 116: Use IP address as Bookie ID

### DIFF
--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -175,9 +175,14 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 
 func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
 	configData := map[string]string{
-		"BK_BOOKIE_EXTRA_OPTS":     "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB",
-		"ZK_URL":                   pravegaCluster.Spec.ZookeeperUri,
-		"BK_useHostNameAsBookieID": "true",
+		"BK_BOOKIE_EXTRA_OPTS": "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB",
+		"ZK_URL":               pravegaCluster.Spec.ZookeeperUri,
+		// Using IP address as the Bookie ID until Pravega's BookKeeper is update to, at least,
+		// version 4.7, which assumes that hostnames can resolve to different IP addresses
+		// over time.
+		// Operator issue: https://github.com/pravega/pravega-operator/issues/116
+		// Pravega PR to update BK: https://github.com/pravega/pravega/pull/3192
+		"BK_useHostNameAsBookieID": "false",
 		"PRAVEGA_CLUSTER_NAME":     pravegaCluster.ObjectMeta.Name,
 		"WAIT_FOR":                 pravegaCluster.Spec.ZookeeperUri,
 	}


### PR DESCRIPTION
## Change log description
- Change Bookie ID from using the pod's hostname to the IP address. 

## Purpose of the change
Related to #116 

This is a temporary workaround to fix BookKeeper failover scenarios until Pravega's BookKeeper version is updated to 4.7 (WiP: https://github.com/pravega/pravega/pull/3192).

## How to test

BookieFailoverTest should pass. 

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>