### PR TITLE
Issue 130: Ability to specify container resources

### DIFF
--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -12,6 +12,13 @@ spec:
       pullPolicy: IfNotPresent
 
     replicas: 3
+    resources:
+      requests:
+        memory: "4Gi"
+        cpu: "4000m"
+      limits:
+        memory: "6Gi"
+        cpu: "6000m"
 
     storage:
       ledgerVolumeClaimTemplate:
@@ -34,7 +41,22 @@ spec:
 
   pravega:
     controllerReplicas: 1
+    controllerResources:
+      requests:
+        memory: "1Gi"
+        cpu: "1000m"
+      limits:
+        memory: "2Gi"
+        cpu: "2000m"
+
     segmentStoreReplicas: 3
+    segmentStoreResources:
+      requests:
+        memory: "4Gi"
+        cpu: "4000m"
+      limits:
+        memory: "6Gi"
+        cpu: "6000m"
 
     # Turn on Pravega Debug Logging
     debugLogging: false

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -14,11 +14,11 @@ spec:
     replicas: 3
     resources:
       requests:
-        memory: "4Gi"
-        cpu: "4000m"
+        memory: "3Gi"
+        cpu: "1000m"
       limits:
-        memory: "6Gi"
-        cpu: "6000m"
+        memory: "5Gi"
+        cpu: "2000m"
 
     storage:
       ledgerVolumeClaimTemplate:
@@ -63,17 +63,17 @@ spec:
         memory: "1Gi"
         cpu: "1000m"
       limits:
-        memory: "2Gi"
+        memory: "3Gi"
         cpu: "2000m"
 
     segmentStoreReplicas: 3
     segmentStoreResources:
       requests:
-        memory: "4Gi"
-        cpu: "4000m"
+        memory: "3Gi"
+        cpu: "1000m"
       limits:
-        memory: "6Gi"
-        cpu: "6000m"
+        memory: "5Gi"
+        cpu: "2000m"
 
     # Turn on Pravega Debug Logging
     debugLogging: false

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -110,12 +110,12 @@ func (s *BookkeeperSpec) withDefaults() (changed bool) {
 		changed = true
 		s.Resources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("4000m"),
-				v1.ResourceMemory: resource.MustParse("4Gi"),
+				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceMemory: resource.MustParse("3Gi"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("6000m"),
-				v1.ResourceMemory: resource.MustParse("6Gi"),
+				v1.ResourceCPU:    resource.MustParse("2000m"),
+				v1.ResourceMemory: resource.MustParse("5Gi"),
 			},
 		}
 	}

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -110,11 +110,11 @@ func (s *BookkeeperSpec) withDefaults() (changed bool) {
 		changed = true
 		s.Resources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceCPU:    resource.MustParse("500m"),
 				v1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("2000m"),
+				v1.ResourceCPU:    resource.MustParse("1000m"),
 				v1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		}

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -67,6 +67,10 @@ type BookkeeperSpec struct {
 
 	// ServiceAccountName configures the service account used on BookKeeper instances
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// BookieResources specifies the request and limit of resources that bookie can have.
+	// BookieResources includes CPU and memory resources
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 func (s *BookkeeperSpec) withDefaults() (changed bool) {
@@ -95,6 +99,20 @@ func (s *BookkeeperSpec) withDefaults() (changed bool) {
 		changed = true
 		boolTrue := true
 		s.AutoRecovery = &boolTrue
+	}
+
+	if s.Resources == nil {
+		changed = true
+		s.Resources = &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4000m"),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("6000m"),
+				v1.ResourceMemory: resource.MustParse("6Gi"),
+			},
+		}
 	}
 
 	return changed

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -46,6 +46,18 @@ const (
 	// MinimumBookkeeperReplicas is the minimum number of Bookkeeper replicas
 	// accepted
 	MinimumBookkeeperReplicas = 3
+
+	// DefaultBookkeeperRequestCPU is the default CPU request for BookKeeper
+	DefaultBookkeeperRequestCPU = "500m"
+
+	// DefaultBookkeeperLimitCPU is the default CPU limit for BookKeeper
+	DefaultBookkeeperLimitCPU = "1"
+
+	// DefaultBookkeeperRequestMemory is the default memory request for BookKeeper
+	DefaultBookkeeperRequestMemory = "1Gi"
+
+	// DefaultBookkeeperLimitMemory is the limit memory limit for BookKeeper
+	DefaultBookkeeperLimitMemory = "2Gi"
 )
 
 // BookkeeperSpec defines the configuration of BookKeeper
