### PR TITLE
Issue 184: `DESIRED VERSION` field from `kubectl get PravegaCluster` is blank during upgrade

### DIFF
--- a/charts/pravega-operator/templates/crd.yaml
+++ b/charts/pravega-operator/templates/crd.yaml
@@ -18,7 +18,7 @@ spec:
   - name: Desired Version
     type: string
     description: The desired pravega version
-    JSONPath: .status.TargetVersion
+    JSONPath: .spec.version
   - name: Desired Members
     type: integer
     description: The number of desired pravega members

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -17,7 +17,7 @@ spec:
   - name: Desired Version
     type: string
     description: The desired pravega version
-    JSONPath: .status.TargetVersion
+    JSONPath: .spec.version
   - name: Desired Members
     type: integer
     description: The number of desired pravega members


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
When upgrading a Pravega Cluster in operator 0.4.0,  the `DESIRED VERSION` field is obtained as an empty field during entire upgrade process.
```
$ kubectl get pravegacluster
NAME           VERSION              DESIRED VERSION   DESIRED MEMBERS   READY MEMBERS   AGE
bar-pravega    0.5.0-2222.8ba5431                     5                 5               4m
```

### Purpose of the change
Fixes #184 

### What the code does
The code populates the `DESIRED VERSION` field with the appropriate value

### How to verify it
To reproduce the issue tried upgrading a sample Pravega Cluster from version `0.5.0-2222.8ba5431` to version `0.5.0-2236.5228e2d` and then running `kubectl get PravegaCluster`. The `DESIRED VERSION` field obtained was blank as mentioned in the issue.
Created a new operator image with the fix and confirmed that the error reported in the issue is not noticed after the fix. The following result is obtained after the fix has been applied :-
```
$ kubectl get PravegaCluster
NAME          VERSION              DESIRED VERSION      DESIRED MEMBERS   READY MEMBERS   AGE
bar-pravega   0.5.0-2222.8ba5431   0.5.0-2236.5228e2d   5                 5               6m
```