### PR TITLE
[WiP] Issue 81: Support rolling upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Pravega operator manages Pravega clusters deployed to Kubernetes and automat
 
 - [x] Create and destroy a Pravega cluster
 - [x] Resize cluster
-- [ ] Rolling upgrades
+- [x] Rolling upgrades
 
 > Note that unchecked features are in the roadmap but not available yet.
 


### PR DESCRIPTION
## Status: Work in progress


### Motivation

Pravega has been in active development for some time and versions have been released at a steady pace. However, there is no automated process, guidelines, or best practices to upgrade a Pravega deployment to a newer version.

### Limitations

Pravega is made up multiple components which can be differentiated into two blocks: internal and external components. Internal components refer to the Pravega Controller, the Segment Store, and BookKeeper. Whereas external components refer to ZooKeeper and the Tier 2 backend.

The Pravega operator scope is limited to internal components, and therefore, this upgrade procedure will only affect the aforementioned components. 


### Overview

The activity diagram below shows the overall upgrade process started by an end-user and performed by the operator.

![pravega k8 upgrade 1](https://user-images.githubusercontent.com/3786750/51993601-7908b000-24af-11e9-8149-82fd1b036630.png)

The user story would be the following:

- A user wants to upgrade a Pravega cluster named “pravega” from version X to version Y.
- The user expresses that desire by one of the following forms:
  - kubectl edit PravegaCluster pravega, and editing the “version” field in the YAML resource
  - kubectl patch PravegaCluster pravega -p '{"spec":{"version": ”Y”}}'
  - kubectl apply -f file.yaml, where file.yaml is the YAML resource definition with the “version” updated to “Y”
- The Pravega operator detects the version change and
  - if the upgrade is allowed, it applies the rolling upgrade
  - otherwise, it rejects the user request
- If the rolling upgrade faces any issues, the operator rolls back to the upgrade.


### Rolling upgrade process

![pravega operator component update](https://user-images.githubusercontent.com/3786750/51993862-f3d1cb00-24af-11e9-857d-281eceb7fd90.png)

Once an upgrade request has been validated, the operator will apply the rolling upgrade to all the components that are part of the Pravega cluster.

The order in which the components will be upgraded is the following:

1. Controller
2. Segment Store
3. BookKeeper

The upgrade workflow is as follows:

- The operator will change the PravegaCluster phase from RUNNING to UPGRADING to indicate that the cluster resource has an in-progress upgrade.
- For each cluster component, the operator will check if there is an ongoing rolling upgrade. To do that, the operator will check the rollout status for the Deployment (Pravega Controller) or StatefulSet (Pravega SegmentStore and BookKeeper).
  - If there’s an ongoing upgrade, the process will end and will start again at the next operator tick.
  - Otherwise, there’s no ongoing upgrade.
- The operator will check if the current component version matches the target version.
  - If no, the component is not upgraded or upgrading, so the operator will trigger a rolling upgrade using the “RollingUpdate” Kubernetes strategy by updating the container template in the Deployment or StatefulSet to use the new version. Then it will exit.
  - Otherwise, the component is already upgraded.
- The operator will check if there are more components to be upgraded.
  - If yes, it will go to 2.
  - Otherwise, all components are already upgraded
- The operator will change the PravegaCluster phase from UPGRADING to RUNNING to indicate that the cluster is already running with the new version.

### Required changes

#### Controller
TBD

#### Segment Store
TBD

#### Client
- Add ability to identify server-side component versions.
- Show warning logs if the client version does not match the server version, but it is compatible.
- Fail to start or throw exception if the client version is not compatible with the server version.

#### Operator
- Add support for `PravegaCluster` resource status to know whether or not the resource is ready to serve requests
  - https://github.com/pravega/pravega-operator/issues/10
- Implement an admission webhook to validate upgrade requests, i.e., whether the upgrade from version X to version Y is allowed/implemented or not.
  - https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks
  - https://github.com/kubernetes-sigs/controller-runtime/blob/master/example/validatingwebhook.go
  - https://github.com/pravega/pravega-operator/issues/7

### Version support

A Pravega cluster is upgraded as a whole. A user can’t upgrade only a singular component. 
Support rolling upgrade from one minor release to its immediate next minor release, e.g. from 0.5 to 0.6, no 0.5 to 0.7.
Support rolling upgrade from within the same minor release, e.g. from 0.5.0 to 0.5.4
Support rolling upgrade from any patch release to the immediate next minor release, e.g. from 0.5.6 to 0.6.0, or 0.5.2 to 0.6.4.

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>