### PR TITLE
Issue 183: Set upgrade error status

### DIFF
--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -103,7 +103,8 @@ Segment Store instances need access to a persistent volume to store the cache. L
 
 Also, Segment Store pods need to be individually accessed by clients, so having a stable network identifier provided by the Statefulset and a headless service is very convenient.
 
-As opposed to BookKeeper, we don't currently need to perform verifications or actions during the upgrade process. The `RollingUpgrade` strategy will automatically upgrade a pod and wait until it becomes ready before upgrading the following one.
+Same as Bookkeeper, we use `OnDelete` strategy for Segment Store. The reason that we don't use `RollingUpdate` strategy here is that we found it convenient to manage the upgrade
+and rollback in the same fashion. Using `RollingUpdate` will introduce Kubernetes rollback mechanism which will cause trouble to our implementation. 
 
 ### Pravega Controller upgrade
 

--- a/pkg/apis/pravega/v1alpha1/status.go
+++ b/pkg/apis/pravega/v1alpha1/status.go
@@ -108,7 +108,7 @@ func (ps *ClusterStatus) SetPodsReadyConditionFalse() {
 }
 
 func (ps *ClusterStatus) SetUpgradingConditionTrue(reason, message string) {
-	c := newClusterCondition(ClusterConditionUpgrading, corev1.ConditionTrue, "", "")
+	c := newClusterCondition(ClusterConditionUpgrading, corev1.ConditionTrue, reason, message)
 	ps.setClusterCondition(*c)
 }
 

--- a/pkg/apis/pravega/v1alpha1/status.go
+++ b/pkg/apis/pravega/v1alpha1/status.go
@@ -22,6 +22,11 @@ const (
 	ClusterConditionPodsReady ClusterConditionType = "PodsReady"
 	ClusterConditionUpgrading                      = "Upgrading"
 	ClusterConditionError                          = "Error"
+
+	// Reasons for cluster upgrading condition
+	UpgradingControllerReason   = "UpgradingController"
+	UpgradingSegmentstoreReason = "UpgradingSegmentstore"
+	UpgradingBookkeeperReason   = "UpgradingBookkeeper"
 )
 
 // ClusterStatus defines the observed state of PravegaCluster
@@ -102,7 +107,7 @@ func (ps *ClusterStatus) SetPodsReadyConditionFalse() {
 	ps.setClusterCondition(*c)
 }
 
