### PR TITLE
Issue 283: Restricting modification of version field during active rollback

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -168,6 +168,14 @@ func (pwh *pravegaWebhookHandler) clusterIsAvailable(ctx context.Context, p *pra
 		}
 	}
 
+	_, rollback := found.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionRollback)
+	if rollback != nil && rollback.Status == corev1.ConditionTrue {
+		// Reject the request if the requested version is new.
+		if p.Spec.Version != found.Spec.Version {
+			return fmt.Errorf("failed to process the request, cluster is upgrading")
+		}
+	}
+
 	// Add other conditions here
 	return nil
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -172,7 +172,7 @@ func (pwh *pravegaWebhookHandler) clusterIsAvailable(ctx context.Context, p *pra
 	if rollback != nil && rollback.Status == corev1.ConditionTrue {
 		// Reject the request if the requested version is new.
 		if p.Spec.Version != found.Spec.Version {
-			return fmt.Errorf("failed to process the request, cluster is upgrading")
+			return fmt.Errorf("failed to process the request, cluster is in rollback")
 		}
 	}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -168,8 +168,7 @@ func (pwh *pravegaWebhookHandler) clusterIsAvailable(ctx context.Context, p *pra
 		}
 	}
 
-	_, rollback := found.Status.GetClusterCondition(pravegav1alpha1.ClusterConditionRollback)
-	if rollback != nil && rollback.Status == corev1.ConditionTrue {
+	if found.Status.IsClusterInRollbackState() {
 		// Reject the request if the requested version is new.
 		if p.Spec.Version != found.Spec.Version {
 			return fmt.Errorf("failed to process the request, cluster is in rollback")

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -271,6 +271,7 @@ var _ = Describe("Admission webhook", func() {
 				})
 			})
 		})
+
 		Context("Reject request when upgrading", func() {
 			var (
 				client client.Client
@@ -295,7 +296,33 @@ var _ = Describe("Admission webhook", func() {
 					Ω(err).ShouldNot(BeNil())
 				})
 			})
-
 		})
+
+		Context("Reject request when rolling back", func() {
+			var (
+				client client.Client
+				err    error
+			)
+
+			BeforeEach(func() {
+				p.Spec = v1alpha1.ClusterSpec{
+					Version: "0.5.0-001",
+				}
+				p.Status.SetRollbackConditionTrue("", "")
+				client = fake.NewFakeClient(p)
+				pwh = &pravegaWebhookHandler{client: client}
+			})
+
+			Context("Sending request when rolling back", func() {
+				It("should not pass", func() {
+					p.Spec = v1alpha1.ClusterSpec{
+						Version: "0.5.0-002",
+					}
+					err = pwh.clusterIsAvailable(context.TODO(), p)
+					Ω(err).ShouldNot(BeNil())
+				})
+			})
+		})
+
 	})
 })

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Admission webhook", func() {
 						Version: "0.5.0-002",
 					}
 					err = pwh.clusterIsAvailable(context.TODO(), p)
-					Ω(err).ShouldNot(BeNil())
+					Ω(err).Should(MatchError("failed to process the request, cluster is in rollback"))
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Currently we are allowed to modify the `version` field of PravegaCluster through `kubectl edit PravegaCluster` when there is an active rollback is going on.
This should be restricted by the admission webhook.

### Purpose of the change
Fixes #283

### What the code does
The code restricts the alteration of the `version` field of the PravegaCluster through `kubectl edit PravegaCluster` command during an active rollback.

### How to verify it
When the cluster is in Rollback State, updation of the version field for the PravegaCluster will display the following error
```
$ kubectl edit PravegaCluster
error: pravegaclusters.pravega.pravega.io "pravega" could not be patched: Internal error occurred: admission webhook "pravegawebhook.pravega.io" denied the request: failed to process the request, cluster is in rollback
You can run `kubectl replace -f /tmp/kubectl-edit-72tb6.yaml` to try this update again.
```