### PR TITLE
Issue 262: Adding Helm Test for Pravega Cluster

### DIFF
--- a/charts/pravega/templates/tests/clusterrole.yaml
+++ b/charts/pravega/templates/tests/clusterrole.yaml
@@ -1,0 +1,23 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "{{.Release.Name}}-pravega-test"
+rules:
+- apiGroups:
+  - pravega.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - "*"
+  verbs:
+  - '*'

--- a/charts/pravega/templates/tests/clusterrole.yaml
+++ b/charts/pravega/templates/tests/clusterrole.yaml
@@ -8,16 +8,4 @@ rules:
   resources:
   - "*"
   verbs:
-  - "*"
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
   - get
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - "*"
-  verbs:
-  - '*'

--- a/charts/pravega/templates/tests/clusterrolebinding.yaml
+++ b/charts/pravega/templates/tests/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "{{.Release.Name}}-pravega-test"
+subjects:
+- kind: ServiceAccount
+  name: "{{.Release.Name}}-pravega-test"
+  namespace: "{{.Release.Namespace}}"
+roleRef:
+  kind: ClusterRole
+  name: "{{.Release.Name}}-pravega-test"
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/pravega/templates/tests/service_account.yaml
+++ b/charts/pravega/templates/tests/service_account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{.Release.Name}}-pravega-test"
+  annotations:
+    nautilus.dellemc.com/serviceaccount-secret-name: pravega
+  labels:
+    app.kubernetes.io/name: pravega
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/pravega/templates/tests/test.yaml
+++ b/charts/pravega/templates/tests/test.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata: 
+  name: "{{ .Release.Name }}-pravega-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  serviceAccountName: "{{.Release.Name}}-pravega-test"
+  containers:
+  - name: {{ .Release.Name }}-pravega-test
+    image: lachlanevenson/k8s-kubectl:v1.14.6
+    imagePullPolicy: "IfNotPresent"
+    command: ["sh", "-c"]
+    args:
+    -  kubectl get PravegaCluster -n {{ .Release.Namespace }} {{ template "pravega.fullname" . }} -o jsonpath='{.status.conditions[?(@.type=="PodsReady")].status}' | grep True ;
+  restartPolicy: Never


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Implementing helm test on the Pravega Cluster so that post an upgrade we can determine whether the upgrade was successful or not by simply running `helm test <release-name>`.

### Purpose of the change
Fixes #262 

### What the code does
The helm test simply checks whether `PodsReady` status field of the Pravega Cluster is set to true or not which can be used to determine whether the Pravega Cluster is ready or not.

### How to verify it
Run `helm test <release-name>`
If the PravegaCluster upgrade was successful and all pods are in Ready state then the test should pass, else it should fail.
