### PR TITLE
Issue 187: Webhook rejects requests when cluster is upgrading

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -63,7 +63,7 @@ func (pwh *pravegaWebhookHandler) Handle(ctx context.Context, req admissiontypes
 	copy := pravega.DeepCopy()
 
 	if err := pwh.clusterIsAvailable(ctx, copy); err != nil {
-		return admission.ErrorResponse(http.StatusBadRequest, err)
+		return admission.ErrorResponse(http.StatusServiceUnavailable, err)
 	}
 
 	if err := pwh.mutatePravegaManifest(ctx, copy); err != nil {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -160,8 +160,11 @@ func (pwh *pravegaWebhookHandler) clusterIsAvailable(ctx context.Context, p *pra
 	}
 
 	_, upgrade := found.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
-	if upgrade.Status == corev1.ConditionTrue {
-		return fmt.Errorf("failed to process the request, cluster is upgrading")
+	if upgrade != nil && upgrade.Status == corev1.ConditionTrue {
+		// Reject the request if the requested version is new.
+		if p.Spec.Version != found.Spec.Version && p.Spec.Version != found.Status.CurrentVersion {
+			return fmt.Errorf("failed to process the request, cluster is upgrading")
+		}
 	}
 
 	// Add other conditions here

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"net/http"
 
+	corev1 "k8s.io/api/core/v1"
+
 	pravegav1alpha1 "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -59,6 +61,10 @@ func (pwh *pravegaWebhookHandler) Handle(ctx context.Context, req admissiontypes
 		return admission.ErrorResponse(http.StatusBadRequest, err)
 	}
 	copy := pravega.DeepCopy()
+
+	if err := pwh.clusterIsAvailable(ctx, copy); err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
 
 	if err := pwh.mutatePravegaManifest(ctx, copy); err != nil {
 		return admission.ErrorResponse(http.StatusBadRequest, err)
@@ -136,6 +142,29 @@ func (pwh *pravegaWebhookHandler) mutatePravegaVersion(ctx context.Context, p *p
 		return fmt.Errorf("unsupported upgrade from version %s to %s", foundVersion, requestVersion)
 	}
 
+	return nil
+}
+
+func (pwh *pravegaWebhookHandler) clusterIsAvailable(ctx context.Context, p *pravegav1alpha1.PravegaCluster) error {
+	found := &pravegav1alpha1.PravegaCluster{}
+	nn := types.NamespacedName{
+		Namespace: p.Namespace,
+		Name:      p.Name,
+	}
+	err := pwh.client.Get(context.TODO(), nn, found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to obtain PravegaCluster resource: %v", err)
+	}
+
+	_, upgrade := found.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
+	if upgrade.Status == corev1.ConditionTrue {
+		return fmt.Errorf("failed to process the request, cluster is upgrading")
+	}
+
+	// Add other conditions here
 	return nil
 }
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -271,5 +271,31 @@ var _ = Describe("Admission webhook", func() {
 				})
 			})
 		})
+		Context("Reject request when upgrading", func() {
+			var (
+				client client.Client
+				err    error
+			)
+
+			BeforeEach(func() {
+				p.Spec = v1alpha1.ClusterSpec{
+					Version: "0.5.0-001",
+				}
+				p.Status.SetUpgradingConditionTrue()
+				client = fake.NewFakeClient(p)
+				pwh = &pravegaWebhookHandler{client: client}
+			})
+
+			Context("Sending request when upgrading", func() {
+				It("should not pass", func() {
+					p.Spec = v1alpha1.ClusterSpec{
+						Version: "0.5.0-002",
+					}
+					err = pwh.clusterIsAvailable(context.TODO(), p)
+					Ω(err).ShouldNot(BeNil())
+				})
+			})
+
+		})
 	})
 })


### PR DESCRIPTION
### Change log description
Enable webhook to reject requests when cluster is upgrading

### Purpose of the change
Fix #187

### How to test
Unit test should pass

Signed-off-by: wenqimou <452787782@qq.com>