### PR TITLE
Issue 228: Use emptyDir as default cache volume

### DIFF
--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -139,18 +139,6 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		s.Options = map[string]string{}
 	}
 
-	if s.CacheVolumeClaimTemplate == nil {
-		changed = true
-		s.CacheVolumeClaimTemplate = &v1.PersistentVolumeClaimSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-			Resources: v1.ResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceStorage: resource.MustParse(DefaultPravegaCacheVolumeSize),
-				},
-			},
-		}
-	}
-
 	if s.Tier2 == nil {
 		changed = true
 		s.Tier2 = &Tier2Spec{}


### PR DESCRIPTION
### Change log description
This PR uses the `emptyDir` as the default volume for segmentstore cache.

### Purpose of the change
Fix #228 

### What the code does
Remove the default cache template in code and specify the `emptyDir` when cache template is nil. 

### How to verify it
When segmentstore pvc template is not specified, the cache volume should be the `emptyDir`. We can log into the segmentstore pod and do `df` to check the volume size. 

Signed-off-by: wenqimou <452787782@qq.com>