### PR TITLE
Issue 214: Adding version field to the output of `kubectl get PravegaCluster`

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -10,6 +10,10 @@ spec:
     plural: pravegaclusters
     singular: pravegacluster
   additionalPrinterColumns:
+  - name: Version
+    type: string
+    description: The current pravega version
+    JSONPath: .spec.pravega.image.tag
   - name: Desired Members
     type: integer
     description: The number of desired pravega members


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
In operator 0.3.2, the `Version` field is not printed while executing `kubectl get PravegaCluster`. 
The result it currently gives is :-
```
NAME      DESIRED MEMBERS   READY MEMBERS   AGE
pravega   7                 2               15s
```
This fix includes the `Version` field to the result

### Purpose of the change
Fixes #214

### What the code does
The code adds the `Version` field as an Additional Printer Column to the PravegaCluster CustomResourceDefinition in Operator 0.3.2

### How to verify it
`kubectl get PravegaCluster` should give a result similar to this :-
```
NAME      VERSION              DESIRED MEMBERS   READY MEMBERS   AGE
pravega   0.5.0-2269.6f8a820   7                 1               12s
```
