### PR TITLE
Issue 210: Fix Bookkeeper readiness probe failure

### DIFF
--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -126,13 +126,14 @@ func makeBookiePodSpec(clusterName string, bookkeeperSpec *v1alpha1.BookkeeperSp
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: []string{"/bin/sh", "-c", "/opt/bookkeeper/bin/bookkeeper shell bookiesanity"},
+							Command: []string{"/bin/sh", "-c", "/opt/bookkeeper/bin/bookkeeper shell bookiesanity -timeout 5"},
 						},
 					},
 					// Bookie pods should start fast. We give it up to 1.5 minute to become ready.
 					InitialDelaySeconds: 20,
 					PeriodSeconds:       10,
 					FailureThreshold:    9,
+					TimeoutSeconds:      5,
 				},
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{


### PR DESCRIPTION
Signed-off-by: wenqimou <452787782@qq.com>

### Change log description

This PR fixes the Bookkeeper readiness probe failure by increasing the timeout of the probe from 1 second to 5 seconds. The issue reports that the probe fails frequently under heavy load, so increasing the timeout will mitigate this problem.

### Purpose of the change

Fix #210 

### What the code does

Increate the readiness probe timeout from 1 second to 5 seconds.

### How to verify it

Run longevity test should not have readiness probe failure.  
