### PR TITLE
Issue 204: Segment Store start failure when external access is enabled

### DIFF
--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ template "pravega-components.fullname" . }}

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -9,6 +9,9 @@ spec:
     enabled: {{ .Values.externalAccess.enabled }}
     type: {{ .Values.externalAccess.type }}
   bookkeeper:
+    {{- if .Values.externalAccess.enabled }}
+    serviceAccountName: {{ .Values.serviceAccount.name }}
+    {{- end }}
     image:
       repository: {{ .Values.bookkeeper.image.repository }}
     replicas: {{ .Values.bookkeeper.replicas }}
@@ -40,6 +43,10 @@ spec:
             storage: {{ .Values.bookkeeper.storage.indexVolumeRequest }}
     autoRecovery: {{ .Values.bookkeeper.autoRecovery }}
   pravega:
+    {{- if .Values.externalAccess.enabled }}
+    controllerServiceAccountName: {{ .Values.serviceAccount.name }}
+    segmentStoreServiceAccountName: {{ .Values.serviceAccount.name }}
+    {{- end }}
     image:
       repository: {{ .Values.pravega.image.repository }}
     controllerReplicas: {{ .Values.pravega.controllerReplicas }}

--- a/charts/pravega/templates/role.yaml
+++ b/charts/pravega/templates/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "pravega-components.fullname" . }}
-  namespace: "default"
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - pravega.pravega.io


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The Segment Store fails to start with Pravega external connectivity is enabled using helm method of installation `$helm install charts/pravega --name bar --set zookeeperUri=pravega-zk-client:2181, externalAccess.enabled=true`, as the service account that is configured in the segment store pod lacks the appropriate permissions.
```
# kubectl get po --all-namespaces
NAMESPACE     NAME                                                 READY   STATUS      RESTARTS   AGE
default       bar-pravega-bookie-0                                 1/1     Running     0          79s
default       bar-pravega-bookie-1                                 1/1     Running     0          79s
default       bar-pravega-bookie-2                                 1/1     Running     0          78s
default       bar-pravega-pravega-controller-6d7fc79-lx8zf         1/1     Running     0          79s
default       bar-pravega-pravega-segmentstore-0                   0/1     Error       2          78s
default       foo-pravega-operator-778ff44c8-wpmvv                 1/1     Running     0          2m56s
default       pravega-zk-0                                         1/1     Running     0          127m
default       pravega-zk-1                                         1/1     Running     0          126m
default       pravega-zk-2                                         1/1     Running     0          126m
default       shaka-zulu-nfs-client-provisioner-59d7f8f84c-tvh7w   1/1     Running     0          17d
```

### Purpose of the change
Fixes #204 and #233 

### What the code does
The fix creates a new service account, role, and role binding, with minimum required permissions to obtain the external address, configure and enable it on the `PravegaCluster` manifest.

### How to verify it
The Segment Store will start successfully when we run the command `$helm install charts/pravega --name bar --set zookeeperUri=pravega-zk-client:2181, externalAccess.enabled=true`.
The following result is obtained after the fix has been applied :-
```
# kubectl get po --all-namespaces
NAMESPACE     NAME                                                 READY   STATUS      RESTARTS   AGE
default       bar-pravega-bookie-0                                 1/1     Running     0          79s
default       bar-pravega-bookie-1                                 1/1     Running     0          79s
default       bar-pravega-bookie-2                                 1/1     Running     0          78s
default       bar-pravega-pravega-controller-6d7fc79-lx8zf         1/1     Running     0          79s
default       bar-pravega-pravega-segmentstore-0                   1/1     Running     0          78s
default       foo-pravega-operator-778ff44c8-wpmvv                 1/1     Running     0          2m56s
default       pravega-zk-0                                         1/1     Running     0          127m
default       pravega-zk-1                                         1/1     Running     0          126m
default       pravega-zk-2                                         1/1     Running     0          126m
default       shaka-zulu-nfs-client-provisioner-59d7f8f84c-tvh7w   1/1     Running     0          17d

```