@@ -110,12 +122,12 @@ func (s *BookkeeperSpec) withDefaults() (changed bool) {
 		changed = true
 		s.Resources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("500m"),
-				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourceCPU:    resource.MustParse(DefaultBookkeeperRequestCPU),
+				v1.ResourceMemory: resource.MustParse(DefaultBookkeeperRequestMemory),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1000m"),
-				v1.ResourceMemory: resource.MustParse("2Gi"),
+				v1.ResourceCPU:    resource.MustParse(DefaultBookkeeperLimitCPU),
+				v1.ResourceMemory: resource.MustParse(DefaultBookkeeperLimitMemory),
 			},
 		}
 	}

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -39,6 +39,10 @@ const (
 	// Bookkeeper journal volume
 	DefaultBookkeeperJournalVolumeSize = "10Gi"
 
+	// DefaultBookkeeperIndexVolumeSize is the default volume size for the
+	// Bookkeeper index volume
+	DefaultBookkeeperIndexVolumeSize = "10Gi"
+
 	// MinimumBookkeeperReplicas is the minimum number of Bookkeeper replicas
 	// accepted
 	MinimumBookkeeperReplicas = 3
@@ -136,6 +140,11 @@ type BookkeeperStorageSpec struct {
 	// This field is optional. If no PVC spec and there is no default storage class,
 	// stateful containers will use emptyDir as volume
 	JournalVolumeClaimTemplate *v1.PersistentVolumeClaimSpec `json:"journalVolumeClaimTemplate"`
+
+	// IndexVolumeClaimTemplate is the spec to describe PVC for the BookKeeper index
+	// This field is optional. If no PVC spec and there is no default storage class,
+	// stateful containers will use emptyDir as volume
+	IndexVolumeClaimTemplate *v1.PersistentVolumeClaimSpec `json:"indexVolumeClaimTemplate"`
 }
 
 func (s *BookkeeperStorageSpec) withDefaults() (changed bool) {
@@ -158,6 +167,18 @@ func (s *BookkeeperStorageSpec) withDefaults() (changed bool) {
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceStorage: resource.MustParse(DefaultBookkeeperJournalVolumeSize),
+				},
+			},
+		}
+	}
+
+	if s.IndexVolumeClaimTemplate == nil {
+		changed = true
+		s.IndexVolumeClaimTemplate = &v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse(DefaultBookkeeperIndexVolumeSize),
 				},
 			},
 		}

--- a/pkg/apis/pravega/v1alpha1/bookkeeper.go
+++ b/pkg/apis/pravega/v1alpha1/bookkeeper.go
@@ -111,11 +111,11 @@ func (s *BookkeeperSpec) withDefaults() (changed bool) {
 		s.Resources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("1000m"),
-				v1.ResourceMemory: resource.MustParse("3Gi"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 			Limits: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("2000m"),
-				v1.ResourceMemory: resource.MustParse("5Gi"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		}
 	}

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -151,7 +151,7 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 			},
 			Limits: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("2000m"),
-				v1.ResourceMemory: resource.MustParse("2Gi"),
+				v1.ResourceMemory: resource.MustParse("3Gi"),
 			},
 		}
 	}
@@ -160,12 +160,12 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.SegmentStoreResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("4000m"),
-				v1.ResourceMemory: resource.MustParse("4Gi"),
+				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceMemory: resource.MustParse("3Gi"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("6000m"),
-				v1.ResourceMemory: resource.MustParse("6Gi"),
+				v1.ResourceCPU:    resource.MustParse("2000m"),
+				v1.ResourceMemory: resource.MustParse("5Gi"),
 			},
 		}
 	}

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -87,6 +87,14 @@ type PravegaSpec struct {
 	// SegmentStoreServiceAccountName configures the service account used on segment store instances.
 	// If not specified, Kubernetes will automatically assign the default service account in the namespace
 	SegmentStoreServiceAccountName string `json:"segmentStoreServiceAccountName,omitempty"`
+
+	// ControllerResources specifies the request and limit of resources that controller can have.
+	// ControllerResources includes CPU and memory resources
+	ControllerResources *v1.ResourceRequirements `json:"controllerResources,omitempty"`
+
+	// SegmentStoreResources specifies the request and limit of resources that segmentStore can have.
+	// SegmentStoreResources includes CPU and memory resources
+	SegmentStoreResources *v1.ResourceRequirements `json:"segmentStoreResources,omitempty"`
 }
 
 func (s *PravegaSpec) withDefaults() (changed bool) {
@@ -129,8 +137,37 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.Tier2 = &Tier2Spec{}
 	}
+
 	if s.Tier2.withDefaults() {
 		changed = true
+	}
+
+	if s.controllerResources == nil {
+		changed = true
+		s.controllerResources = &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2000m"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		}
+	}
+
+	if s.segmentStoreResources == nil {
+		changed = true
+		s.segmentStoreResources = &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4000m"),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("6000m"),
+				v1.ResourceMemory: resource.MustParse("6Gi"),
+			},
+		}
 	}
 
 	return changed

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -146,12 +146,12 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.ControllerResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1000m"),
-				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourceCPU:    resource.MustParse("500m"),
+				v1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("2000m"),
-				v1.ResourceMemory: resource.MustParse("3Gi"),
+				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 		}
 	}