-func (ps *ClusterStatus) SetUpgradingConditionTrue() {
+func (ps *ClusterStatus) SetUpgradingConditionTrue(reason, message string) {
 	c := newClusterCondition(ClusterConditionUpgrading, corev1.ConditionTrue, "", "")
 	ps.setClusterCondition(*c)
 }

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -39,8 +39,8 @@ func MakeControllerDeployment(p *api.PravegaCluster) *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			ProgressDeadlineSeconds: &timeout,
 			Replicas:                &p.Spec.Pravega.ControllerReplicas,
-			RevisionHistoryLimit: &zero,
-			Template:             MakeControllerPodTemplate(p),
+			RevisionHistoryLimit:    &zero,
+			Template:                MakeControllerPodTemplate(p),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: util.LabelsForController(p),
 			},

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -35,8 +35,9 @@ func MakeControllerDeployment(p *api.PravegaCluster) *appsv1.Deployment {
 			Labels:    util.LabelsForController(p),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &p.Spec.Pravega.ControllerReplicas,
-			Template: MakeControllerPodTemplate(p),
+			ProgressDeadlineSeconds: func(i int32) *int32 { return &i }(600),
+			Replicas:                &p.Spec.Pravega.ControllerReplicas,
+			Template:                MakeControllerPodTemplate(p),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: util.LabelsForController(p),
 			},

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -44,7 +44,7 @@ func MakeSegmentStoreStatefulSet(pravegaCluster *api.PravegaCluster) *appsv1.Sta
 			Replicas:            &pravegaCluster.Spec.Pravega.SegmentStoreReplicas,
 			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},
 			Template: MakeSegmentStorePodTemplate(pravegaCluster),
 			Selector: &metav1.LabelSelector{

--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -22,9 +22,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 type componentSyncVersionFun struct {

--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 type componentSyncVersionFun struct {
@@ -168,6 +169,10 @@ func (r *ReconcilePravegaCluster) syncControllerVersion(p *pravegav1alpha1.Prave
 		if err != nil {
 			return false, err
 		}
+
+		// Set the upgrade condition reason to be UpgradingControllerReason, message to be 0
+		p.Status.SetUpgradingConditionTrue(pravegav1alpha1.UpgradingControllerReason, "0")
+
 		// Updated pod template. Upgrade process has been triggered
 		return false, nil
 	}
@@ -179,7 +184,7 @@ func (r *ReconcilePravegaCluster) syncControllerVersion(p *pravegav1alpha1.Prave
 	// Check whether the upgrade is in progress or has completed
 	if deploy.Status.UpdatedReplicas != deploy.Status.Replicas ||
 		deploy.Status.UpdatedReplicas != deploy.Status.ReadyReplicas {
-		// Update still in progress, check if there is progress made within a timeout.
+		// Update still in progress, check if there is progress made within the timeout.
 		for _, v := range deploy.Status.Conditions {
 			if v.Type == appsv1.DeploymentProgressing &&
 				v.Status == corev1.ConditionFalse && v.Reason == "ProgressDeadlineExceeded" {
@@ -187,6 +192,17 @@ func (r *ReconcilePravegaCluster) syncControllerVersion(p *pravegav1alpha1.Prave
 				return false, fmt.Errorf("updating deployment (%s) failed due to %s", deploy.Name, v.Reason)
 			}
 		}
+		// Check if the updated pod has error. If so, return error and fail fast
+		pods, err := r.getDeployPodsWithVersion(deploy, p.Status.TargetVersion)
+		if err != nil {
+			return false, err
+		}
+		_, err = r.checkUpdatedPods(pods, p.Status.TargetVersion)
+		if err != nil {
+			// Abort if there is any errors with the updated pods
+			return false, err
+		}
+		// Wait until next reconcile iteration
 		return false, nil
 	}
 
@@ -218,6 +234,10 @@ func (r *ReconcilePravegaCluster) syncSegmentStoreVersion(p *pravegav1alpha1.Pra
 		if err != nil {
 			return false, err
 		}
+
+		// Set the upgrade condition reason to be UpgradingSegmentstoreReason, message to be 0
+		p.Status.SetUpgradingConditionTrue(pravegav1alpha1.UpgradingSegmentstoreReason, "0")
+
 		// Updated pod template. Upgrade process has been triggered
 		return false, nil
 	}
@@ -241,7 +261,11 @@ func (r *ReconcilePravegaCluster) syncSegmentStoreVersion(p *pravegav1alpha1.Pra
 	}
 
 	// If all replicas are ready, upgrade an old pod
-	ready, err := r.checkUpdatedPods(sts, p.Status.TargetVersion)
+	pods, err := r.getStsPodsWithVersion(sts, p.Status.TargetVersion)
+	if err != nil {
+		return false, err
+	}
+	ready, err := r.checkUpdatedPods(pods, p.Status.TargetVersion)
 	if err != nil {
 		// Abort if there is any errors with the updated pods
 		return false, err
@@ -265,8 +289,8 @@ func (r *ReconcilePravegaCluster) syncSegmentStoreVersion(p *pravegav1alpha1.Pra
 		}
 	}
 
-	// StatefulSet upgrade completed
-	return true, nil
+	// Wait until next reconcile iteration
+	return false, nil
 }
 
 func (r *ReconcilePravegaCluster) syncBookkeeperVersion(p *pravegav1alpha1.PravegaCluster) (synced bool, err error) {
@@ -291,6 +315,10 @@ func (r *ReconcilePravegaCluster) syncBookkeeperVersion(p *pravegav1alpha1.Prave
 		if err != nil {
 			return false, err
 		}
+
+		// Set the upgrade condition reason to be UpgradingBookkeeperReason, message to be 0
+		p.Status.SetUpgradingConditionTrue(pravegav1alpha1.UpgradingBookkeeperReason, "0")
+
 		// Updated pod template
 		return false, nil
 	}
@@ -309,16 +337,20 @@ func (r *ReconcilePravegaCluster) syncBookkeeperVersion(p *pravegav1alpha1.Prave
 		return true, nil
 	}
 
+	// Upgrade still in progress
+
 	// Check if bookkeeper fail to have progress
 	err = checkUpgradeCondition(p, pravegav1alpha1.UpgradingBookkeeperReason, sts.Status.UpdatedReplicas)
 	if err != nil {
 		return false, fmt.Errorf("updating statefulset (%s) failed due to %v", sts.Name, err)
 	}
 
-	// Upgrade still in progress
 	// If all replicas are ready, upgrade an old pod
-
-	ready, err := r.checkUpdatedPods(sts, p.Status.TargetVersion)
+	pods, err := r.getStsPodsWithVersion(sts, p.Status.TargetVersion)
+	if err != nil {
+		return false, err
+	}
+	ready, err := r.checkUpdatedPods(pods, p.Status.TargetVersion)
 	if err != nil {
 		// Abort if there is any errors with the updated pods
 		return false, err
@@ -346,12 +378,7 @@ func (r *ReconcilePravegaCluster) syncBookkeeperVersion(p *pravegav1alpha1.Prave
 	return false, nil
 }
 
-func (r *ReconcilePravegaCluster) checkUpdatedPods(sts *appsv1.StatefulSet, version string) (bool, error) {
-	pods, err := r.getPodsWithVersion(sts, version)
-	if err != nil {
-		return false, err
-	}
-
+func (r *ReconcilePravegaCluster) checkUpdatedPods(pods []*corev1.Pod, version string) (bool, error) {
 	for _, pod := range pods {
 		//TODO: find out a more reliable way to determine if a pod is having issues
 		if pod.Status.ContainerStatuses[0].RestartCount > 1 {
@@ -359,10 +386,9 @@ func (r *ReconcilePravegaCluster) checkUpdatedPods(sts *appsv1.StatefulSet, vers
 		}
 
 		if !util.IsPodReady(pod) {
-			// At least one updated pod is still not ready
-			if pod.Status.ContainerStatuses[0].State.Waiting != nil && (pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" ||
-				pod.Status.ContainerStatuses[0].State.Waiting.Reason == "CrashLoopBackOff") {
-				return false, fmt.Errorf("pod %s update failed because of %s", pod.Name, pod.Status.ContainerStatuses[0].State.Waiting.Reason)
+			// At least one updated pod is still not ready, check if it is faulty.
+			if faulty, err := util.IsPodFaulty(pod); faulty {
+				return false, err
 			}
 			return false, nil
 		}
@@ -397,7 +423,7 @@ func (r *ReconcilePravegaCluster) getOneOutdatedPod(sts *appsv1.StatefulSet, ver
 	return nil, nil
 }
 
-func (r *ReconcilePravegaCluster) getPodsWithVersion(sts *appsv1.StatefulSet, version string) ([]*corev1.Pod, error) {
+func (r *ReconcilePravegaCluster) getStsPodsWithVersion(sts *appsv1.StatefulSet, version string) ([]*corev1.Pod, error) {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: sts.Spec.Template.Labels,
 	})
@@ -405,12 +431,27 @@ func (r *ReconcilePravegaCluster) getPodsWithVersion(sts *appsv1.StatefulSet, ve
 		return nil, fmt.Errorf("failed to convert label selector: %v", err)
 	}
 
+	return r.getPodsWithVersion(selector, sts.Namespace, version)
+}
+
+func (r *ReconcilePravegaCluster) getDeployPodsWithVersion(deploy *appsv1.Deployment, version string) ([]*corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: deploy.Spec.Template.Labels,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert label selector: %v", err)
+	}
+
+	return r.getPodsWithVersion(selector, deploy.Namespace, version)
+}
+
+func (r *ReconcilePravegaCluster) getPodsWithVersion(selector labels.Selector, namespace string, version string) ([]*corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	podlistOps := &client.ListOptions{
-		Namespace:     sts.Namespace,
+		Namespace:     namespace,
 		LabelSelector: selector,
 	}
-	err = r.client.List(context.TODO(), podlistOps, podList)
+	err := r.client.List(context.TODO(), podlistOps, podList)
 	if err != nil {
 		return nil, err
 	}
@@ -427,15 +468,18 @@ func (r *ReconcilePravegaCluster) getPodsWithVersion(sts *appsv1.StatefulSet, ve
 
 func checkUpgradeCondition(p *pravegav1alpha1.PravegaCluster, reason string, updatedReplicas int32) error {
 	_, lastCondition := p.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
-	if lastCondition.Reason == reason && lastCondition.Message != string(updatedReplicas) {
-		// nothing changed, check if reaches timeout
+	if lastCondition.Reason == reason && lastCondition.Message == string(updatedReplicas) {
+		// if reason and message are the same as before, which means there is no progress since the last reconciling,
+		// then check if it reaches the timeout.
 		parsedTime, _ := time.Parse(time.RFC3339, lastCondition.LastUpdateTime)
 		if time.Now().After(parsedTime.Add(time.Duration(10 * time.Minute))) {
-			// timeout has passed
+			// timeout
 			return fmt.Errorf("progress deadline exceeded")
 		}
+		// it hasn't reached timeout
+		return nil
 	}
-	// update the status to the latest, this will also set the transition timestamp to now
+	// progress has been made, update the status to the latest. This will also set the transition timestamp to now
 	p.Status.SetUpgradingConditionTrue(reason, string(updatedReplicas))
 	return nil
 }

--- a/pkg/controller/pravegacluster/upgrade_test.go
+++ b/pkg/controller/pravegacluster/upgrade_test.go
@@ -50,7 +50,6 @@ var _ = Describe("Pravega Cluster", func() {
 	Context("Upgrade", func() {
 		var (
 			req reconcile.Request
-			res reconcile.Result
 			p   *v1alpha1.PravegaCluster
 		)
 
@@ -80,7 +79,7 @@ var _ = Describe("Pravega Cluster", func() {
 			BeforeEach(func() {
 				client = fake.NewFakeClient(p)
 				r = &ReconcilePravegaCluster{client: client, scheme: s}
-				res, err = r.Reconcile(req)
+				_, err = r.Reconcile(req)
 			})
 
 			Context("First reconcile", func() {
@@ -94,7 +93,7 @@ var _ = Describe("Pravega Cluster", func() {
 					foundPravega *v1alpha1.PravegaCluster
 				)
 				BeforeEach(func() {
-					res, err = r.Reconcile(req)
+					_, err = r.Reconcile(req)
 					foundPravega = &v1alpha1.PravegaCluster{}
 					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
 				})
@@ -113,7 +112,6 @@ var _ = Describe("Pravega Cluster", func() {
 		Context("Upgrade to new version", func() {
 			var (
 				client client.Client
-				err    error
 			)
 
 			BeforeEach(func() {
@@ -123,14 +121,14 @@ var _ = Describe("Pravega Cluster", func() {
 				p.WithDefaults()
 				client = fake.NewFakeClient(p)
 				r = &ReconcilePravegaCluster{client: client, scheme: s}
-				res, err = r.Reconcile(req)
+				_, _ = r.Reconcile(req)
 				foundPravega := &v1alpha1.PravegaCluster{}
 				_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
 				foundPravega.Spec.Version = "0.6.0"
 				// bypass the pods ready check in the upgrade logic
 				foundPravega.Status.SetPodsReadyConditionTrue()
 				client.Update(context.TODO(), foundPravega)
-				res, err = r.Reconcile(req)
+				_, _ = r.Reconcile(req)
 			})
 
 			Context("Condition", func() {
@@ -164,7 +162,7 @@ var _ = Describe("Pravega Cluster", func() {
 					sts.Status.ReadyReplicas = 1
 					r.client.Update(context.TODO(), sts)
 
-					res, err = r.Reconcile(req)
+					_, _ = r.Reconcile(req)
 					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
 					foundPravega = &v1alpha1.PravegaCluster{}
 					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
@@ -194,7 +192,7 @@ var _ = Describe("Pravega Cluster", func() {
 					sts.Spec.Template.Spec.Containers[0].Image = targetImage
 					r.client.Update(context.TODO(), sts)
 
-					res, err = r.Reconcile(req)
+					_, _ = r.Reconcile(req)
 					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
 					foundPravega = &v1alpha1.PravegaCluster{}
 					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
@@ -231,7 +229,7 @@ var _ = Describe("Pravega Cluster", func() {
 					sts.Spec.Template.Spec.Containers[0].Image = targetImage
 					r.client.Update(context.TODO(), sts)
 
-					res, err = r.Reconcile(req)
+					_, _ = r.Reconcile(req)
 					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
 					foundPravega = &v1alpha1.PravegaCluster{}
 					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)

--- a/pkg/controller/pravegacluster/upgrade_test.go
+++ b/pkg/controller/pravegacluster/upgrade_test.go
@@ -112,8 +112,8 @@ var _ = Describe("Pravega Cluster", func() {
 
 		Context("Upgrade to new version", func() {
 			var (
-				client    client.Client
-				err       error
+				client client.Client
+				err    error
 			)
 
 			BeforeEach(func() {
@@ -155,7 +155,7 @@ var _ = Describe("Pravega Cluster", func() {
 			Context("Upgrade Bookkeeper", func() {
 				var (
 					foundPravega *v1alpha1.PravegaCluster
-					sts *appsv1.StatefulSet
+					sts          *appsv1.StatefulSet
 				)
 				BeforeEach(func() {
 					sts = &appsv1.StatefulSet{}
@@ -180,7 +180,7 @@ var _ = Describe("Pravega Cluster", func() {
 			Context("Upgrade Segmentstore", func() {
 				var (
 					foundPravega *v1alpha1.PravegaCluster
-					sts *appsv1.StatefulSet
+					sts          *appsv1.StatefulSet
 				)
 				BeforeEach(func() {
 					foundPravega = &v1alpha1.PravegaCluster{}
@@ -210,7 +210,7 @@ var _ = Describe("Pravega Cluster", func() {
 			Context("Upgrade Controller", func() {
 				var (
 					foundPravega *v1alpha1.PravegaCluster
-					sts *appsv1.StatefulSet
+					sts          *appsv1.StatefulSet
 				)
 				BeforeEach(func() {
 					foundPravega = &v1alpha1.PravegaCluster{}

--- a/pkg/controller/pravegacluster/upgrade_test.go
+++ b/pkg/controller/pravegacluster/upgrade_test.go
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package pravegacluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
+	"github.com/pravega/pravega-operator/pkg/util"
+
+	pravegav1alpha1 "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pravega cluster")
+}
+
+var _ = Describe("Pravega Cluster", func() {
+	const (
+		Name      = "example"
+		Namespace = "default"
+	)
+
+	var (
+		s = scheme.Scheme
+		r *ReconcilePravegaCluster
+	)
+
+	Context("Upgrade", func() {
+		var (
+			req reconcile.Request
+			res reconcile.Result
+			p   *v1alpha1.PravegaCluster
+		)
+
+		BeforeEach(func() {
+			req = reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      Name,
+					Namespace: Namespace,
+				},
+			}
+			p = &v1alpha1.PravegaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      Name,
+					Namespace: Namespace,
+				},
+			}
+			p.Spec.Version = "0.5.0"
+			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, p)
+		})
+
+		Context("Pravega condition", func() {
+			var (
+				client client.Client
+				err    error
+			)
+
+			BeforeEach(func() {
+				client = fake.NewFakeClient(p)
+				r = &ReconcilePravegaCluster{client: client, scheme: s}
+				res, err = r.Reconcile(req)
+			})
+
+			Context("First reconcile", func() {
+				It("shouldn't error", func() {
+					Ω(err).Should(BeNil())
+				})
+			})
+
+			Context("Initial status", func() {
+				var (
+					foundPravega *v1alpha1.PravegaCluster
+				)
+				BeforeEach(func() {
+					res, err = r.Reconcile(req)
+					foundPravega = &v1alpha1.PravegaCluster{}
+					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+				})
+
+				It("should have current version set to spec version", func() {
+					Ω(foundPravega.Status.CurrentVersion).Should(Equal(foundPravega.Spec.Version))
+				})
+
+				It("should set upgrade condition and status to be false", func() {
+					_, upgradeCondition := foundPravega.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
+					Ω(upgradeCondition.Status).Should(Equal(corev1.ConditionFalse))
+				})
+			})
+		})
+
+		Context("Upgrade to new version", func() {
+			var (
+				client    client.Client
+				err       error
+			)
+
+			BeforeEach(func() {
+				p.Spec = v1alpha1.ClusterSpec{
+					Version: "0.5.0",
+				}
+				p.WithDefaults()
+				client = fake.NewFakeClient(p)
+				r = &ReconcilePravegaCluster{client: client, scheme: s}
+				res, err = r.Reconcile(req)
+				foundPravega := &v1alpha1.PravegaCluster{}
+				_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+				foundPravega.Spec.Version = "0.6.0"
+				// bypass the pods ready check in the upgrade logic
+				foundPravega.Status.SetPodsReadyConditionTrue()
+				client.Update(context.TODO(), foundPravega)
+				res, err = r.Reconcile(req)
+			})
+
+			Context("Condition", func() {
+				var (
+					foundPravega *v1alpha1.PravegaCluster
+				)
+				BeforeEach(func() {
+					foundPravega = &v1alpha1.PravegaCluster{}
+					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+				})
+
+				It("should set target version to 0.6.0", func() {
+					Ω(foundPravega.Status.TargetVersion).Should(Equal("0.6.0"))
+				})
+
+				It("should set upgrade condition to be true", func() {
+					_, upgradeCondition := foundPravega.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
+					Ω(upgradeCondition.Status).Should(Equal(corev1.ConditionTrue))
+				})
+			})
+
+			Context("Upgrade Bookkeeper", func() {
+				var (
+					foundPravega *v1alpha1.PravegaCluster
+					sts *appsv1.StatefulSet
+				)
+				BeforeEach(func() {
+					sts = &appsv1.StatefulSet{}
+					name := util.StatefulSetNameForBookie(p.Name)
+					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+					sts.Status.ReadyReplicas = 1
+					r.client.Update(context.TODO(), sts)
+
+					res, err = r.Reconcile(req)
+					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+					foundPravega = &v1alpha1.PravegaCluster{}
+					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+				})
+
+				It("should set upgrade condition reason to UpgradingBookkeeperReason and message to 0", func() {
+					_, upgradeCondition := foundPravega.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
+					Ω(upgradeCondition.Reason).Should(Equal(pravegav1alpha1.UpgradingBookkeeperReason))
+					Ω(upgradeCondition.Message).Should(Equal("0"))
+				})
+			})
+
+			Context("Upgrade Segmentstore", func() {
+				var (
+					foundPravega *v1alpha1.PravegaCluster
+					sts *appsv1.StatefulSet
+				)
+				BeforeEach(func() {
+					foundPravega = &v1alpha1.PravegaCluster{}
+					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+
+					// Bookkeeper
+					sts = &appsv1.StatefulSet{}
+					name := util.StatefulSetNameForBookie(p.Name)
+					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+					targetImage, _ := util.BookkeeperTargetImage(foundPravega)
+					sts.Spec.Template.Spec.Containers[0].Image = targetImage
+					r.client.Update(context.TODO(), sts)
+
+					res, err = r.Reconcile(req)
+					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+					foundPravega = &v1alpha1.PravegaCluster{}
+					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+				})
+
+				It("should set upgrade condition reason to UpgradingSegmentstoreReason and message to 0", func() {
+					_, upgradeCondition := foundPravega.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
+					Ω(upgradeCondition.Reason).Should(Equal(pravegav1alpha1.UpgradingSegmentstoreReason))
+					Ω(upgradeCondition.Message).Should(Equal("0"))
+				})
+			})
+
+			Context("Upgrade Controller", func() {
+				var (
+					foundPravega *v1alpha1.PravegaCluster
+					sts *appsv1.StatefulSet
+				)
+				BeforeEach(func() {
+					foundPravega = &v1alpha1.PravegaCluster{}
+					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+
+					// Bookkeeper
+					sts = &appsv1.StatefulSet{}
+					name := util.StatefulSetNameForBookie(p.Name)
+					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+					targetImage, _ := util.BookkeeperTargetImage(foundPravega)
+					sts.Spec.Template.Spec.Containers[0].Image = targetImage
+					r.client.Update(context.TODO(), sts)
+
+					// Segmentstore
+					name = util.StatefulSetNameForSegmentstore(p.Name)
+					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+					targetImage, _ = util.PravegaTargetImage(foundPravega)
+					sts.Spec.Template.Spec.Containers[0].Image = targetImage
+					r.client.Update(context.TODO(), sts)
+
+					res, err = r.Reconcile(req)
+					_ = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+					foundPravega = &v1alpha1.PravegaCluster{}
+					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+				})
+
+				It("should set upgrade condition reason to UpgradingControllerReason and message to 0", func() {
+					_, upgradeCondition := foundPravega.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionUpgrading)
+					Ω(upgradeCondition.Reason).Should(Equal(pravegav1alpha1.UpgradingControllerReason))
+					Ω(upgradeCondition.Message).Should(Equal("0"))
+				})
+			})
+		})
+	})
+})

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -12,6 +12,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
@@ -111,4 +112,12 @@ func IsPodReady(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+func IsPodFaulty(pod *corev1.Pod) (bool, error) {
+	if pod.Status.ContainerStatuses[0].State.Waiting != nil && (pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" ||
+		pod.Status.ContainerStatuses[0].State.Waiting.Reason == "CrashLoopBackOff") {
+		return true, fmt.Errorf("pod %s update failed because of %s", pod.Name, pod.Status.ContainerStatuses[0].State.Waiting.Reason)
+	}
+	return false, nil
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Admission webhook", func() {
 				p.Spec = v1alpha1.ClusterSpec{
 					Version: "0.5.0-001",
 				}
-				p.Status.SetUpgradingConditionTrue()
+				p.Status.SetUpgradingConditionTrue("", "")
 				client = fake.NewFakeClient(p)
 				pwh = &pravegaWebhookHandler{client: client}
 			})


### PR DESCRIPTION
Signed-off-by: wenqimou <452787782@qq.com>

### Change log description

This PR will set Pravega upgrade condition to false if there are errors happen during the upgrade. The way to detect error is to see if there is any progress has been made during a timeout. 

### Purpose of the change

Fix #186 

### What the code does

The code will put the updated pod number into the `upgrading condition` message. When checking the upgrade status, it will check if the updated pod number has changed, if it has changed, then update the changed number, which will also add a timestamp to the `upgrading condition`. If nothing changed, it will compare the current time with the timestamp in the condition, if the difference exceeds 10 minutes, it will return an error indicating that there is no progress for the last 10 minutes and the upgrade can be considered as failed.

### How to verify it

TBD
