### PR TITLE
Issue 186: Detecting error/failure during upgrade

### DIFF
--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -315,8 +315,10 @@ func (r *ReconcilePravegaCluster) checkUpdatedPods(sts *appsv1.StatefulSet, vers
 
 		if !util.IsPodReady(pod) {
 			// At least one updated pod is still not ready
-			if pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" {
-				return false, fmt.Errorf("pod %s update failed because of ImagePullBackOff", pod.Name)
+			if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" {
+				return false, fmt.Errorf("pod %s update failed because of %s", pod.Name, pod.Status.ContainerStatuses[0].State.Waiting.Reason)
+			} else if pod.Status.ContainerStatuses[0].State.Terminated != nil && pod.Status.ContainerStatuses[0].State.Terminated.ExitCode != 0 {
+				return false, fmt.Errorf("pod %s update failed because of %s", pod.Name, pod.Status.ContainerStatuses[0].State.Terminated.Reason)
 			}
 			return false, nil
 		}

--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -317,8 +317,6 @@ func (r *ReconcilePravegaCluster) checkUpdatedPods(sts *appsv1.StatefulSet, vers
 			// At least one updated pod is still not ready
 			if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" {
 				return false, fmt.Errorf("pod %s update failed because of %s", pod.Name, pod.Status.ContainerStatuses[0].State.Waiting.Reason)
-			} else if pod.Status.ContainerStatuses[0].State.Terminated != nil && pod.Status.ContainerStatuses[0].State.Terminated.ExitCode != 0 {
-				return false, fmt.Errorf("pod %s update failed because of %s", pod.Name, pod.Status.ContainerStatuses[0].State.Terminated.Reason)
 			}
 			return false, nil
 		}

--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -315,6 +315,9 @@ func (r *ReconcilePravegaCluster) checkUpdatedPods(sts *appsv1.StatefulSet, vers
 
 		if !util.IsPodReady(pod) {
 			// At least one updated pod is still not ready
+			if pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" {
+				return false, fmt.Errorf("pod %s update failed because of ImagePullBackOff", pod.Name)
+			}
 			return false, nil
 		}
 	}


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The upgrade process waits indefinitely for the failed pod to recover and does not update the `Error` and `Upgrading` status appropriately.

**kubectl describe PravegaCluster output**
```
Status:
  Conditions:
    Last Transition Time:  2019-05-15T07:57:10Z
    Last Update Time:      2019-05-15T07:57:10Z
    Status:                True
    Type:                  Upgrading
    Last Transition Time:  2019-05-15T07:58:28Z
    Last Update Time:      2019-05-15T07:58:28Z
    Status:                False
    Type:                  PodsReady
    Status:                False
    Type:                  Error
  Current Replicas:        5
  Current Version:         0.5.0-2222.8ba5431
  Members:
    Ready:
      bar-pravega-bookie-1
      bar-pravega-bookie-2
      bar-pravega-pravega-controller-7d6cbd8554-b9pdv
      bar-pravega-pravega-segmentstore-0
    Unready:
      bar-pravega-bookie-0
  Ready Replicas:  4
  Replicas:        5
  Target Version:  0.5.0-2222
Events:            <none>
```

### Purpose of the change
Fixes #186 

### What the code does
The code detects the scenario where a pod upgrade fails due to an `ImagePullBackOff` error and appropriately updates the  `Error` and `Upgrading` status of the PravegaCluster.

### How to verify it
To reproduce the issue tried upgrading a sample Pravega Cluster from version 0.5.0-2222.8ba5431 to version 0.5.0-2222 (which is an invalid version as the corresponding docker image does not exist). The upgrade process was unable to detect the failure and waited indefinitely as mentioned in the issue.

Created a new operator image with the fix and confirmed that the error reported in the issue is not noticed after the fix, i.e. the `Error` and `Upgrading` status of the PravegaCluster were updated appropriately. The following result is obtained after the fix has been applied :-

**kubectl describe PravegaCluster output**
```
Status:
  Conditions:
    Last Transition Time:  2019-08-07T12:59:12Z
    Last Update Time:      2019-08-07T12:59:12Z
    Status:                False
    Type:                  Upgrading
    Last Transition Time:  2019-08-07T12:58:42Z
    Last Update Time:      2019-08-07T12:58:42Z
    Status:                False
    Type:                  PodsReady
    Last Transition Time:  2019-08-07T12:59:12Z
    Last Update Time:      2019-08-07T12:59:12Z
    Message:               failed to sync bookkeeper version. pod bar-pravega-bookie-0 update failed because of ImagePullBackOff
    Reason:                UpgradeFailed
    Status:                True
    Type:                  Error
  Current Replicas:        5
  Current Version:         0.5.0-2222.8ba5431
  Members:
    Ready:
      bar-pravega-bookie-1
      bar-pravega-bookie-2
      bar-pravega-pravega-controller-7d6cbd8554-b9pdv
      bar-pravega-pravega-segmentstore-0
    Unready:
      bar-pravega-bookie-0
  Ready Replicas:  4
  Replicas:        5
Events:            <none>

```