@@ -161,11 +161,11 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		s.SegmentStoreResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("1000m"),
-				v1.ResourceMemory: resource.MustParse("3Gi"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 			Limits: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("2000m"),
-				v1.ResourceMemory: resource.MustParse("5Gi"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		}
 	}

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -45,6 +45,30 @@ const (
 	// DefaultSegmentStoreReplicas is the default number of replicas for the Pravega
 	// Segment Store component
 	DefaultSegmentStoreReplicas = 1
+
+	// DefaultControllerRequestCPU is the default CPU request for Pravega
+	DefaultControllerRequestCPU = "250m"
+
+	// DefaultControllerLimitCPU is the default CPU limit for Pravega
+	DefaultControllerLimitCPU = "500m"
+
+	// DefaultControllerRequestMemory is the default memory request for Pravega
+	DefaultControllerRequestMemory = "512Mi"
+
+	// DefaultControllerLimitMemory is the default memory limit for Pravega
+	DefaultControllerLimitMemory = "1Gi"
+
+	// DefaultSegmentStoreRequestCPU is the default CPU request for Pravega
+	DefaultSegmentStoreRequestCPU = "500m"
+
+	// DefaultSegmentStoreLimitCPU is the default CPU limit for Pravega
+	DefaultSegmentStoreLimitCPU = "1"
+
+	// DefaultSegmentStoreRequestMemory is the default memory request for Pravega
+	DefaultSegmentStoreRequestMemory = "1Gi"
+
+	// DefaultSegmentStoreLimitMemory is the default memory limit for Pravega
+	DefaultSegmentStoreLimitMemory = "2Gi"
 )
 
 // PravegaSpec defines the configuration of Pravega
@@ -146,12 +170,12 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.ControllerResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("250m"),
-				v1.ResourceMemory: resource.MustParse("512Mi"),
+				v1.ResourceCPU:    resource.MustParse(DefaultControllerRequestCPU),
+				v1.ResourceMemory: resource.MustParse(DefaultControllerRequestMemory),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("500m"),
-				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourceCPU:    resource.MustParse(DefaultControllerLimitCPU),
+				v1.ResourceMemory: resource.MustParse(DefaultControllerLimitMemory),
 			},
 		}
 	}
@@ -160,12 +184,12 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.SegmentStoreResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("500m"),
-				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourceCPU:    resource.MustParse(DefaultSegmentStoreRequestCPU),
+				v1.ResourceMemory: resource.MustParse(DefaultSegmentStoreRequestMemory),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1000m"),
-				v1.ResourceMemory: resource.MustParse("2Gi"),
+				v1.ResourceCPU:    resource.MustParse(DefaultSegmentStoreLimitCPU),
+				v1.ResourceMemory: resource.MustParse(DefaultSegmentStoreLimitMemory),
 			},
 		}
 	}

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -142,9 +142,9 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 	}
 
