### PR TITLE
Issue 211: Adding annotation to segment store service for external dns

### DIFF
--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -25,9 +25,6 @@ const (
 	// DefaultPravegaVersion is the default tag used for for the Pravega
 	// Docker image
 	DefaultPravegaVersion = "0.4.0"
-
-	// Default Domain Name
-	DefaultDomainName = "pravega.io"
 )
 
 func init() {
@@ -170,10 +167,6 @@ func (e *ExternalAccess) withDefaults() (changed bool) {
 		if e.Type == "" {
 			changed = true
 			e.Type = DefaultServiceType
-		}
-		if e.DomainName == "" {
-			changed = true
-			e.DomainName = DefaultDomainName
 		}
 	}
 	return changed

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -25,6 +25,9 @@ const (
 	// DefaultPravegaVersion is the default tag used for for the Pravega
 	// Docker image
 	DefaultPravegaVersion = "0.4.0"
+
+	// Default Domain Name
+	DefaultDomainName = "pravega.io"
 )
 
 func init() {
@@ -152,17 +155,27 @@ type ExternalAccess struct {
 	// Options are "LoadBalancer" and "NodePort".
 	// By default, if external access is enabled, it will use "LoadBalancer"
 	Type v1.ServiceType `json:"type,omitempty"`
+
+	// Domain Name to be used for External Access
+	// This value is ignored if External Access is disabled
+	DomainName string `json:"domainName,omitempty"`
 }
 
 func (e *ExternalAccess) withDefaults() (changed bool) {
-	if e.Enabled == false && e.Type != "" {
+	if e.Enabled == false && (e.Type != "" || e.DomainName != "") {
 		changed = true
 		e.Type = ""
-	} else if e.Enabled == true && e.Type == "" {
-		changed = true
-		e.Type = DefaultServiceType
+		e.DomainName = ""
+	} else if e.Enabled == true {
+		if e.Type == "" {
+			changed = true
+			e.Type = DefaultServiceType
+		}
+		if e.DomainName == "" {
+			changed = true
+			e.DomainName = DefaultDomainName
+		}
 	}
-
 	return changed
 }
 


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

### Change log description
Added external-dns annotation to segment store external service that can be used by external-dns provider  to assign a DNS name to the service.
### Purpose of the change
Fixes #211

### What the code does
Added `domainName` to Pravega Cluster Spec, that can be set via manifest to arrive at the FQDN for a single segment store node.
FQDN for segment store pod = SegmentStore_Pod_Name.domainName. ( ends with a . )

Added annotation `external-dns.alpha.kubernetes.io/hostname` to external service for each segment store container.

If external access=true, but domain name is not set in manifest, it would default to "pravega.io"

### How to verify it
1. In Pravega spec set externalaccess=true, and domainName=`example.com.
2 `kubectl svc pravega-pravega-segmentstore-0 -o yaml` should show :
 `external-dns.alpha.kubernetes.io/hostname: pravega-pravega-segmentstore-0.example.com.` 
3. Check External-DNS component creates a DNS record for the segment store.