### PR TITLE
Issue 289: Adding SegmentStoreSvcAnnotations

### DIFF
--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -391,10 +391,9 @@ func MakeSegmentStoreExternalServices(pravegaCluster *api.PravegaCluster) []*cor
 	services := make([]*corev1.Service, pravegaCluster.Spec.Pravega.SegmentStoreReplicas)
 
 	for i := int32(0); i < pravegaCluster.Spec.Pravega.SegmentStoreReplicas; i++ {
-		annotationMap := map[string]string{}
 		ssPodName := util.ServiceNameForSegmentStore(pravegaCluster.Name, i)
+		annotationMap := pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations
 		annotationValue := generateDNSAnnotationForSvc(pravegaCluster.Spec.ExternalAccess.DomainName, ssPodName)
-		annotationMap = pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations
 
 		if annotationValue != "" {
 			annotationMap = cloneMap(pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations)

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -389,12 +389,12 @@ func MakeSegmentStoreExternalServices(pravegaCluster *api.PravegaCluster) []*cor
 
 	serviceType := getSSServiceType(pravegaCluster)
 	services := make([]*corev1.Service, pravegaCluster.Spec.Pravega.SegmentStoreReplicas)
-	var annotationMap map[string]string
 
 	for i := int32(0); i < pravegaCluster.Spec.Pravega.SegmentStoreReplicas; i++ {
-		annotationMap = map[string]string{}
+		annotationMap := map[string]string{}
 		ssPodName := util.ServiceNameForSegmentStore(pravegaCluster.Name, i)
 		annotationValue := generateDNSAnnotationForSvc(pravegaCluster.Spec.ExternalAccess.DomainName, ssPodName)
+		annotationMap = pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations
 
 		if annotationValue != "" {
 			annotationMap = cloneMap(pravegaCluster.Spec.Pravega.SegmentStoreServiceAnnotations)

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -728,14 +728,12 @@ var _ = Describe("PravegaCluster Controller", func() {
 				p.Spec = v1alpha1.ClusterSpec{
 					Version: "0.3.2-rc2",
 					ExternalAccess: &v1alpha1.ExternalAccess{
-						Enabled:    true,
-						Type:       corev1.ServiceTypeClusterIP,
-						DomainName: "",
+						Enabled: true,
+						Type:    corev1.ServiceTypeClusterIP,
 					},
 					Pravega: &v1alpha1.PravegaSpec{
-						SegmentStoreReplicas:            3,
-						SegmentStoreExternalServiceType: corev1.ServiceTypeLoadBalancer,
-						SegmentStoreServiceAnnotations:  annotationsMap,
+						SegmentStoreReplicas:           3,
+						SegmentStoreServiceAnnotations: annotationsMap,
 					},
 				}
 				p.WithDefaults()
@@ -779,14 +777,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 
 				It("should create all segmentstore services", func() {
 					Ω(err).Should(BeNil())
-				})
-
-				It("should set external access service type to LoadBalancer for each service", func() {
-					Ω(p.Spec.Pravega.SegmentStoreExternalServiceType).Should(Equal(corev1.ServiceTypeLoadBalancer))
-					Ω(p.Spec.ExternalAccess.Type).Should(Equal(corev1.ServiceTypeClusterIP))
-					Ω(foundSegmentStoreSvc1.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
-					Ω(foundSegmentStoreSvc2.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
-					Ω(foundSegmentStoreSvc3.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
 				})
 
 				It("should set provided annotations", func() {
@@ -822,8 +812,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 						DomainName: domainName,
 					},
 					Pravega: &v1alpha1.PravegaSpec{
-						SegmentStoreReplicas:            3,
-						SegmentStoreExternalServiceType: corev1.ServiceTypeLoadBalancer,
+						SegmentStoreReplicas: 3,
 					},
 				}
 				p.WithDefaults()
@@ -867,14 +856,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 
 				It("should create all segmentstore services", func() {
 					Ω(err).Should(BeNil())
-				})
-
-				It("should set external access service type to LoadBalancer for each service", func() {
-					Ω(p.Spec.Pravega.SegmentStoreExternalServiceType).Should(Equal(corev1.ServiceTypeLoadBalancer))
-					Ω(p.Spec.ExternalAccess.Type).Should(Equal(corev1.ServiceTypeClusterIP))
-					Ω(foundSegmentStoreSvc1.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
-					Ω(foundSegmentStoreSvc2.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
-					Ω(foundSegmentStoreSvc3.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
 				})
 
 				It("should set provided domain name as annotation", func() {

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -714,5 +714,95 @@ var _ = Describe("PravegaCluster Controller", func() {
 				})
 			})
 		})
+
+		Context("Custom spec with ExternalAccess with annotations and empty domain name", func() {
+			var (
+				client client.Client
+				err    error
+			)
+
+			BeforeEach(func() {
+				annotationsMap := map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix": "abc",
+				}
+				p.Spec = v1alpha1.ClusterSpec{
+					Version: "0.3.2-rc2",
+					ExternalAccess: &v1alpha1.ExternalAccess{
+						Enabled:    true,
+						Type:       corev1.ServiceTypeClusterIP,
+						DomainName: "",
+					},
+					Pravega: &v1alpha1.PravegaSpec{
+						SegmentStoreReplicas:            3,
+						SegmentStoreExternalServiceType: corev1.ServiceTypeLoadBalancer,
+						SegmentStoreServiceAnnotations:  annotationsMap,
+					},
+				}
+				p.WithDefaults()
+				client = fake.NewFakeClient(p)
+				r = &ReconcilePravegaCluster{client: client, scheme: s}
+				res, err = r.Reconcile(req)
+			})
+
+			It("shouldn't error", func() {
+				Ω(err).Should(BeNil())
+			})
+
+			Context("Pravega SegmentStore External Access", func() {
+				var foundSegmentStoreSvc1 *corev1.Service
+				var foundSegmentStoreSvc2 *corev1.Service
+				var foundSegmentStoreSvc3 *corev1.Service
+
+				BeforeEach(func() {
+					foundSegmentStoreSvc1 = &corev1.Service{}
+					nn1 := types.NamespacedName{
+						Name:      util.ServiceNameForSegmentStore(p.Name, 0),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn1, foundSegmentStoreSvc1)
+
+					foundSegmentStoreSvc2 = &corev1.Service{}
+					nn2 := types.NamespacedName{
+						Name:      util.ServiceNameForSegmentStore(p.Name, 1),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn2, foundSegmentStoreSvc2)
+
+					foundSegmentStoreSvc3 = &corev1.Service{}
+					nn3 := types.NamespacedName{
+						Name:      util.ServiceNameForSegmentStore(p.Name, 2),
+						Namespace: Namespace,
+					}
+					err = client.Get(context.TODO(), nn3, foundSegmentStoreSvc3)
+
+				})
+
+				It("should create all segmentstore services", func() {
+					Ω(err).Should(BeNil())
+				})
+
+				It("should set external access service type to LoadBalancer for each service", func() {
+					Ω(p.Spec.Pravega.SegmentStoreExternalServiceType).Should(Equal(corev1.ServiceTypeLoadBalancer))
+					Ω(p.Spec.ExternalAccess.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+					Ω(foundSegmentStoreSvc1.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
+					Ω(foundSegmentStoreSvc2.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
+					Ω(foundSegmentStoreSvc3.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
+				})
+
+				It("should set provided annotations", func() {
+					mapLength := len(foundSegmentStoreSvc1.GetAnnotations())
+					Ω(mapLength).To(Equal(1))
+					Expect(foundSegmentStoreSvc1.GetAnnotations()).To(HaveKeyWithValue(
+						"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix",
+						"abc"))
+					Expect(foundSegmentStoreSvc2.GetAnnotations()).To(HaveKeyWithValue(
+						"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix",
+						"abc"))
+					Expect(foundSegmentStoreSvc3.GetAnnotations()).To(HaveKeyWithValue(
+						"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix",
+						"abc"))
+				})
+			})
+		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
SegmentStoreSvcAnnotations added to the manifest file are not visible in the kubectl describe output for the segmentStoreSvc if the domainName field is empty.

### Purpose of the change
Fixes #289 

### What the code does
The code populates the SegmentStoreSvcAnnotations from the manifest file if external access has been enabled.

### How to verify it
Add SegmentStoreSvcAnnotations to the manifest file 
```
pravega:
    segmentStoreSvcAnnotations:
      service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "abc"
```
Deploy PravegaCluster with external access enabled. The describe output for the segmentStoreSvc should contain the added segmentStoreSvcAnnotations key-value pairs as part of `Annotations` field of the output.
```
$ kubectl describe svc bar-pravega-pravega-segmentstore-0
Name:                     bar-pravega-pravega-segmentstore-0
Namespace:                default
Labels:                   app=pravega-cluster
                          component=pravega-segmentstore
                          pravega_cluster=bar-pravega
Annotations:              ncp/error.loadbalancer: IP_POOL_EXHAUSTED
                          service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: abc
Selector:                 statefulset.kubernetes.io/pod-name=bar-pravega-pravega-segmentstore-0
Type:                     LoadBalancer
IP:                       10.100.200.55
Port:                     server  12345/TCP
TargetPort:               12345/TCP
NodePort:                 server  30860/TCP
Endpoints:                172.28.78.12:12345
Session Affinity:         None
External Traffic Policy:  Local
HealthCheck NodePort:     31566
Events:                   <none>
```