-	if s.controllerResources == nil {
+	if s.ControllerResources == nil {
 		changed = true
-		s.controllerResources = &v1.ResourceRequirements{
+		s.ControllerResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("1000m"),
 				v1.ResourceMemory: resource.MustParse("1Gi"),
@@ -156,9 +156,9 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		}
 	}
 
-	if s.segmentStoreResources == nil {
+	if s.SegmentStoreResources == nil {
 		changed = true
-		s.segmentStoreResources = &v1.ResourceRequirements{
+		s.SegmentStoreResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("4000m"),
 				v1.ResourceMemory: resource.MustParse("4Gi"),

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -146,11 +146,11 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.ControllerResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("500m"),
+				v1.ResourceCPU:    resource.MustParse("250m"),
 				v1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceCPU:    resource.MustParse("500m"),
 				v1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 		}
@@ -160,11 +160,11 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.SegmentStoreResources = &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceCPU:    resource.MustParse("500m"),
 				v1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("2000m"),
+				v1.ResourceCPU:    resource.MustParse("1000m"),
 				v1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		}

--- a/pkg/apis/pravega/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pravega/v1alpha1/zz_generated.deepcopy.go
@@ -60,6 +60,11 @@ func (in *BookkeeperSpec) DeepCopyInto(out *BookkeeperSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
 		*out = make(map[string]string, len(*in))
@@ -90,6 +95,11 @@ func (in *BookkeeperStorageSpec) DeepCopyInto(out *BookkeeperStorageSpec) {
 	}
 	if in.JournalVolumeClaimTemplate != nil {
 		in, out := &in.JournalVolumeClaimTemplate, &out.JournalVolumeClaimTemplate
+		*out = new(v1.PersistentVolumeClaimSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.IndexVolumeClaimTemplate != nil {
+		in, out := &in.IndexVolumeClaimTemplate, &out.IndexVolumeClaimTemplate
 		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
@@ -387,6 +397,16 @@ func (in *PravegaSpec) DeepCopyInto(out *PravegaSpec) {
 	if in.Tier2 != nil {
 		in, out := &in.Tier2, &out.Tier2
 		*out = new(Tier2Spec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ControllerResources != nil {
+		in, out := &in.ControllerResources, &out.ControllerResources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.SegmentStoreResources != nil {
+		in, out := &in.SegmentStoreResources, &out.SegmentStoreResources
+		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -184,7 +184,7 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 
 func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
 	configData := map[string]string{
-		"BK_BOOKIE_EXTRA_OPTS": "\"-Xms1g -Xmx4g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\"",
+		"BK_BOOKIE_EXTRA_OPTS": "\"-Xms1g -Xmx5g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\"",
 		"ZK_URL":               pravegaCluster.Spec.ZookeeperUri,
 		// Set useHostNameAsBookieID to false until BookKeeper Docker
 		// image is updated to 4.7

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -16,7 +16,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -126,16 +125,7 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 						MountPath: "/bk/index",
 					},
 				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4000m"),
-						corev1.ResourceMemory: resource.MustParse("4Gi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6000m"),
-						corev1.ResourceMemory: resource.MustParse("6Gi"),
-					},
-				},
+				Resources: *bookkeeperSpec.Resources,
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -12,6 +12,7 @@ package pravega
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/util"
@@ -183,8 +184,26 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 }
 
 func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
+	javaOpts := []string{
+		"-Xms1g",
+		"-XX:+UnlockExperimentalVMOptions",
+		"-XX:+UseCGroupMemoryLimitForHeap",
+		"-XX:MaxRAMFraction=1",
+		"-XX:MaxDirectMemorySize=1g",
+		"-XX:+UseG1GC",
+		"-XX:MaxGCPauseMillis=10",
+		"-XX:+ParallelRefProcEnabled",
+		"-XX:+AggressiveOpts",
+		"-XX:+DoEscapeAnalysis",
+		"-XX:ParallelGCThreads=32",
+		"-XX:ConcGCThreads=32",
+		"-XX:G1NewSizePercent=50",
+		"-XX:+DisableExplicitGC",
+		"-XX:-ResizePLAB",
+	}
+
 	configData := map[string]string{
-		"BK_BOOKIE_EXTRA_OPTS": "\"-Xms1g -Xmx5g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\"",
+		"BK_BOOKIE_EXTRA_OPTS": strings.Join(javaOpts, " "),
 		"ZK_URL":               pravegaCluster.Spec.ZookeeperUri,
 		// Set useHostNameAsBookieID to false until BookKeeper Docker
 		// image is updated to 4.7

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -16,6 +16,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -120,6 +121,16 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 						MountPath: "/bk/ledgers",
 					},
 				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("4.0"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("6.0"),
+						corev1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				},
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
@@ -175,7 +186,7 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 
 func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
 	configData := map[string]string{
-		"BK_BOOKIE_EXTRA_OPTS": "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB",
+		"BK_BOOKIE_EXTRA_OPTS": "-Xms1g -Xmx4g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB",
 		"ZK_URL":               pravegaCluster.Spec.ZookeeperUri,
 		// Using IP address as the Bookie ID until Pravega's BookKeeper is update to, at least,
 		// version 4.7, which assumes that hostnames can resolve to different IP addresses

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -24,6 +24,7 @@ import (
 const (
 	LedgerDiskName  = "ledger"
 	JournalDiskName = "journal"
+	IndexDiskName   = "index"
 )
 
 func MakeBookieHeadlessService(pravegaCluster *v1alpha1.PravegaCluster) *corev1.Service {
@@ -120,6 +121,10 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 						Name:      JournalDiskName,
 						MountPath: "/bk/ledgers",
 					},
+					{
+						Name:      IndexDiskName,
+						MountPath: "/bk/index",
+					},
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -180,6 +185,12 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 				Name: LedgerDiskName,
 			},
 			Spec: *spec.Storage.LedgerVolumeClaimTemplate,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: IndexDiskName,
+			},
+			Spec: *spec.Storage.IndexVolumeClaimTemplate,
 		},
 	}
 }

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -123,11 +123,11 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4.0"),
+						corev1.ResourceCPU:    resource.MustParse("4000m"),
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6.0"),
+						corev1.ResourceCPU:    resource.MustParse("6000m"),
 						corev1.ResourceMemory: resource.MustParse("6Gi"),
 					},
 				},

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -184,8 +184,8 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 
 func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
 	configData := map[string]string{
-		"BK_BOOKIE_EXTRA_OPTS":     "\"-Xms1g -Xmx4g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\"",
-		"ZK_URL":                   pravegaCluster.Spec.ZookeeperUri,
+		"BK_BOOKIE_EXTRA_OPTS": "\"-Xms1g -Xmx4g -XX:MaxDirectMemorySize=1g -XX:+UseG1GC  -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB\"",
+		"ZK_URL":               pravegaCluster.Spec.ZookeeperUri,
 		// Using IP address as the Bookie ID until Pravega's BookKeeper is update to, at least,
 		// version 4.7, which assumes that hostnames can resolve to different IP addresses
 		// over time.

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -76,6 +77,16 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 								Name: util.ConfigMapNameForController(name),
 							},
 						},
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
 					},
 				},
 				ReadinessProbe: &corev1.Probe{

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -117,7 +117,10 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 
 func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	var javaOpts = []string{
-		"-Xms1g -Xmx3g -XX:MaxDirectMemorySize=1g -Dpravegaservice.clusterName=" + p.Name,
+		"-Xms1g",
+		"-XX:+UnlockExperimentalVMOptions",
+		"-XX:+UseCGroupMemoryLimitForHeap",
+		"-Dpravegaservice.clusterName=" + p.Name,
 	}
 
 	for name, value := range p.Spec.Pravega.Options {
@@ -135,10 +138,6 @@ func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		"USER_PASSWORD_FILE":     "/etc/pravega/conf/passwd",
 		"TLS_ENABLED":            "false",
 		"WAIT_FOR":               p.Spec.ZookeeperUri,
-	}
-
-	for name, value := range p.Spec.Pravega.Options {
-		configData[name] = value
 	}
 
 	configMap := &corev1.ConfigMap{

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -81,11 +81,11 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceCPU:    resource.MustParse("1000m"),
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceCPU:    resource.MustParse("2000m"),
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
 					},
 				},
