### PR TITLE
Update default image tag in operator chart

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -1,6 +1,6 @@
 name: pravega-operator
-version: 0.3.2
-appVersion: 0.3.2
+version: 0.4.0
+appVersion: 0.4.0
 description: pravega operator Helm chart for Kubernetes
 keywords:
 - pravega

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/pravega-operator
-  tag: 0.3.2
+  tag: 0.4.0
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings


### PR DESCRIPTION
### Change log description
Update default image tag in operator chart to 0.4.0

### Purpose of the change
Fix #200

### How to test
`helm install charts/pravega-operator --name foo` should install an operator with version 0.4.0

---

Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>