### PR TITLE
Issue 242: Preserve heap dump file

### DIFF
--- a/pkg/controller/pravega/bookie.go
+++ b/pkg/controller/pravega/bookie.go
@@ -125,6 +125,10 @@ func makeBookiePodSpec(p *v1alpha1.PravegaCluster) *corev1.PodSpec {
 						Name:      IndexDiskName,
 						MountPath: "/bk/index",
 					},
+					{
+						Name:      heapDumpName,
+						MountPath: heapDumpDir,
+					},
 				},
 				Resources: *p.Spec.Bookkeeper.Resources,
 				ReadinessProbe: &corev1.Probe{
@@ -155,6 +159,14 @@ func makeBookiePodSpec(p *v1alpha1.PravegaCluster) *corev1.PodSpec {
 			},
 		},
 		Affinity: util.PodAntiAffinity("bookie", p.Name),
+		Volumes: []corev1.Volume{
+			{
+				Name: heapDumpName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
 	}
 
 	if p.Spec.Bookkeeper.ServiceAccountName != "" {
@@ -194,6 +206,7 @@ func MakeBookieConfigMap(pravegaCluster *v1alpha1.PravegaCluster) *corev1.Config
 		"-XX:+ExitOnOutOfMemoryError",
 		"-XX:+CrashOnOutOfMemoryError",
 		"-XX:+HeapDumpOnOutOfMemoryError",
+		"-XX:HeapDumpPath=" + heapDumpDir,
 	}
 
 	if match, _ := util.CompareVersions(pravegaCluster.Spec.Version, "0.4.0", ">="); match {

--- a/pkg/controller/pravega/constants.go
+++ b/pkg/controller/pravega/constants.go
@@ -18,4 +18,6 @@ const (
 	segmentStoreKind      = "pravega-segmentstore"
 	tlsVolumeName         = "tls-secret"
 	tlsMountDir           = "/etc/secret-volume"
+	heapDumpName          = "heap-dump"
+	heapDumpDir           = "/tmp/dumpFile/heap"
 )

--- a/pkg/controller/pravega/constants.go
+++ b/pkg/controller/pravega/constants.go
@@ -19,5 +19,5 @@ const (
 	tlsVolumeName         = "tls-secret"
 	tlsMountDir           = "/etc/secret-volume"
 	heapDumpName          = "heap-dump"
-	heapDumpDir           = "/tmp/dumpfile/heap"
+	heapDumpDir           = "/tmp/dumpfile/heap/java_heap_dump_$(date).hprof"
 )

--- a/pkg/controller/pravega/constants.go
+++ b/pkg/controller/pravega/constants.go
@@ -19,5 +19,5 @@ const (
 	tlsVolumeName         = "tls-secret"
 	tlsMountDir           = "/etc/secret-volume"
 	heapDumpName          = "heap-dump"
-	heapDumpDir           = "/tmp/dumpFile/heap"
+	heapDumpDir           = "/tmp/dumpfile/heap"
 )

--- a/pkg/controller/pravega/constants.go
+++ b/pkg/controller/pravega/constants.go
@@ -19,5 +19,5 @@ const (
 	tlsVolumeName         = "tls-secret"
 	tlsMountDir           = "/etc/secret-volume"
 	heapDumpName          = "heap-dump"
-	heapDumpDir           = "/tmp/dumpfile/heap/java_heap_dump_$(date).hprof"
+	heapDumpDir           = "/tmp/dumpfile/heap"
 )

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -84,6 +84,12 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 						},
 					},
 				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      heapDumpName,
+						MountPath: heapDumpDir,
+					},
+				},
 				Resources: *p.Spec.Pravega.ControllerResources,
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -112,6 +118,14 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 			},
 		},
 		Affinity: util.PodAntiAffinity("pravega-controller", p.Name),
+		Volumes: []corev1.Volume{
+			{
+				Name: heapDumpName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
 	}
 
 	if p.Spec.Pravega.ControllerServiceAccountName != "" {
@@ -148,6 +162,7 @@ func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		"-XX:+ExitOnOutOfMemoryError",
 		"-XX:+CrashOnOutOfMemoryError",
 		"-XX:+HeapDumpOnOutOfMemoryError",
+		"-XX:HeapDumpPath=" + heapDumpDir,
 		"-Dpravegaservice.clusterName=" + p.Name,
 	}
 

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -157,7 +157,6 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	javaOpts := []string{
 		"-Xms1g",
-		"-XX:MaxDirectMemorySize=1g",
 		"-XX:+ExitOnOutOfMemoryError",
 		"-XX:+CrashOnOutOfMemoryError",
 		"-XX:+HeapDumpOnOutOfMemoryError",

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -356,10 +356,11 @@ var _ = Describe("PravegaCluster Controller", func() {
 				})
 
 				It("should set secret volume", func() {
-					Ω(foundController.Spec.Template.Spec.Volumes[0].Name).Should(Equal("tls-secret"))
-					Ω(foundController.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).Should(Equal("controller-secret"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).Should(Equal("tls-secret"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).Should(Equal("/etc/secret-volume"))
+					Ω(foundController.Spec.Template.Spec.Volumes[0].Name).Should(Equal("heap-dump"))
+					Ω(foundController.Spec.Template.Spec.Volumes[1].Name).Should(Equal("tls-secret"))
+					Ω(foundController.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName).Should(Equal("controller-secret"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).Should(Equal("tls-secret"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).Should(Equal("/etc/secret-volume"))
 				})
 			})
 

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -395,7 +395,8 @@ var _ = Describe("PravegaCluster Controller", func() {
 				})
 
 				It("should set secret volume", func() {
-					Ω(foundSS.Spec.Template.Spec.Volumes[0].Name).Should(Equal("tls-secret"))
+					Ω(foundSS.Spec.Template.Spec.Volumes[0].Name).Should(Equal("heap-dump"))
+					Ω(foundSS.Spec.Template.Spec.Volumes[1].Name).Should(Equal("tls-secret"))
 					Ω(foundSS.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).Should(Equal("segmentstore-secret"))
 					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).Should(Equal("tls-secret"))
 					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).Should(Equal("/etc/secret-volume"))

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -397,9 +397,9 @@ var _ = Describe("PravegaCluster Controller", func() {
 				It("should set secret volume", func() {
 					Ω(foundSS.Spec.Template.Spec.Volumes[0].Name).Should(Equal("heap-dump"))
 					Ω(foundSS.Spec.Template.Spec.Volumes[1].Name).Should(Equal("tls-secret"))
-					Ω(foundSS.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).Should(Equal("segmentstore-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).Should(Equal("tls-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).Should(Equal("/etc/secret-volume"))
+					Ω(foundSS.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName).Should(Equal("segmentstore-secret"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name).Should(Equal("tls-secret"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath).Should(Equal("/etc/secret-volume"))
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: wenqimou <452787782@qq.com>

### Change log description

This PR preserves the heap dump files during pod restart when OOM happens.

### Purpose of the change

Fix #242 

### What the code does

The heap dump will output to our specified directory, which is a mounted `emptyDIr`. Data in `emptyDIr` can survive the pod restart on the same node.

### How to verify it

Trigger an OOM, see if heap dump is in the specified directory after pod restarts. 