@@ -127,7 +127,7 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 
 func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	var javaOpts = []string{
-		"-Dpravegaservice.clusterName=" + p.Name,
+		"-Xms1g -Xmx2g -Dpravegaservice.clusterName=" + p.Name,
 	}
 
 	for name, value := range p.Spec.Pravega.Options {

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -79,16 +79,7 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 						},
 					},
 				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1000m"),
-						corev1.ResourceMemory: resource.MustParse("1Gi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("2000m"),
-						corev1.ResourceMemory: resource.MustParse("2Gi"),
-					},
-				},
+				Resources: *pravegaSpec.ControllerResources,
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -117,7 +117,7 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 
 func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	var javaOpts = []string{
-		"-Xms1g -Xmx2g -Dpravegaservice.clusterName=" + p.Name,
+		"-Xms1g -Xmx3g -XX:MaxDirectMemorySize=1g -Dpravegaservice.clusterName=" + p.Name,
 	}
 
 	for name, value := range p.Spec.Pravega.Options {

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -20,7 +20,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -99,16 +98,7 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 						MountPath: cacheVolumeMountPoint,
 					},
 				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4000m"),
-						corev1.ResourceMemory: resource.MustParse("4Gi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6000m"),
-						corev1.ResourceMemory: resource.MustParse("6Gi"),
-					},
-				},
+				Resources: *pravegaSpec.SegmentStoreResources,
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -101,11 +101,11 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceCPU:    resource.MustParse("4000m"),
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6"),
+						corev1.ResourceCPU:    resource.MustParse("6000m"),
 						corev1.ResourceMemory: resource.MustParse("6Gi"),
 					},
 				},
