### PR TITLE
Issue 273: Publish Events for Critical failures

### DIFF
--- a/charts/app/configmap.yaml
+++ b/charts/app/configmap.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: pravega-cluster-app-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: pravega-cluster
+  annotations:
+    com.dellemc.kahm.subscribed: "true"
+data:
+  eventRules:  |-
+    rules:
+      - description: srs critical events
+        matchon:
+          - field: type
+            value: Critical
+        notifiers:
+          - streamingdata-srs
+  healthChecks:  |-
+  eventRemedies:  |-
+    symptoms:
+      - symptomid: PRAVEGA-0001 
+        description: Multiple Segment Store restarts have been detected in a short period of time.
+        remedies: 
+          - Check the resource utilization of Segment Store instances (e.g., Kubernetes client, dashboard). If they are low in resources (e.g., CPU/RAM), more resources should be provided to handle the workload induced.
+          - Check that the Zookeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Check that the Bookkeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Contact your Dell EMC support representative to help you solving the issue.
+      - symptomid: PRAVEGA-0002
+        description: Multiple Segment Container failures have been detected in a short period of time.
+        remedies: 
+          - Check that the Bookkeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Contact your Dell EMC support representative to help you solving the issue.
+      - symptomid: PRAVEGA-1000
+        description: A Stream operation has failed.
+        remedies: 
+          - If you are creating a Stream, please make sure that the Stream name is formed of valid characters.
+          - Check if the problem is related with the client's security credentials when operating against Pravega.
+          - Verify that the Controller and Segment Store service instances are not restarting, which can cause Stream operations to fail. 
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.
+      - symptomid: PRAVEGA-1001
+        description: A Transaction operation has failed.
+        remedies: 
+          - Check if the problem is related with the client's security credentials when operating against Pravega.
+          - Verify that the Controller and Segment Store service instances are not restarting, which can cause Transaction operations to fail. 
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.
+      - symptomid: PRAVEGA-1002
+        description: A Pravega Controller detected a Zookeeper session expiration.
+        remedies: 
+          - Check that the Zookeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.
+      - symptomid: PRAVEGA-1003
+        description: A Segment Store restart has been detected.
+        remedies: 
+          - Check the resource utilization of Segment Store instances (e.g., Kubernetes client, dashboard). If they are low in resources (e.g., CPU/RAM), more resources should be provided to handle the workload induced.
+          - Check that the Zookeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Check that the Bookkeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.
+      - symptomid: PRAVEGA-1004
+        description: A Segment Container restart has been detected.
+        remedies: 
+          - Check that the Bookkeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.
+      - symptomid: PRAVEGA-1005
+        description: Writes to Bookkeeper exhibit slow performance.
+        remedies: 
+          - Check that the Bookkeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Check the metrics of the storage infrastructure used by Bookkeeper volumes (e.g., VMWare vSAN, AWS EBS) and verify that there are no performance problems.
+          - Check that Bookies are not low in resources (i.e., CPU, RAM) or that their journal/ledger volumes are not reaching their maximum capacity.
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.
+      - symptomid: PRAVEGA-1006
+        description: Writes to Tier 2 exhibit slow performance.
+        remedies: 
+          - Check the health of your Tier 2 storage deployment (e.g., Isilon, ECS).
+          - Make sure that network connectivity from the Nautilus cluster to the Tier 2 deployment is working fine.
+          - Check that Pravega Segment Store instances are not low in resources (e.g., CPU, RAM).
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.
+      - symptomid: PRAVEGA-1007
+        description: Controller Stream/Transaction operations exhibit slow performance.
+        remedies: 
+          - Check the health of your Tier 2 storage deployment (e.g., Isilon, ECS).
+          - Check that the Zookeeper service is working properly (e.g., all instances are up and running without recent restarts).
+          - Check that Pravega Segment Store instances are not low in resources (e.g., CPU, RAM).
+          - Contact your Dell EMC support representative to help you solving the issue if it persists.

