### PR TITLE
Fix Pravega and BookKeeper Java options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
 
     - stage: e2e
       name: End-to-end tests
-      if: type = pull_request OR branch = master
+      if: type = pull_request OR branch = master OR tag IS present
       services:
         - docker
       env:
@@ -85,7 +85,7 @@ jobs:
 
     - stage: deploy
       name: Push Docker image
-      if: branch = master AND tag IS present
+      if: type != pull_request AND tag IS present
       services:
         - docker
       script:

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -184,15 +184,18 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 }
 
 func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
-	javaOpts := []string{
-		// Leading and trailing double quotes are required for Bookies to
-		// pick up these Java options.
-		"\"",
+	memoryOpts := []string{
 		"-Xms1g",
 		"-XX:+UnlockExperimentalVMOptions",
 		"-XX:+UseCGroupMemoryLimitForHeap",
 		"-XX:MaxRAMFraction=1",
 		"-XX:MaxDirectMemorySize=1g",
+		"-XX:+ExitOnOutOfMemoryError",
+		"-XX:+CrashOnOutOfMemoryError",
+		"-XX:+HeapDumpOnOutOfMemoryError",
+	}
+
+	gcOpts := []string{
 		"-XX:+UseG1GC",
 		"-XX:MaxGCPauseMillis=10",
 		"-XX:+ParallelRefProcEnabled",
@@ -203,12 +206,21 @@ func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.Config
 		"-XX:G1NewSizePercent=50",
 		"-XX:+DisableExplicitGC",
 		"-XX:-ResizePLAB",
-		"\"",
+	}
+
+	gcLoggingOpts := []string{
+		"-XX:+PrintGCDetails",
+		"-XX:+PrintGCApplicationStoppedTime",
+		"-XX:+UseGCLogFileRotation",
+		"-XX:NumberOfGCLogFiles=5",
+		"-XX:GCLogFileSize=64m",
 	}
 
 	configData := map[string]string{
-		"BK_BOOKIE_EXTRA_OPTS": strings.Join(javaOpts, " "),
-		"ZK_URL":               pravegaCluster.Spec.ZookeeperUri,
+		"BOOKIE_MEM_OPTS":        strings.Join(memoryOpts, " "),
+		"BOOKIE_GC_OPTS":         strings.Join(gcOpts, " "),
+		"BOOKIE_GC_LOGGING_OPTS": strings.Join(gcLoggingOpts, " "),
+		"ZK_URL":                 pravegaCluster.Spec.ZookeeperUri,
 		// Set useHostNameAsBookieID to false until BookKeeper Docker
 		// image is updated to 4.7
 		// This value can be explicitly overridden when using the operator

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -185,6 +185,9 @@ func makeBookieVolumeClaimTemplates(spec *v1alpha1.BookkeeperSpec) []corev1.Pers
 
 func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.ConfigMap {
 	javaOpts := []string{
+		// Leading and trailing double quotes are required for Bookies to
+		// pick up these Java options.
+		"\"",
 		"-Xms1g",
 		"-XX:+UnlockExperimentalVMOptions",
 		"-XX:+UseCGroupMemoryLimitForHeap",
@@ -200,6 +203,7 @@ func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.Config
 		"-XX:G1NewSizePercent=50",
 		"-XX:+DisableExplicitGC",
 		"-XX:-ResizePLAB",
+		"\"",
 	}
 
 	configData := map[string]string{

--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -188,7 +188,7 @@ func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.Config
 		"-Xms1g",
 		"-XX:+UnlockExperimentalVMOptions",
 		"-XX:+UseCGroupMemoryLimitForHeap",
-		"-XX:MaxRAMFraction=1",
+		"-XX:MaxRAMFraction=2",
 		"-XX:MaxDirectMemorySize=1g",
 		"-XX:+ExitOnOutOfMemoryError",
 		"-XX:+CrashOnOutOfMemoryError",
@@ -210,6 +210,7 @@ func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.Config
 
 	gcLoggingOpts := []string{
 		"-XX:+PrintGCDetails",
+		"-XX:+PrintGCDateStamps",
 		"-XX:+PrintGCApplicationStoppedTime",
 		"-XX:+UseGCLogFileRotation",
 		"-XX:NumberOfGCLogFiles=5",

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -120,6 +120,10 @@ func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		"-Xms1g",
 		"-XX:+UnlockExperimentalVMOptions",
 		"-XX:+UseCGroupMemoryLimitForHeap",
+		"-XX:+ExitOnOutOfMemoryError",
+		"-XX:+CrashOnOutOfMemoryError",
+		"-XX:+HeapDumpOnOutOfMemoryError",
+		"-XX:MaxRAMFraction=1",
 		"-Dpravegaservice.clusterName=" + p.Name,
 	}
 

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -117,13 +117,13 @@ func makeControllerPodSpec(name string, pravegaSpec *api.PravegaSpec) *corev1.Po
 
 func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	var javaOpts = []string{
-		"-Xms1g",
+		"-Xms512m",
 		"-XX:+UnlockExperimentalVMOptions",
 		"-XX:+UseCGroupMemoryLimitForHeap",
+		"-XX:MaxRAMFraction=2",
 		"-XX:+ExitOnOutOfMemoryError",
 		"-XX:+CrashOnOutOfMemoryError",
 		"-XX:+HeapDumpOnOutOfMemoryError",
-		"-XX:MaxRAMFraction=1",
 		"-Dpravegaservice.clusterName=" + p.Name,
 	}
 

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -146,10 +146,10 @@ func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		"-Xms1g",
 		"-XX:+UnlockExperimentalVMOptions",
 		"-XX:+UseCGroupMemoryLimitForHeap",
+		"-XX:MaxRAMFraction=2",
 		"-XX:+ExitOnOutOfMemoryError",
 		"-XX:+CrashOnOutOfMemoryError",
 		"-XX:+HeapDumpOnOutOfMemoryError",
-		"-XX:MaxRAMFraction=1",
 		"-Dpravegaservice.clusterName=" + p.Name,
 	}
 

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -146,6 +146,9 @@ func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		"-Xms1g",
 		"-XX:+UnlockExperimentalVMOptions",
 		"-XX:+UseCGroupMemoryLimitForHeap",
+		"-XX:+ExitOnOutOfMemoryError",
+		"-XX:+CrashOnOutOfMemoryError",
+		"-XX:+HeapDumpOnOutOfMemoryError",
 		"-XX:MaxRAMFraction=1",
 		"-Dpravegaservice.clusterName=" + p.Name,
 	}


### PR DESCRIPTION
### Change log description

- Set BookKeeper Java options using the `BOOKIE_MEM_OPTS`, `BOOKIE_GC_OPTS`, and `BOOKIE_GC_LOGGING_OPTS` environment variables instead of `BK_BOOKIE_EXTRA_OPTS`.
- Make Segmentstore, Controller, and BookKeeper processes exit and crash on out of memory errors.
- Fix CI triggers.

### Purpose of the change
Fix #144
Related to #141 

### How to test the change

After deploying a Pravega cluster, `kubectl exec` into the containers, list the processes with `ps aux`, and check that Java options are properly passed to the Java process. 

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>