### PR TITLE
Fix Makefile in make version 3.81

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,7 @@ login:
 
 push: build login
 	docker push $(REPO):$(VERSION)
-	if [[ ${TRAVIS_TAG} =~ ^([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-	  docker push $(REPO):latest
-	fi
+	if [[ ${TRAVIS_TAG} =~ ^([0-9]+\.[0-9]+\.[0-9]+)$$ ]]; then docker push $(REPO):latest; fi;
 
 clean:
 	rm -f bin/$(PROJECT_NAME)


### PR DESCRIPTION
Fix Makefile. Note that the result of make -v in Travis is GNU Make 3.81 and we normally have 4.0+ version locally. 

Signed-off-by: wenqimou <452787782@qq.com>