### PR TITLE
[Issue 116] Create a test mode flag to disable replica restrictions

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pravega/pravega-operator/pkg/apis"
 	"github.com/pravega/pravega-operator/pkg/controller"
+	controllerconfig "github.com/pravega/pravega-operator/pkg/controller/config"
 	"github.com/pravega/pravega-operator/pkg/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -35,7 +36,7 @@ var (
 
 func init() {
 	flag.BoolVar(&versionFlag, "version", false, "Show version and quit")
-	flag.Parse()
+	flag.BoolVar(&controllerconfig.TestMode, "test", false, "Enable test mode. Do not use this flag in production")
 }
 
 func printVersion() {
@@ -47,11 +48,16 @@ func printVersion() {
 }
 
 func main() {
-	printVersion()
 	flag.Parse()
+
+	printVersion()
 
 	if versionFlag {
 		os.Exit(0)
+	}
+
+	if controllerconfig.TestMode {
+		log.Warn("----- Running in test mode. Make sure you are NOT in production -----")
 	}
 
 	namespace, err := k8sutil.GetWatchNamespace()

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -13,6 +13,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	"github.com/pravega/pravega-operator/pkg/controller/config"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -70,7 +71,7 @@ func (s *BookkeeperSpec) withDefaults() {
 	}
 	s.Image.withDefaults()
 
-	if s.Replicas < MinimumBookkeeperReplicas {
+	if !config.TestMode && s.Replicas < MinimumBookkeeperReplicas {
 		s.Replicas = MinimumBookkeeperReplicas
 	}
 

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -13,6 +13,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	"github.com/pravega/pravega-operator/pkg/controller/config"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -89,11 +90,11 @@ type PravegaSpec struct {
 }
 
 func (s *PravegaSpec) withDefaults() {
-	if s.ControllerReplicas < 1 {
+	if !config.TestMode && s.ControllerReplicas < 1 {
 		s.ControllerReplicas = 1
 	}
 
-	if s.SegmentStoreReplicas < 1 {
+	if !config.TestMode && s.SegmentStoreReplicas < 1 {
 		s.SegmentStoreReplicas = 1
 	}
 

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -1,0 +1,8 @@
+package config
+
+// TestMode enables test mode in the operator and applies
+// the following changes:
+// - Disables BookKeeper minimum number of replicas
+// - Disables Pravega Controller minimum number of replicas
+// - Disables Segment Store minimum number of replicas
+var TestMode bool

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package config
 
 // TestMode enables test mode in the operator and applies


### PR DESCRIPTION
## Change log description
- Add a test mode flag to disable replica restrictions. Otherwise, the operator will run as usual.

## Purpose of the change
Related to #116 

## How to test

BookieFailoverTest and MultiControllerTest should pass when the operator is started with the `-test` flag.

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>