--- a/charts/app/pravega-cluster.yaml
+++ b/charts/app/pravega-cluster.yaml
@@ -1,0 +1,52 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  namespace: "default"
+  name: "pravega-cluster"
+  labels:
+    product: "streamingdata"
+    app.kubernetes.io/name: "pravega-cluster"
+  annotations:
+    com.dellemc.kahm.subscribed: "true"
+spec:
+  assemblyPhase: "Pending"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "pravega-cluster"
+  componentKinds:
+    - group: core
+      kind: Service
+    - group: core
+      kind: Pod
+    - group: apps
+      kind: Deployment
+    - group: apps
+      kind: ReplicaSet
+    - group: apps
+      kind: StatefulSet
+    - group: core
+      kind: ConfigMap
+    - group: core
+      kind: Secret
+    - group: core
+      kind: PersistentVolumeClaim
+    - group: rbac.authorization.k8s.io
+      kind: Role
+    - group: rbac.authorization.k8s.io
+      kind: RoleBinding
+    - group: core
+      kind: ServiceAccount
+    - group: pravega.pravega.io
+      kind: PravegaCluster
+  descriptor:
+    type: "pravega-cluster"
+    version: "latest"
+    description: >
+      Deployment of 0.6.0 Pravega with Metrics Stack.
+    keywords:
+      - "nautilus"
+      - "pravega"
+    links:
+      - description: "Project Website"
+        url: "http://pravega.io/"
+    info:

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -2,6 +2,8 @@ apiVersion: "pravega.pravega.io/v1alpha1"
 kind: "PravegaCluster"
 metadata:
   name: {{ template "pravega.fullname" . }}
+  labels: 
+    app.kubernetes.io/name: "pravega-cluster"
 spec:
   version: {{ .Values.version }}
   zookeeperUri: {{ .Values.zookeeperUri }}

--- a/pkg/apis/pravega/v1alpha1/status.go
+++ b/pkg/apis/pravega/v1alpha1/status.go
@@ -29,6 +29,8 @@ const (
 	UpdatingControllerReason   = "Updating Controller"
 	UpdatingSegmentstoreReason = "Updating Segmentstore"
 	UpdatingBookkeeperReason   = "Updating Bookkeeper"
+	UpgradeErrorReason         = "Upgrade Error"
+	RollbackErrorReason        = "Rollback Error"
 )
 
 // ClusterStatus defines the observed state of PravegaCluster

