### PR TITLE
Update README: Add service account role definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,34 @@ spec:
 ...
 ```
 
+If external access is enabled in your Pravega cluster, Segment Store pods will require access to some Kubernetes API endpoints to obtain the external IP and port. Make sure that the service account you are using for the Segment Store has, at least, the following permissions.
+
+```
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pravega-components
+  namespace: "pravega-namespace"
+rules:
+- apiGroups: ["pravega.pravega.io"]
+  resources: ["*"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pravega-components
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+```
+
+Replace the `namespace` with your own namespace.
+
 ### Installing on a Custom Namespace with RBAC enabled
 
 Create the namespace.


### PR DESCRIPTION
Add role and cluster role definitions when configuring Pravega cluster with external access enabled.