@@ -153,7 +153,7 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 
 func MakeSegmentstoreConfigMap(pravegaCluster *api.PravegaCluster) *corev1.ConfigMap {
 	javaOpts := []string{
-		"-Dpravegaservice.clusterName=" + pravegaCluster.Name,
+		"-Xms1g -Xmx4g -XX:MaxDirectMemorySize=1g -Dpravegaservice.clusterName=" + pravegaCluster.Name,
 	}
 
 	for name, value := range pravegaCluster.Spec.Pravega.Options {

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -96,6 +97,16 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 					{
 						Name:      cacheVolumeName,
 						MountPath: cacheVolumeMountPoint,
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("6"),
+						corev1.ResourceMemory: resource.MustParse("6Gi"),
 					},
 				},
 				ReadinessProbe: &corev1.Probe{

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -143,7 +143,7 @@ func makeSegmentstorePodSpec(pravegaCluster *api.PravegaCluster) corev1.PodSpec 
 
 func MakeSegmentstoreConfigMap(pravegaCluster *api.PravegaCluster) *corev1.ConfigMap {
 	javaOpts := []string{
-		"-Xms1g -Xmx4g -XX:MaxDirectMemorySize=1g -Dpravegaservice.clusterName=" + pravegaCluster.Name,
+		"-Xms1g -Xmx5g -XX:MaxDirectMemorySize=1g -Dpravegaservice.clusterName=" + pravegaCluster.Name,
 	}
 
 	for name, value := range pravegaCluster.Spec.Pravega.Options {

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package pravegacluster
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+
+	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
+	"github.com/pravega/pravega-operator/pkg/util"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBookie(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pravega cluster")
+}
+
+var _ = Describe("PravegaCluster Controller", func() {
+	const (
+		Name      = "example"
+		Namespace = "default"
+	)
+
+	var (
+		s = scheme.Scheme
+		r *ReconcilePravegaCluster
+	)
+
+	Context("Reconcile", func() {
+		var (
+			res reconcile.Result
+			req reconcile.Request
+			p   *v1alpha1.PravegaCluster
+		)
+
+		BeforeEach(func() {
+			req = reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      Name,
+					Namespace: Namespace,
+				},
+			}
+			p = &v1alpha1.PravegaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      Name,
+					Namespace: Namespace,
+				},
+			}
+			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, p)
+		})
+
+		Context("Default spec", func() {
+			var (
+				client client.Client
+				err    error
+			)
+
+			BeforeEach(func() {
+				p.WithDefaults()
+				client = fake.NewFakeClient(p)
+				r = &ReconcilePravegaCluster{client: client, scheme: s}
+				res, err = r.Reconcile(req)
+			})
+
+			It("shouldn't error", func() {
+				Ω(err).To(BeNil())
+			})
+
+			Context("Default bookkeeper", func() {
+				It("should have a default bookie resource", func() {
+					foundBk := &appsv1.StatefulSet{}
+					nn := types.NamespacedName{
+						Name:      util.StatefulSetNameForBookie(p.Name),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn, foundBk)
+					Ω(err).To(BeNil())
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("500m"))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("1Gi"))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("1"))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("2Gi"))
+				})
+			})
+
+			Context("Default Pravega controller", func() {
+				It("should have a default controller resource", func() {
+					foundController := &appsv1.Deployment{}
+					nn := types.NamespacedName{
+						Name:      util.DeploymentNameForController(p.Name),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn, foundController)
+					Ω(err).To(BeNil())
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("250m"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("512Mi"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("500m"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("1Gi"))
+				})
+			})
+
+			Context("Default Pravega segmentstore", func() {
+				It("should have a default controller resource", func() {
+					foundSS := &appsv1.StatefulSet{}
+					nn := types.NamespacedName{
+						Name:      util.StatefulSetNameForSegmentstore(p.Name),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn, foundSS)
+					Ω(err).To(BeNil())
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("500m"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("1Gi"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("1"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("2Gi"))
+				})
+			})
+		})
+
+		Context("Custom spec", func() {
+			var (
+				client client.Client
+				err    error
+			)
+
+			BeforeEach(func() {
+				customReq := &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2000m"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("4000m"),
+						corev1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				}
+				p.Spec = v1alpha1.ClusterSpec{
+					Bookkeeper: &v1alpha1.BookkeeperSpec{
+						Resources: customReq,
+					},
+					Pravega: &v1alpha1.PravegaSpec{
+						ControllerResources:   customReq,
+						SegmentStoreResources: customReq,
+					},
+				}
+				p.WithDefaults()
+				client = fake.NewFakeClient(p)
+				r = &ReconcilePravegaCluster{client: client, scheme: s}
+				res, err = r.Reconcile(req)
+			})
+
+			It("shouldn't error", func() {
+				Ω(err).To(BeNil())
+			})
+
+			Context("Custom bookkeeper", func() {
+				It("should have a custom bookie resource", func() {
+					foundBK := &appsv1.StatefulSet{}
+					nn := types.NamespacedName{
+						Name:      util.StatefulSetNameForBookie(p.Name),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn, foundBK)
+					Ω(err).To(BeNil())
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("2"))
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("4Gi"))
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("4"))
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("6Gi"))
+				})
+			})
+
+			Context("Custom Pravega controller", func() {
+				It("should have a custom controller resource", func() {
+					foundController := &appsv1.Deployment{}
+					nn := types.NamespacedName{
+						Name:      util.DeploymentNameForController(p.Name),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn, foundController)
+					Ω(err).To(BeNil())
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("2"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("4Gi"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("4"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("6Gi"))
+				})
+			})
+
+			Context("Custom Pravega segmentstore", func() {
+				It("should have a custom segmentstore resource", func() {
+					foundSS := &appsv1.StatefulSet{}
+					nn := types.NamespacedName{
+						Name:      util.StatefulSetNameForSegmentstore(p.Name),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn, foundSS)
+					Ω(err).To(BeNil())
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("2"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("4Gi"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("4"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("6Gi"))
+				})
+			})
+		})
+	})
+})

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -49,7 +49,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 
 	Context("Reconcile", func() {
 		var (
-			res reconcile.Result
 			req reconcile.Request
 			p   *v1alpha1.PravegaCluster
 		)
@@ -80,7 +79,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 				p.WithDefaults()
 				client = fake.NewFakeClient(p)
 				r = &ReconcilePravegaCluster{client: client, scheme: s}
-				res, err = r.Reconcile(req)
+				_, err = r.Reconcile(req)
 			})
 
 			It("shouldn't error", func() {
@@ -96,10 +95,10 @@ var _ = Describe("PravegaCluster Controller", func() {
 					}
 					err = client.Get(context.TODO(), nn, foundBk)
 					Ω(err).To(BeNil())
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("500m"))
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("1Gi"))
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("1"))
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("2Gi"))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperRequestCPU))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperRequestMemory))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperLimitCPU))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperLimitMemory))
 				})
 			})
 
