### PR TITLE
Issue:239 Accept auth secret

### DIFF
--- a/doc/auth.md
+++ b/doc/auth.md
@@ -1,19 +1,18 @@
 # Enable Authentication
 
-Client can communicate with Pravega in a more secure way by enabling Authentication.
-Authentication Handler can be implemented in different ways. For details see [Pravega AUthentication](https://github.com/pravega/pravega/blob/master/documentation/src/docs/auth/auth-plugin.md) for details.
+Pravega supports pluggable authentication and authorization (referred to as auth for short). For details please see [Pravega Authentication](https://github.com/pravega/pravega/blob/master/documentation/src/docs/auth/auth-plugin.md).
 
-PasswordAuthHandler(default) is the most basic authentication handler.
-For using this, user needs to do the following:
+By default, the PasswordAuthHandler plugin is installed on the system.
+To use the default `PasswordAuthHandler` plugin for `auth`, the following steps can be followed:
 
-1. Create a userPassword file containing `<user>:<password>:<acl>;` on each line for one user.
+1. Create a file containing `<user>:<password>:<acl>;` with one line per user.
 Delimiter should be `:` with `;` at the end of each line.
-Use the   [PasswordCreatorTool](https://github.com/pravega/pravega/blob/master/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java) to create a new file with the password encrypted. Use this file when creating the secret in next step.
+Use the   [PasswordCreatorTool](https://github.com/pravega/pravega/blob/master/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java) to create a new file with the password encrypted.
+Use this file when creating the secret in next step.
+Sample encrypted password file:
 
-Example:
-
-cat userPassword.txt
 ```
+cat userpass.txt
 admin:353030303a633132666135376233353937356534613430383430373939343839333733616463363433616532363238653930346230333035393666643961316264616661393a3639376330623663396634343864643262663335326463653062613965336439613864306264323839633037626166663563613166333733653631383732353134643961303435613237653130353633633031653364366565316434626534656565636335663666306465663064376165313765646263656638373764396361:*,READ_UPDATE;
 ```
 
@@ -25,6 +24,7 @@ $ kubectl create secret generic password-auth \
 ```
 
 Ensure secret is created:
+
 ```
 $ kubectl describe secret password-auth
 
@@ -40,7 +40,7 @@ Data
 userpass.txt:  418 bytes
 ```
 
-3. Then specify the secret names in the `authentication` block and these parameters in the `options` block.
+3. Specify the secret names in the `authentication` block and these parameters in the `options` block.
 
 ```
 apiVersion: "pravega.pravega.io/v1alpha1"
@@ -65,7 +65,14 @@ spec:
 ...
 ```
 
-YWRtaW46MTExMV9hYWFh is base64encoded(admin:1111_aaaa) where admin is username and 1111_aaaa is the password to be used for segmentstore to controller communication.
+`pravega.client.auth.method` and `pravega.client.auth.token` represent the auth method and token to be used for internal communications from the Segment Store to the Controller.
+If you intend to use the default auth plugin, these values are:
+```
+pravega.client.auth.method: Basic
+pravega.client.auth.token: Base 64 encoded value of <username>:<pasword>,
+```
+where username and password are credentials you intend to use.
+
 Note that Pravega operator uses `/etc/auth-passwd-volume` as the mounting directory for secrets.
 
-For more security configurations, check [here](https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md).
+For more security configurations, please check [here](https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md).

--- a/doc/auth.md
+++ b/doc/auth.md
@@ -1,0 +1,71 @@
+# Enable Authentication
+
+Client can communicate with Pravega in a more secure way by enabling Authentication.
+Authentication Handler can be implemented in different ways. For details see [Pravega AUthentication](https://github.com/pravega/pravega/blob/master/documentation/src/docs/auth/auth-plugin.md) for details.
+
+PasswordAuthHandler(default) is the most basic authentication handler.
+For using this, user needs to do the following:
+
+1. Create a userPassword file containing `<user>:<password>:<acl>;` on each line for one user.
+Delimiter should be `:` with `;` at the end of each line.
+Use the   [PasswordCreatorTool](https://github.com/pravega/pravega/blob/master/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java) to create a new file with the password encrypted. Use this file when creating the secret in next step.
+
+Example:
+
+cat userPassword.txt
+```
+admin:353030303a633132666135376233353937356534613430383430373939343839333733616463363433616532363238653930346230333035393666643961316264616661393a3639376330623663396634343864643262663335326463653062613965336439613864306264323839633037626166663563613166333733653631383732353134643961303435613237653130353633633031653364366565316434626534656565636335663666306465663064376165313765646263656638373764396361:*,READ_UPDATE;
+```
+
+2. Create a kubernetes secret with this file:
+
+```
+$ kubectl create secret generic password-auth \
+  --from-file=./userPassword.txt \
+```
+
+Ensure secret is created:
+```
+$ kubectl describe secret password-auth
+
+Name:         password-auth
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+
+Type:  Opaque
+
+Data
+====
+userpass.txt:  418 bytes
+```
+
+3. Then specify the secret names in the `authentication` block and these parameters in the `options` block.
+
+```
+apiVersion: "pravega.pravega.io/v1alpha1"
+kind: "PravegaCluster"
+metadata:
+  name: "example"
+spec:
+  authentication:
+    enabled: true
+    passwordAuthSecret: password-auth
+...
+  pravega:
+    options:
+      controller.auth.enabled: "true"
+      controller.auth.userPasswordFile: "/etc/auth-volume/userpass.txt"
+      controller.auth.tokenSigningKey: "secret"
+      autoScale.authEnabled: "true"
+      autoScale.tokenSigningKey: "secret"
+      pravega.client.auth.token: "YWRtaW46MTExMV9hYWFh"
+      pravega.client.auth.method: "Basic"
+
+...
+```
+
+YWRtaW46MTExMV9hYWFh is base64encoded(admin:1111_aaaa) where admin is username and 1111_aaaa is the password to be used for segmentstore to controller communication.
+Note that Pravega operator uses `/etc/auth-passwd-volume` as the mounting directory for secrets.
+
+For more security configurations, check [here](https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md).

--- a/doc/auth.md
+++ b/doc/auth.md
@@ -9,10 +9,10 @@ To use the default `PasswordAuthHandler` plugin for `auth`, the following steps 
 Delimiter should be `:` with `;` at the end of each line.
 Use the   [PasswordCreatorTool](https://github.com/pravega/pravega/blob/master/controller/src/test/java/io/pravega/controller/auth/PasswordFileCreatorTool.java) to create a new file with the password encrypted.
 Use this file when creating the secret in next step.
-Sample encrypted password file:
 
+Sample encrypted password file:
 ```
-cat userpass.txt
+$ cat userdata.txt
 admin:353030303a633132666135376233353937356534613430383430373939343839333733616463363433616532363238653930346230333035393666643961316264616661393a3639376330623663396634343864643262663335326463653062613965336439613864306264323839633037626166663563613166333733653631383732353134643961303435613237653130353633633031653364366565316434626534656565636335663666306465663064376165313765646263656638373764396361:*,READ_UPDATE;
 ```
 
@@ -20,7 +20,7 @@ admin:353030303a6331326661353762333539373565346134303834303739393438393337336164
 
 ```
 $ kubectl create secret generic password-auth \
-  --from-file=./userpass.txt \
+  --from-file=./userdata.txt \
 ```
 
 Ensure secret is created:
@@ -37,7 +37,7 @@ Type:  Opaque
 
 Data
 ====
-userpass.txt:  418 bytes
+userdata.txt:  418 bytes
 ```
 
 3. Specify the secret names in the `authentication` block and these parameters in the `options` block.
@@ -55,7 +55,7 @@ spec:
   pravega:
     options:
       controller.auth.enabled: "true"
-      controller.auth.userPasswordFile: "/etc/auth-passwd-volume/userpass.txt"
+      controller.auth.userPasswordFile: "/etc/auth-passwd-volume/userdata.txt"
       controller.auth.tokenSigningKey: "secret"
       autoScale.authEnabled: "true"
       autoScale.tokenSigningKey: "secret"
@@ -69,7 +69,7 @@ spec:
 If you intend to use the default auth plugin, these values are:
 ```
 pravega.client.auth.method: Basic
-pravega.client.auth.token: Base 64 encoded value of <username>:<pasword>,
+pravega.client.auth.token: Base64 encoded value of <username>:<pasword>,
 ```
 where username and password are credentials you intend to use.
 

--- a/doc/auth.md
+++ b/doc/auth.md
@@ -21,7 +21,7 @@ admin:353030303a6331326661353762333539373565346134303834303739393438393337336164
 
 ```
 $ kubectl create secret generic password-auth \
-  --from-file=./userPassword.txt \
+  --from-file=./userpass.txt \
 ```
 
 Ensure secret is created:
@@ -55,7 +55,7 @@ spec:
   pravega:
     options:
       controller.auth.enabled: "true"
-      controller.auth.userPasswordFile: "/etc/auth-volume/userpass.txt"
+      controller.auth.userPasswordFile: "/etc/auth-passwd-volume/userpass.txt"
       controller.auth.tokenSigningKey: "secret"
       autoScale.authEnabled: "true"
       autoScale.tokenSigningKey: "secret"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -11,5 +11,6 @@ This document explains how to configure Pravega
 * [Tune Pravega Configuration](pravega-options.md)
 * [Tune Bookkeeper Configuration](bookkeeper-options.md)
 * [Enable TLS](tls.md)
+* [Enable Authentication](auth.md)
 * [Enable external access](external-access.md)
 * [Enable admission webhook](webhook.md)

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -77,6 +77,9 @@ type ClusterSpec struct {
 	// https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md
 	TLS *TLSPolicy `json:"tls,omitempty"`
 
+	// Authentication can be enabled for authorizing all communication from clients to controller and segment store
+	// See the following file for a complete list of options:
+	// https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md
 	Authentication *AuthenticationParameters `json:"authentication,omitempty"`
 
 	// Version is the expected version of the Pravega cluster.
@@ -207,8 +210,8 @@ type AuthenticationParameters struct {
 	// By default, authentication is not enabled
 	Enabled bool `json:"enabled"`
 
-	// name of Secret containing Authentication Parameters like username, password and acl
-	// optional - to be used only when PasswordAuthHandler is used for authentication
+	// name of Secret containing Password based Authentication Parameters like username, password and acl
+	// optional - used only by PasswordAuthHandler for authentication
 	PasswordAuthSecret string `json:"passwordAuthSecret,omitempty"`
 }
 

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -208,7 +208,8 @@ type AuthenticationParameters struct {
 	Enabled bool `json:"enabled"`
 
 	// name of Secret containing Authentication Parameters like username, password and acl
-	ControllerAuthSecret string `json:"controllerAuthSecret,omitempty"`
+	// optional - to be used only when PasswordAuthHandler is used for authentication
+	PasswordAuthSecret string `json:"passwordAuthSecret,omitempty"`
 }
 
 func (ap *AuthenticationParameters) IsEnabled() bool {

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -55,7 +55,6 @@ type PravegaCluster struct {
 // WithDefaults set default values when not defined in the spec.
 func (p *PravegaCluster) WithDefaults() (changed bool) {
 	changed = p.Spec.withDefaults()
-
 	return changed
 }
 
@@ -77,6 +76,8 @@ type ClusterSpec struct {
 	// See the following file for a complete list of options:
 	// https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md
 	TLS *TLSPolicy `json:"tls,omitempty"`
+
+	Authentication *AuthenticationParameters `json:"authentication,omitempty"`
 
 	// Version is the expected version of the Pravega cluster.
 	// The pravega-operator will eventually make the Pravega cluster version
@@ -115,6 +116,11 @@ func (s *ClusterSpec) withDefaults() (changed bool) {
 		s.TLS = &TLSPolicy{
 			Static: &StaticTLS{},
 		}
+	}
+
+	if s.Authentication == nil {
+		changed = true
+		s.Authentication = &AuthenticationParameters{}
 	}
 
 	if s.Version == "" {
@@ -194,6 +200,22 @@ func (tp *TLSPolicy) IsSecureSegmentStore() bool {
 		return false
 	}
 	return len(tp.Static.SegmentStoreSecret) != 0
+}
+
+type AuthenticationParameters struct {
+	// Enabled specifies whether or not authentication is enabled
+	// By default, authentication is not enabled
+	Enabled bool `json:"enabled"`
+
+	// name of Secret containing Authentication Parameters like username, password and acl
+	ControllerAuthSecret string `json:"controllerAuthSecret,omitempty"`
+}
+
+func (ap *AuthenticationParameters) IsEnabled() bool {
+	if ap == nil {
+		return false
+	}
+	return ap.Enabled
 }
 
 // ImageSpec defines the fields needed for a Docker repository image

--- a/pkg/controller/pravega/constants.go
+++ b/pkg/controller/pravega/constants.go
@@ -11,13 +11,16 @@
 package pravega
 
 const (
-	cacheVolumeName       = "cache"
-	cacheVolumeMountPoint = "/tmp/pravega/cache"
-	tier2FileMountPoint   = "/mnt/tier2"
-	tier2VolumeName       = "tier2"
-	segmentStoreKind      = "pravega-segmentstore"
-	tlsVolumeName         = "tls-secret"
-	tlsMountDir           = "/etc/secret-volume"
-	heapDumpName          = "heap-dump"
-	heapDumpDir           = "/tmp/dumpfile/heap"
+	cacheVolumeName        = "cache"
+	cacheVolumeMountPoint  = "/tmp/pravega/cache"
+	tier2FileMountPoint    = "/mnt/tier2"
+	tier2VolumeName        = "tier2"
+	segmentStoreKind       = "pravega-segmentstore"
+	tlsVolumeName          = "tls-secret"
+	tlsMountDir            = "/etc/secret-volume"
+	heapDumpName           = "heap-dump"
+	heapDumpDir            = "/tmp/dumpfile/heap"
+	authVolumeName         = "auth-secret"
+	authMountDir           = "/etc/auth-volume"
+	defaultTokenSigningKey = "secret"
 )

--- a/pkg/controller/pravega/constants.go
+++ b/pkg/controller/pravega/constants.go
@@ -20,7 +20,7 @@ const (
 	tlsMountDir            = "/etc/secret-volume"
 	heapDumpName           = "heap-dump"
 	heapDumpDir            = "/tmp/dumpfile/heap"
-	authVolumeName         = "auth-secret"
-	authMountDir           = "/etc/auth-volume"
+	authVolumeName         = "auth-passwd-secret"
+	authMountDir           = "/etc/auth-passwd-volume"
 	defaultTokenSigningKey = "secret"
 )

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -143,7 +143,7 @@ func configureControllerTLSSecrets(podSpec *corev1.PodSpec, p *api.PravegaCluste
 }
 
 func configureAuthSecrets(podSpec *corev1.PodSpec, p *api.PravegaCluster) {
-	if p.Spec.Authentication.IsEnabled() && p.Spec.Authentication. != nil {
+	if p.Spec.Authentication.IsEnabled() && p.Spec.Authentication.PasswordAuthSecret != "" {
 		addSecretVolumeWithMount(podSpec, p, authVolumeName, p.Spec.Authentication.PasswordAuthSecret,
 			authVolumeName, authMountDir)
 	}

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -144,7 +144,7 @@ func configureControllerTLSSecrets(podSpec *corev1.PodSpec, p *api.PravegaCluste
 
 func configureAuthSecrets(podSpec *corev1.PodSpec, p *api.PravegaCluster) {
 	if p.Spec.Authentication.IsEnabled() {
-		addSecretVolumeWithMount(podSpec, p, authVolumeName, p.Spec.Authentication.ControllerAuthSecret,
+		addSecretVolumeWithMount(podSpec, p, authVolumeName, p.Spec.Authentication.PasswordAuthSecret,
 			authVolumeName, authMountDir)
 	}
 }

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -143,7 +143,7 @@ func configureControllerTLSSecrets(podSpec *corev1.PodSpec, p *api.PravegaCluste
 }
 
 func configureAuthSecrets(podSpec *corev1.PodSpec, p *api.PravegaCluster) {
-	if p.Spec.Authentication.IsEnabled() {
+	if p.Spec.Authentication.IsEnabled() && p.Spec.Authentication. != nil {
 		addSecretVolumeWithMount(podSpec, p, authVolumeName, p.Spec.Authentication.PasswordAuthSecret,
 			authVolumeName, authMountDir)
 	}

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -181,8 +181,9 @@ func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		javaOpts = append(javaOpts, fmt.Sprintf("-D%v=%v", name, value))
 	}
 
+	authEnabledStr := fmt.Sprint(p.Spec.Authentication.IsEnabled())
 	configData := map[string]string{
-		"AUTHORIZATION_ENABLED": "false",
+		"AUTHORIZATION_ENABLED": authEnabledStr,
 		"CLUSTER_NAME":          p.Name,
 		"ZK_URL":                p.Spec.ZookeeperUri,
 		"JAVA_OPTS":             strings.Join(javaOpts, " "),


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

### Change log description
Currently default credentials are used for  authentication and there is no way to specify "user defined" user/password for authentication. This change allows users to create a secret containing username,password,acl and use the same for authentication, by specifying secret location on pod using system property '-Dcontroller.auth.userPasswordFile' 

### Purpose of the change
Fixes #239

### What the code does
A new field 'Authentication' with 2 enclosing values - enabled and ControllerAuthSecret have been added to ClusterSpec.
When Enabled is set to "true", user can specify the secret name that contains the authentication credentials. Note that user needs to create this secret ahead of specifying it in the manifest using a command like ` kubectl create secret generic controller-auth --from-file=./userpass.txt`. This secret is stored on volume '/etc/auth-volume' in the controller pod. So in "options" under pravega user needs to specify `controller.auth.userPasswordFile: "/etc/auth-volume/userpass.txt"

### How to verify it
After creating necessary secrets, enabled tls and authentication on pravega and checked that there were no authentication related exceptions in controller/segmentstore logs. Also PasswordAuthHandler used the file mentioned against `controller.auth.userPasswordFile1 property`
```
2019-08-16 11:52:33,545 6697 [ControllerServiceStarter STARTING] DEBUG i.p.c.s.r.auth.PasswordAuthHandler - Loading /etc/auth-volume/userpass.txt
```

