### PR TITLE
Issue 235: Make sure ledgers are not under replicated post upgrade

### DIFF
--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -265,8 +265,13 @@ func (r *ReconcilePravegaCluster) syncBookkeeperVersion(p *pravegav1alpha1.Prave
 	if sts.Status.UpdatedReplicas == sts.Status.Replicas &&
 		sts.Status.UpdatedReplicas == sts.Status.ReadyReplicas {
 		// StatefulSet upgrade completed
-		// TODO: wait until there is no under replicated ledger
-		// https://bookkeeper.apache.org/docs/4.7.2/reference/cli/#listunderreplicated
+		underreplicated, err := util.IsLedgerUnderreplicated(p)
+		if err != nil {
+			return false, fmt.Errorf("failed to check underreplicated ledgers: %v", err)
+		}
+		if underreplicated {
+			return false, nil
+		}
 		return true, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: wenqimou <452787782@qq.com>

### Change log description

This PR make sure when the bookkeeper upgrade finishes, there is no under replicated ledgers before moving to the next step. 

### Purpose of the change

Fix #235 

### What the code does

The code leverages the bookkeeper shell command `listunderreplicated`. By checking the source code, this command is basically checking the znode in zookeeper, the zode directory is [here](https://github.com/apache/bookkeeper/blob/86e8a72c7fcfb38b76bcbf434df586f3dc00a2af/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/ZkLedgerUnderreplicationManager.java#L79). Knowing that, this code uses the zookeeper go-client to check if the znode is empty, which can determine if there are under replicated ledgers. 


### How to verify it

TODO. Deploy a cluster, run some workload and upgrade the pravega cluster. Monitor zookeeper znode to see if the upgrade proceeds when under replicated ledgers are not 0. 
