### PR TITLE
Issue:244,255 Support custom annotations and separate service types for external access for Controller and Segment Store

### DIFF
--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -123,6 +123,22 @@ type PravegaSpec struct {
 	// SegmentStoreResources specifies the request and limit of resources that segmentStore can have.
 	// SegmentStoreResources includes CPU and memory resources
 	SegmentStoreResources *v1.ResourceRequirements `json:"segmentStoreResources,omitempty"`
+
+	// Type specifies the service type to achieve external access.
+	// Options are "LoadBalancer" and "NodePort".
+	// By default, if external access is enabled, it will use "LoadBalancer"
+	ControllerExternalServiceType v1.ServiceType `json:"controllerExtServiceType,omitempty"`
+
+	// Annotations to be added to the external service
+	ControllerServiceAnnotations map[string]string `json:"controllerSvcAnnotations"`
+
+	// Type specifies the service type to achieve external access.
+	// Options are "LoadBalancer" and "NodePort".
+	// By default, if external access is enabled, it will use "LoadBalancer"
+	SegmentStoreExternalServiceType v1.ServiceType `json:"segmentStoreExtServiceType,omitempty"`
+
+	// Annotations to be added to the external service
+	SegmentStoreServiceAnnotations map[string]string `json:"segmentStoreSvcAnnotations"`
 }
 
 func (s *PravegaSpec) withDefaults() (changed bool) {
@@ -206,6 +222,16 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 				v1.ResourceMemory: resource.MustParse(DefaultSegmentStoreLimitMemory),
 			},
 		}
+	}
+
+	if s.ControllerServiceAnnotations == nil {
+		changed = true
+		s.ControllerServiceAnnotations = map[string]string{}
+	}
+
+	if s.SegmentStoreServiceAnnotations == nil {
+		changed = true
+		s.SegmentStoreServiceAnnotations = map[string]string{}
 	}
 
 	return changed

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -172,11 +172,6 @@ func (e *ExternalAccess) withDefaults() (changed bool) {
 		changed = true
 		e.Type = ""
 		e.DomainName = ""
-	} else if e.Enabled == true {
-		if e.Type == "" {
-			changed = true
-			e.Type = DefaultServiceType
-		}
 	}
 	return changed
 }

