### PR TITLE
Issue 204: SegmentStore fails to start with "externalAccess.enabled=true"

### DIFF
--- a/charts/pravega/templates/_helpers.tpl
+++ b/charts/pravega/templates/_helpers.tpl
@@ -14,3 +14,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "pravega-components.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.serviceAccount.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/pravega/templates/clusterrole.yaml
+++ b/charts/pravega/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.externalAccess.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "pravega-components.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources: 
+  - nodes
+  verbs:
+  - get
+{{- end }}

--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.externalAccess.enabled }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "pravega-components.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: {{ template "pravega-components.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/pravega/templates/role.yaml
+++ b/charts/pravega/templates/role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.externalAccess.enabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "pravega-components.fullname" . }}
+  namespace: "default"
+rules:
+- apiGroups:
+  - pravega.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - get
+- apiGroups: 
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+{{- end }}

--- a/charts/pravega/templates/rolebinding.yaml
+++ b/charts/pravega/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.externalAccess.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "pravega-components.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+roleRef:
+  kind: Role
+  name: {{ template "pravega-components.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/pravega/templates/service_account.yaml
+++ b/charts/pravega/templates/service_account.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.externalAccess.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -9,6 +9,9 @@ externalAccess:
   enabled: false
   type: LoadBalancer
 
+serviceAccount:
+  name: pravega-components
+
 bookkeeper:
   image:
     repository: pravega/bookkeeper


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
SegmentStore fails to start with Pravega external connectivity is enabled using helm method of installation `$helm install charts/pravega --name bar --set zookeeperUri=pravega-zk-client:2181, externalAccess.enabled=true`, as the service account that is configured in the SegmentStore pod lacks the appropriate permissions.

### Purpose of the change
Fixes #204 

### What the code does
The fix creates a new service account, role, and role binding, with minimum required permissions to obtain the external address, configure and enable it on the `PravegaCluster` manifest.

### How to verify it
The SegmentStore will start successfully when we run the command `$helm install charts/pravega --name bar --set zookeeperUri=pravega-zk-client:2181, externalAccess.enabled=true`