--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -73,8 +73,7 @@ func (r *ReconcilePravegaCluster) syncClusterVersion(p *pravegav1alpha1.PravegaC
 			p.Status.SetErrorConditionTrue("UpgradeFailed", err.Error())
 			// emit an event for Upgrade Failure
 			message := fmt.Sprintf("Error Upgrading from version %v to %v. %v", p.Status.CurrentVersion, p.Status.TargetVersion, err.Error())
-			reason := "UpgradeError"
-			event := util.NewEvent("UPGRADE_ERROR", p, reason, message, "Error")
+			event := util.NewEvent("UPGRADE_ERROR", p, pravegav1alpha1.UpgradeErrorReason, message, "Error")
 			pubErr := r.client.Create(context.TODO(), event)
 			if pubErr != nil {
 				log.Printf("Error publishing Upgrade Failure event to k8s. %v", pubErr)
@@ -161,8 +160,7 @@ func (r *ReconcilePravegaCluster) rollbackClusterVersion(p *pravegav1alpha1.Prav
 		p.Status.SetErrorConditionTrue("RollbackFailed", err.Error())
 		// emit an event for Rollback Failure
 		message := fmt.Sprintf("Error Rollingback from version %v to %v. %v", p.Status.CurrentVersion, p.Status.TargetVersion, err.Error())
-		reason := "RollbackError"
-		event := util.NewEvent("ROLLBACK_ERROR", p, reason, message, "Error")
+		event := util.NewEvent("ROLLBACK_ERROR", p, pravegav1alpha1.RollbackErrorReason, message, "Error")
 		pubErr := r.client.Create(context.TODO(), event)
 		if pubErr != nil {
 			log.Printf("Error publishing ROLLBACK_ERROR event to k8s. %v", pubErr)

--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -71,6 +71,14 @@ func (r *ReconcilePravegaCluster) syncClusterVersion(p *pravegav1alpha1.PravegaC
 		if err != nil {
 			log.Printf("error syncing cluster version, upgrade failed. %v", err)
 			p.Status.SetErrorConditionTrue("UpgradeFailed", err.Error())
+			// emit an event for Upgrade Failure
+			message := fmt.Sprintf("Error Upgrading from version %v to %v. %v", p.Status.CurrentVersion, p.Status.TargetVersion, err.Error())
+			reason := "UpgradeError"
+			event := util.NewEvent("UPGRADE_ERROR", p, reason, message, "Error")
+			pubErr := r.client.Create(context.TODO(), event)
+			if pubErr != nil {
+				log.Printf("Error publishing Upgrade Failure event to k8s. %v", pubErr)
+			}
 			r.clearUpgradeStatus(p)
 			return err
 		}
@@ -151,6 +159,14 @@ func (r *ReconcilePravegaCluster) rollbackClusterVersion(p *pravegav1alpha1.Prav
 	if err != nil {
 		// Error rolling back, set appropriate status and ask for manual intervention
 		p.Status.SetErrorConditionTrue("RollbackFailed", err.Error())
+		// emit an event for Rollback Failure
+		message := fmt.Sprintf("Error Rollingback from version %v to %v. %v", p.Status.CurrentVersion, p.Status.TargetVersion, err.Error())
+		reason := "RollbackError"
+		event := util.NewEvent("ROLLBACK_ERROR", p, reason, message, "Error")
+		pubErr := r.client.Create(context.TODO(), event)
+		if pubErr != nil {
+			log.Printf("Error publishing ROLLBACK_ERROR event to k8s. %v", pubErr)
+		}
 		r.clearRollbackStatus(p)
 		log.Printf("Error rolling back to cluster version %v. Reason: %v", version, err)
 		//r.client.Status().Update(context.TODO(), p)

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -135,7 +135,7 @@ func NewEvent(name string, p *v1alpha1.PravegaCluster, reason string, message st
 		},
 		InvolvedObject: corev1.ObjectReference{
 			APIVersion:      "pravega.pravega.io/v1alpha1",
-			Kind:            "pravegacluster",
+			Kind:            "PravegaCluster",
 			Name:            p.GetName(),
 			Namespace:       p.GetNamespace(),
 			ResourceVersion: p.GetResourceVersion(),

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -131,11 +131,15 @@ func NewEvent(name string, p *v1alpha1.PravegaCluster, reason string, message st
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: p.Namespace,
+			Labels:    LabelsForPravegaCluster(p),
 		},
 		InvolvedObject: corev1.ObjectReference{
-			Kind:      "pravegacluster",
-			Name:      p.GetName(),
-			Namespace: p.GetNamespace(),
+			APIVersion:      "pravega.pravega.io/v1alpha1",
+			Kind:            "pravegacluster",
+			Name:            p.GetName(),
+			Namespace:       p.GetNamespace(),
+			ResourceVersion: p.GetResourceVersion(),
+			UID:             p.GetUID(),
 		},
 		Reason:              reason,
 		Message:             message,

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -13,6 +13,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
@@ -20,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	k8s "github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,4 +122,28 @@ func IsPodFaulty(pod *corev1.Pod) (bool, error) {
 		return true, fmt.Errorf("pod %s update failed because of %s", pod.Name, pod.Status.ContainerStatuses[0].State.Waiting.Reason)
 	}
 	return false, nil
+}
+
+func NewEvent(name string, p *v1alpha1.PravegaCluster, reason string, message string, eventType string) *corev1.Event {
+	now := metav1.Now()
+	operatorName, _ := k8s.GetOperatorName()
+	event := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: p.Namespace,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "pravegacluster",
+			Name:      p.GetName(),
+			Namespace: p.GetNamespace(),
+		},
+		Reason:              reason,
+		Message:             message,
+		FirstTimestamp:      now,
+		LastTimestamp:       now,
+		Type:                eventType,
+		ReportingController: operatorName,
+		ReportingInstance:   os.Getenv("POD_NAME"),
+	}
+	return &event
 }


### PR DESCRIPTION
### Change log description
This change enables operator to emit K8s Events for failures that need human intervention.
Error Events are emitted for `Upgrade Failure` and `RollbackFailure`.

### Purpose of the change
Fixes #273.

### How to verify it
Events should get added to kubernetes event queue, when upgrade fails and rollback fails.
The following is the describe output of the event that is created.
```
Name:             UPGRADE_ERROR
Namespace:        default
Labels:           app=pravega-cluster
                  pravega_cluster=pravega
Annotations:      <none>
API Version:      v1
Event Time:       <nil>
First Timestamp:  2019-11-07T19:50:12Z
Involved Object:
  API Version:       pravega.pravega.io/v1alpha1
  Kind:              pravegacluster
  Name:              pravega
  Namespace:         default
  Resource Version:  2333666
  UID:               1be047dc-0197-11ea-84b4-005056b2ae40
Kind:                Event
Last Timestamp:      2019-11-07T19:50:12Z
Message:             Error Upgrading from version 0.6.0-2403.d7338a3 to 0.6.0.2405.acdf2db. failed to sync bookkeeper version. pod pravega-bookie-0 update failed because of ImagePullBackOff
Metadata:
  Creation Timestamp:  2019-11-07T19:50:12Z
  Resource Version:    2333752
  Self Link:           /api/v1/namespaces/default/events/UPGRADE_ERROR
  UID:                 cf8b8e56-0197-11ea-989b-005056b2515d
Reason:                Upgrade Error
Reporting Component:   pravega-operator
Reporting Instance:    pravega-operator-84f74c4c7c-cv7px
Source:
Type:    Error
Events:  <none>
```