--- a/pkg/apis/pravega/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pravega/v1alpha1/zz_generated.deepcopy.go
@@ -486,6 +486,20 @@ func (in *PravegaSpec) DeepCopyInto(out *PravegaSpec) {
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ControllerServiceAnnotations != nil {
+		in, out := &in.ControllerServiceAnnotations, &out.ControllerServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.SegmentStoreServiceAnnotations != nil {
+		in, out := &in.SegmentStoreServiceAnnotations, &out.SegmentStoreServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -350,27 +350,54 @@ func MakeSegmentStoreHeadlessService(pravegaCluster *api.PravegaCluster) *corev1
 	}
 }
 
+func getSSServiceType(pravegaCluster *api.PravegaCluster) (serviceType corev1.ServiceType) {
+	if pravegaCluster.Spec.Pravega.SegmentStoreExternalServiceType == "" {
+		if pravegaCluster.Spec.ExternalAccess.Type == "" {
+			return api.DefaultServiceType
+		}
+		return pravegaCluster.Spec.ExternalAccess.Type
+	}
+	return pravegaCluster.Spec.Pravega.SegmentStoreExternalServiceType
+}
+
+func cloneMap(sourceMap map[string]string) (annotationMap map[string]string) {
+	if len(sourceMap) == 0 {
+		return map[string]string{}
+	}
+	annotationMap = make(map[string]string, len(sourceMap)+1)
+	for key, value := range sourceMap {
+		annotationMap[key] = value
+	}
+	return annotationMap
+}
+
+func generateDNSAnnotationForSvc(domainName string, podName string) (dnsAnnotationValue string) {
+	var ssFQDN string
+	if domainName != "" {
+		domain := strings.TrimSpace(domainName)
+		if strings.HasSuffix(domain, dot) {
+			ssFQDN = podName + dot + domain
+		} else {
+			ssFQDN = podName + dot + domain + dot
+		}
+	}
+	return ssFQDN
+}
+
 func MakeSegmentStoreExternalServices(pravegaCluster *api.PravegaCluster) []*corev1.Service {
 	var service *corev1.Service
-	var ssPodName string
-	var ssFQDN string
-	var annotationMap map[string]string
 
+	serviceType := getSSServiceType(pravegaCluster)
+	annotationMap := cloneMap(pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations)
 	services := make([]*corev1.Service, pravegaCluster.Spec.Pravega.SegmentStoreReplicas)
 
 	for i := int32(0); i < pravegaCluster.Spec.Pravega.SegmentStoreReplicas; i++ {
-		ssPodName = util.ServiceNameForSegmentStore(pravegaCluster.Name, i)
-		if pravegaCluster.Spec.ExternalAccess.DomainName != "" {
-			domainName := strings.TrimSpace(pravegaCluster.Spec.ExternalAccess.DomainName)
-			if strings.HasSuffix(domainName, dot) {
-				ssFQDN = ssPodName + dot + domainName
-			} else {
-				ssFQDN = ssPodName + dot + domainName + dot
-			}
-			annotationMap = map[string]string{externalDNSAnnotationKey: ssFQDN}
-		} else {
-			annotationMap = map[string]string{}
+		ssPodName := util.ServiceNameForSegmentStore(pravegaCluster.Name, i)
+		annotationValue := generateDNSAnnotationForSvc(pravegaCluster.Spec.ExternalAccess.DomainName, ssPodName)
+		if annotationValue != "" {
+			annotationMap[externalDNSAnnotationKey] = annotationValue
 		}
+
 		service = &corev1.Service{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Service",
@@ -383,7 +410,7 @@ func MakeSegmentStoreExternalServices(pravegaCluster *api.PravegaCluster) []*cor
 				Annotations: annotationMap,
 			},
 			Spec: corev1.ServiceSpec{
-				Type: pravegaCluster.Spec.ExternalAccess.Type,
+				Type: serviceType,
 				Ports: []corev1.ServicePort{
 					{
 						Name:       "server",

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -388,13 +388,16 @@ func MakeSegmentStoreExternalServices(pravegaCluster *api.PravegaCluster) []*cor
 	var service *corev1.Service
 
 	serviceType := getSSServiceType(pravegaCluster)
-	annotationMap := cloneMap(pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations)
 	services := make([]*corev1.Service, pravegaCluster.Spec.Pravega.SegmentStoreReplicas)
+	var annotationMap map[string]string
 
 	for i := int32(0); i < pravegaCluster.Spec.Pravega.SegmentStoreReplicas; i++ {
+		annotationMap = map[string]string{}
 		ssPodName := util.ServiceNameForSegmentStore(pravegaCluster.Name, i)
 		annotationValue := generateDNSAnnotationForSvc(pravegaCluster.Spec.ExternalAccess.DomainName, ssPodName)
+
 		if annotationValue != "" {
+			annotationMap = cloneMap(pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations)
 			annotationMap[externalDNSAnnotationKey] = annotationValue
 		}
 

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -473,6 +473,123 @@ var _ = Describe("PravegaCluster Controller", func() {
 			)
 
 			BeforeEach(func() {
+				domainName = "pravega.com."
+				p.Spec = v1alpha1.ClusterSpec{
+					Version: "0.3.2-rc2",
+					ExternalAccess: &v1alpha1.ExternalAccess{
+						Enabled:    true,
+						Type:       corev1.ServiceTypeClusterIP,
+						DomainName: domainName,
+					},
+					Pravega: &v1alpha1.PravegaSpec{
+						ControllerReplicas:   2,
+						SegmentStoreReplicas: 3,
+					},
+				}
+				p.WithDefaults()
+				client = fake.NewFakeClient(p)
+				r = &ReconcilePravegaCluster{client: client, scheme: s}
+				res, err = r.Reconcile(req)
+			})
+
+			It("shouldn't error", func() {
+				Ω(err).Should(BeNil())
+			})
+
+			Context("Pravega Controller External Access", func() {
+				var foundControllerSvc *corev1.Service
+
+				BeforeEach(func() {
+					foundControllerSvc = &corev1.Service{}
+					nn := types.NamespacedName{
+						Name:      util.ServiceNameForController(p.Name),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn, foundControllerSvc)
+				})
+
+				It("should create a controller service", func() {
+					Ω(err).Should(BeNil())
+				})
+
+				It("should set external access service type to LoadBalancer", func() {
+					Ω(p.Spec.ExternalAccess.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+					Ω(foundControllerSvc.Spec.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+				})
+
+				It("should not set any annotations", func() {
+					mapLength := len(foundControllerSvc.GetAnnotations())
+					Ω(mapLength).To(Equal(0))
+				})
+			})
+
+			Context("Pravega SegmentStore External Access", func() {
+				var foundSegmentStoreSvc1 *corev1.Service
+				var foundSegmentStoreSvc2 *corev1.Service
+				var foundSegmentStoreSvc3 *corev1.Service
+
+				BeforeEach(func() {
+					foundSegmentStoreSvc1 = &corev1.Service{}
+					nn1 := types.NamespacedName{
+						Name:      util.ServiceNameForSegmentStore(p.Name, 0),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn1, foundSegmentStoreSvc1)
+
+					foundSegmentStoreSvc2 = &corev1.Service{}
+					nn2 := types.NamespacedName{
+						Name:      util.ServiceNameForSegmentStore(p.Name, 1),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn2, foundSegmentStoreSvc2)
+
+					foundSegmentStoreSvc3 = &corev1.Service{}
+					nn3 := types.NamespacedName{
+						Name:      util.ServiceNameForSegmentStore(p.Name, 2),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn3, foundSegmentStoreSvc3)
+
+				})
+
+				It("should create all segmentstore services", func() {
+					Ω(err).Should(BeNil())
+				})
+
+				It("should set external access service type to ClusterIP for each service", func() {
+					Ω(p.Spec.ExternalAccess.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+					Ω(foundSegmentStoreSvc1.Spec.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+					Ω(foundSegmentStoreSvc2.Spec.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+					Ω(foundSegmentStoreSvc3.Spec.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+				})
+
+				It("should set only DNS name annotation", func() {
+					mapLength := len(foundSegmentStoreSvc1.GetAnnotations())
+					Ω(mapLength).To(Equal(1))
+
+					svcName1 := util.ServiceNameForSegmentStore(p.Name, 0) + "." + domainName
+					Expect(foundSegmentStoreSvc1.GetAnnotations()).To(HaveKeyWithValue(
+						"external-dns.alpha.kubernetes.io/hostname", svcName1))
+
+					svcName2 := util.ServiceNameForSegmentStore(p.Name, 1) + "." + domainName
+					Expect(foundSegmentStoreSvc2.GetAnnotations()).To(HaveKeyWithValue(
+						"external-dns.alpha.kubernetes.io/hostname", svcName2))
+
+					svcName3 := util.ServiceNameForSegmentStore(p.Name, 2) + "." + domainName
+					Expect(foundSegmentStoreSvc3.GetAnnotations()).To(HaveKeyWithValue(
+						"external-dns.alpha.kubernetes.io/hostname", svcName3))
+				})
+			})
+		})
+
+		Context("Custom spec with ExternalAccess with annotations and overridden Service Type", func() {
+			var (
+				client     client.Client
+				err        error
+				domainName string
+			)
+
+			BeforeEach(func() {
 				annotationsMap := map[string]string{
 					"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
 				}
@@ -501,16 +618,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 
 			It("shouldn't error", func() {
 				Ω(err).Should(BeNil())
-			})
-
-			It("should requeue after ReconfileTime delay", func() {
-				Ω(res.RequeueAfter).To(Equal(ReconcileTime))
-			})
-
-			Context("Cluster", func() {
-				It("should have a custom version", func() {
-					Ω(p.Spec.Version).Should(Equal("0.3.2-rc2"))
-				})
 			})
 
 			Context("Pravega Controller External Access", func() {
@@ -542,7 +649,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 
 			Context("Pravega SegmentStore External Access", func() {
 				var foundSegmentStoreSvc1 *corev1.Service
-
 				var foundSegmentStoreSvc2 *corev1.Service
 				var foundSegmentStoreSvc3 *corev1.Service
 
@@ -576,6 +682,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 
 				It("should set external access service type to NodePort for each service", func() {
 					Ω(p.Spec.Pravega.SegmentStoreExternalServiceType).Should(Equal(corev1.ServiceTypeNodePort))
+					Ω(p.Spec.ExternalAccess.Type).Should(Equal(corev1.ServiceTypeClusterIP))
 					Ω(foundSegmentStoreSvc1.Spec.Type).Should(Equal(corev1.ServiceTypeNodePort))
 					Ω(foundSegmentStoreSvc2.Spec.Type).Should(Equal(corev1.ServiceTypeNodePort))
 					Ω(foundSegmentStoreSvc3.Spec.Type).Should(Equal(corev1.ServiceTypeNodePort))
@@ -585,6 +692,12 @@ var _ = Describe("PravegaCluster Controller", func() {
 					mapLength := len(foundSegmentStoreSvc1.GetAnnotations())
 					Ω(mapLength).To(Equal(2))
 					Expect(foundSegmentStoreSvc1.GetAnnotations()).To(HaveKeyWithValue(
+						"service.beta.kubernetes.io/aws-load-balancer-type",
+						"nlb"))
+					Expect(foundSegmentStoreSvc2.GetAnnotations()).To(HaveKeyWithValue(
+						"service.beta.kubernetes.io/aws-load-balancer-type",
+						"nlb"))
+					Expect(foundSegmentStoreSvc3.GetAnnotations()).To(HaveKeyWithValue(
 						"service.beta.kubernetes.io/aws-load-balancer-type",
 						"nlb"))
 					svcName1 := util.ServiceNameForSegmentStore(p.Name, 0) + "." + domainName
@@ -598,7 +711,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 					svcName3 := util.ServiceNameForSegmentStore(p.Name, 2) + "." + domainName
 					Expect(foundSegmentStoreSvc3.GetAnnotations()).To(HaveKeyWithValue(
 						"external-dns.alpha.kubernetes.io/hostname", svcName3))
-
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

### Change log description
Enables different service types to be provided for Controller and SegmentStore for external access, while maintaining backward compatibility with existing Cluster Spec.
Adds support for specifying custom annotations on controller and segment store external services.

### Purpose of the change
Fixes #244, #245

### What the code does
Code uses external access service type from fields `ControllerExternalServiceType` for controller and `SegmentStoreExternalServiceType` for SegmentStore under `spec.pravega`, if these are specified.
If these are not specified in the manifest, service type specified under `spec.ExternalAccess.Type` is used for both controller and segment store services.
If both values are not provided and external access is enabled, defaultServiceType (LoadBalancer) is used.
Also two new fields added for Annotations under `spec.Pravega`
```
ControllerServiceAnnotations
SegmentStoreServiceAnnotations
```

### How to verify it
All Unit Tests and E2E Tests should pass after this change.