### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Description
+
+_(Describe the feature, bug, question, proposal that you are requesting)_
+
+### Importance
+
+_(Indicate the importance of this issue to you (blocker, must-have, should-have, nice-to-have))_
+
+### Location
+
+_(Where is the piece of code, package, or document affected by this issue?)_
+
+### Suggestions for an improvement
+
+_(How do you suggest to fix or proceed with this issue?)_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Change log description
+
+_(2-3 concise points about the changes in this PR. When committing this PR, the committer is expected to copy the content of this section to the merge description box)_
+
+### Purpose of the change
+
+_(e.g., Fixes #666, Closes #1234)_
+
+### What the code does
+
+_(Detailed description of the code changes)_
+
+### How to verify it
+
+_(Steps to verify that the changes are effective)_


### PR DESCRIPTION
### Change log description

- Add GitHub issue and PR templates to provide users with hints to describe their issues and PR better. 

### What the code does

Add Markdown templates to a new `.github` directory.

### How to verify it

After it is merged, new issues and PRs should display the template content.

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>