### PR TITLE
Issue 258: Cleaning up old resources post upgrade

### DIFF
--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -24,6 +24,7 @@ import (
 )
 
 func MakeControllerDeployment(p *api.PravegaCluster) *appsv1.Deployment {
+	zero := int32(0)
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -36,6 +37,7 @@ func MakeControllerDeployment(p *api.PravegaCluster) *appsv1.Deployment {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &p.Spec.Pravega.ControllerReplicas,
+			RevisionHistoryLimit: &zero,
 			Template: MakeControllerPodTemplate(p),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: util.LabelsForController(p),

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -36,9 +36,9 @@ func MakeControllerDeployment(p *api.PravegaCluster) *appsv1.Deployment {
 			Labels:    util.LabelsForController(p),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &p.Spec.Pravega.ControllerReplicas,
+			Replicas:             &p.Spec.Pravega.ControllerReplicas,
 			RevisionHistoryLimit: &zero,
-			Template: MakeControllerPodTemplate(p),
+			Template:             MakeControllerPodTemplate(p),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: util.LabelsForController(p),
 			},


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
During an upgrade, the Controller which is deployed as a Kubernetes Deployment creates a new ReplicaSet and moves pods from the old ReplicaSet to the new one at a controlled rate. It however retains the older ReplicaSet even after the upgrade has been successfully completed, because the old ReplicaSet can be used to perform a rollback using `kubectl undo deployment/<deployment-name>`.
However we want to clean up the old ReplicaSets after a successful upgrade since we do not intent to perform an `undo` in order to rollback the Deployment.

### Purpose of the change
Fixes #258

### What the code does
The code sets the `revisionHistoryLimit` field in the `spec` of the Controller Deployment which is used to specify how many old ReplicaSets for this Deployment we want to retain. The rest will be garbage-collected in the background. We set the value of this field to 0 which results in cleaning up the entire history the Deployment by removing the older ReplicaSets.

### How to verify it
To reproduce the issue tried upgrading a sample Pravega Cluster from version 0.5.0-2222.8ba5431 to version 0.5.0-2236.5228e2d and verified that a new ReplicaSet is created with the updated version, while the older ReplicaSet is still retained.

Created a new operator image with the fix and confirmed that the old ReplicaSet is now removed after the upgrade has successfully completed and we now find only the newly created ReplicaSet.

However, in case the upgrade fails due to an `Image Pull` or any such error, both the old and new ReplicaSets are retained and we are able to rollback to the older version in such cases.