@@ -112,10 +111,10 @@ var _ = Describe("PravegaCluster Controller", func() {
 					}
 					err = client.Get(context.TODO(), nn, foundController)
 					Ω(err).To(BeNil())
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("250m"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("512Mi"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("500m"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("1Gi"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerRequestCPU))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerRequestMemory))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerLimitCPU))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerLimitMemory))
 				})
 			})
 
@@ -128,28 +127,29 @@ var _ = Describe("PravegaCluster Controller", func() {
 					}
 					err = client.Get(context.TODO(), nn, foundSS)
 					Ω(err).To(BeNil())
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("500m"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("1Gi"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("1"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("2Gi"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreRequestCPU))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreRequestMemory))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreLimitCPU))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreLimitMemory))
 				})
 			})
 		})
 
 		Context("Custom spec", func() {
 			var (
-				client client.Client
-				err    error
+				client    client.Client
+				err       error
+				customReq *corev1.ResourceRequirements
 			)
 
 			BeforeEach(func() {
-				customReq := &corev1.ResourceRequirements{
+				customReq = &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("2000m"),
+						corev1.ResourceCPU:    resource.MustParse("2"),
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4000m"),
+						corev1.ResourceCPU:    resource.MustParse("4"),
 						corev1.ResourceMemory: resource.MustParse("6Gi"),
 					},
 				}
@@ -165,7 +165,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 				p.WithDefaults()
 				client = fake.NewFakeClient(p)
 				r = &ReconcilePravegaCluster{client: client, scheme: s}
-				res, err = r.Reconcile(req)
+				_, err = r.Reconcile(req)
 			})
 
 			It("shouldn't error", func() {
@@ -181,10 +181,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 					}
 					err = client.Get(context.TODO(), nn, foundBK)
 					Ω(err).To(BeNil())
-					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("2"))
-					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("4Gi"))
-					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("4"))
-					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("6Gi"))
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources).To(Equal(*customReq))
 				})
 			})
 
@@ -197,10 +194,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 					}
 					err = client.Get(context.TODO(), nn, foundController)
 					Ω(err).To(BeNil())
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("2"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("4Gi"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("4"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("6Gi"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources).To(Equal(*customReq))
 				})
 			})
 
@@ -213,10 +207,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 					}
 					err = client.Get(context.TODO(), nn, foundSS)
 					Ω(err).To(BeNil())
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo("2"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo("4Gi"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo("4"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo("6Gi"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources).To(Equal(*customReq))
 				})
 			})
 		})

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -12,8 +12,9 @@ package pravegacluster
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/util"
@@ -83,7 +84,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 			})
 
 			It("shouldn't error", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			Context("Default bookkeeper", func() {
@@ -94,11 +95,11 @@ var _ = Describe("PravegaCluster Controller", func() {
 						Namespace: Namespace,
 					}
 					err = client.Get(context.TODO(), nn, foundBk)
-					Ω(err).To(BeNil())
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperRequestCPU))
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperRequestMemory))
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperLimitCPU))
-					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultBookkeeperLimitMemory))
+					Ω(err).Should(BeNil())
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).Should(Equal("500m"))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).Should(Equal("1Gi"))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).Should(Equal("1"))
+					Ω(foundBk.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).Should(Equal("2Gi"))
 				})
 			})
 
@@ -110,11 +111,11 @@ var _ = Describe("PravegaCluster Controller", func() {
 						Namespace: Namespace,
 					}
 					err = client.Get(context.TODO(), nn, foundController)
-					Ω(err).To(BeNil())
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerRequestCPU))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerRequestMemory))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerLimitCPU))
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultControllerLimitMemory))
+					Ω(err).Should(BeNil())
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).Should(Equal("250m"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).Should(Equal("512Mi"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).Should(Equal("500m"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).Should(Equal("1Gi"))
 				})
 			})
 
@@ -126,11 +127,11 @@ var _ = Describe("PravegaCluster Controller", func() {
 						Namespace: Namespace,
 					}
 					err = client.Get(context.TODO(), nn, foundSS)
-					Ω(err).To(BeNil())
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreRequestCPU))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreRequestMemory))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreLimitCPU))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(BeEquivalentTo(v1alpha1.DefaultSegmentStoreLimitMemory))
+					Ω(err).Should(BeNil())
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).Should(Equal("500m"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).Should(Equal("1Gi"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).Should(Equal("1"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).Should(Equal("2Gi"))
 				})
 			})
 		})
