### PR TITLE
Issue 191: Steps to manually uninstall operator and Pravega

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The project is currently alpha. While no breaking API changes are currently plan
     * [Upgrade a Pravega Cluster](#upgrade-a-pravega-cluster)
     * [Uninstall the Pravega Cluster](#uninstall-the-pravega-cluster)
     * [Uninstall the Operator](#uninstall-the-operator)
+    * [Manual installation](#manual-installation)
  * [Configuration](#configuration)
  * [Development](#development)
 * [Releases](#releases)
@@ -57,8 +58,6 @@ $ kubectl get deploy
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 foo-pravega-operator     1         1         1            1           17s
 ```
-
-You can also manually install the operator with `kubectl` commands. Check out the [manual installation](doc/manual-installation.md#install-the-Operator-manually) for instructions.
 
 ### Install a sample Pravega cluster
 
@@ -180,6 +179,10 @@ If you want to delete Pravega clusters, make sure to do it before uninstalling t
 ```
 $ helm delete foo --purge
 ```
+
+### Manual installation
+
+You can also manually install/uninstall the operator and Pravega with `kubectl` commands. Check out the [manual installation](doc/manual-installation.md) document for instructions.
 
 ## Configuration
 

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -1,5 +1,11 @@
 ## Manual installation
 
+* [Install the Operator manually](#install-the-operator-manually)
+* [Set up Tier 2 Storage](#set-up-tier-2-storage)
+* [Install the Pravega cluster manually](#install-the-pravega-cluster-manually)
+* [Uninstall the Pravega Cluster manually](#uninstall-the-pravega-cluster-manually)
+* [Uninstall the Operator manually](#uninstall-the-operator-manually)
+
 ### Install the Operator manually
 
 > Note: If you are running on Google Kubernetes Engine (GKE), please [check this first](#installation-on-google-kubernetes-engine).
@@ -30,7 +36,7 @@ Pravega requires a long term storage provider known as Tier 2 storage.
 
 Check out the available [options for Tier 2](tier2.md) and how to configure it.
 
-In this example we are going to use a `pravega-tier2` PVC using [NFS as the storage backend](tier2.md#use-nfs-as-tier-2). 
+In this example we are going to use a `pravega-tier2` PVC using [NFS as the storage backend](tier2.md#use-nfs-as-tier-2).
 
 ### Install the Pravega cluster manually
 
@@ -80,4 +86,21 @@ Verify that the cluster instances and its components are being created.
 $ kubectl get PravegaCluster
 NAME      VERSION   DESIRED MEMBERS   READY MEMBERS   AGE
 example   0.4.0     7                 0               25s
+```
+
+### Uninstall the Pravega cluster manually
+
+```
+$ kubectl delete -f pravega.yaml
+$ kubectl delete pvc pravega-tier2
+```
+
+### Uninstall the Operator manually
+
+> Note that the Pravega clusters managed by the Pravega operator will NOT be deleted even if the operator is uninstalled.
+
+To delete all clusters, delete all cluster CR objects before uninstalling the operator.
+
+```
+$ kubectl delete -f deploy
 ```


### PR DESCRIPTION
### Change log description

- Add section to manually install/uninstall operator and Pravega to readme file.
- Add steps to manually uninstall operator and Pravega in `doc/manual-installation.md`.

### Purpose of the change
Fix #191
Fix #182

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>