@@ -169,7 +170,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 			})
 
 			It("shouldn't error", func() {
-				Ω(err).To(BeNil())
+				Ω(err).Should(BeNil())
 			})
 
 			Context("Custom bookkeeper", func() {
@@ -180,8 +181,11 @@ var _ = Describe("PravegaCluster Controller", func() {
 						Namespace: Namespace,
 					}
 					err = client.Get(context.TODO(), nn, foundBK)
-					Ω(err).To(BeNil())
-					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources).To(Equal(*customReq))
+					Ω(err).Should(BeNil())
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).Should(Equal("2"))
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).Should(Equal("4Gi"))
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).Should(Equal("4"))
+					Ω(foundBK.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).Should(Equal("6Gi"))
 				})
 			})
 
@@ -193,8 +197,11 @@ var _ = Describe("PravegaCluster Controller", func() {
 						Namespace: Namespace,
 					}
 					err = client.Get(context.TODO(), nn, foundController)
-					Ω(err).To(BeNil())
-					Ω(foundController.Spec.Template.Spec.Containers[0].Resources).To(Equal(*customReq))
+					Ω(err).Should(BeNil())
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).Should(Equal("2"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).Should(Equal("4Gi"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).Should(Equal("4"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).Should(Equal("6Gi"))
 				})
 			})
 
@@ -206,8 +213,11 @@ var _ = Describe("PravegaCluster Controller", func() {
 						Namespace: Namespace,
 					}
 					err = client.Get(context.TODO(), nn, foundSS)
-					Ω(err).To(BeNil())
-					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources).To(Equal(*customReq))
+					Ω(err).Should(BeNil())
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).Should(Equal("2"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).Should(Equal("4Gi"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).Should(Equal("4"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).Should(Equal("6Gi"))
 				})
 			})
 		})

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -144,6 +144,8 @@ func WaitForClusterToTerminate(t *testing.T, f *framework.Framework, ctx *framew
 	}
 
 	t.Logf("pravega cluster terminated: %s", p.Name)
+	time.Sleep(time.Duration(time.Second * 10))
+	
 	return nil
 }
 

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -145,7 +145,7 @@ func WaitForClusterToTerminate(t *testing.T, f *framework.Framework, ctx *framew
 
 	t.Logf("pravega cluster terminated: %s", p.Name)
 	time.Sleep(time.Duration(time.Second * 10))
-	
+
 	return nil
 }
 

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -121,6 +121,7 @@ func WaitForClusterToTerminate(t *testing.T, f *framework.Framework, ctx *framew
 		LabelSelector: labels.SelectorFromSet(util.LabelsForPravegaCluster(p)).String(),
 	}
 
+	// Wait for Pods to terminate
 	err := wait.Poll(RetryInterval, 2*time.Minute, func() (done bool, err error) {
 		podList, err := f.KubeClient.Core().Pods(p.Namespace).List(listOptions)
 		if err != nil {
@@ -143,9 +144,30 @@ func WaitForClusterToTerminate(t *testing.T, f *framework.Framework, ctx *framew
 		return err
 	}
 
-	t.Logf("pravega cluster terminated: %s", p.Name)
-	time.Sleep(time.Duration(time.Second * 10))
+	// Wait for PVCs to terminate
+	err = wait.Poll(RetryInterval, 1*time.Minute, func() (done bool, err error) {
+		pvcList, err := f.KubeClient.Core().PersistentVolumeClaims(p.Namespace).List(listOptions)
+		if err != nil {
+			return false, err
+		}
 
+		var names []string
+		for i := range pvcList.Items {
+			pvc := &pvcList.Items[i]
+			names = append(names, pvc.Name)
+		}
+		t.Logf("waiting for pvc to terminate (%v)", names)
+		if len(names) != 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	t.Logf("pravega cluster terminated: %s", p.Name)
 	return nil
 }
 


### PR DESCRIPTION
### Change log description

This PR will bring the following changes:
- Set adequate default resource requests and limits for Pravega components
- Expose those resource setting to allow custom configurations
- Replace static `Xmx` JVM option with the dynamic, Docker-aware flags `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` which will set the heap memory size to the given Pod memory limit. (Ref: https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits)

At this moment, the PR is being used for testing with the goal of finding the suitable values for resource requests and limits.

### Purpose of the change
Fix #130 

### How to test the change
When defining the Pravega cluster specification in the YAML file, include the following options to set custom resource requests and limits for each Pravega component.

```
apiVersion: "pravega.pravega.io/v1alpha1"
kind: "PravegaCluster"
metadata:
  name: "example"
spec:
  ...
  bookkeeper:
    ...
    resources:
      requests:
        memory: "3Gi"
        cpu: "1000m"
      limits:
        memory: "5Gi"
        cpu: "2000m"

  pravega:
    ...
    controllerResources:
      requests:
        memory: "1Gi"
        cpu: "1000m"
      limits:
        memory: "3Gi"
        cpu: "2000m"

    segmentStoreResources:
      requests:
        memory: "3Gi"
        cpu: "1000m"
      limits:
        memory: "5Gi"
        cpu: "2000m"
```

You can verify that those values have been correctly set by looking at the Pods description.

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>