### PR TITLE
Issue 287: Deleting SegmentStore Services after Scaledown

### DIFF
--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -288,7 +288,7 @@ func CheckPvcSanity(t *testing.T, f *framework.Framework, ctx *framework.TestCtx
 		if pvc.Status.Phase != corev1.ClaimBound {
 			continue
 		}
-		if util.PvcIsOrphan(pvc.Name, p.Spec.Bookkeeper.Replicas) {
+		if util.IsOrphan(pvc.Name, p.Spec.Bookkeeper.Replicas) {
 			return fmt.Errorf("bookie pvc is illegal")
 		}
 
@@ -306,7 +306,7 @@ func CheckPvcSanity(t *testing.T, f *framework.Framework, ctx *framework.TestCtx
 		if pvc.Status.Phase != corev1.ClaimBound {
 			continue
 		}
-		if util.PvcIsOrphan(pvc.Name, p.Spec.Pravega.SegmentStoreReplicas) {
+		if util.IsOrphan(pvc.Name, p.Spec.Pravega.SegmentStoreReplicas) {
 			return fmt.Errorf("segment store pvc is illegal")
 		}
 

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -110,13 +110,13 @@ func LabelsForPravegaCluster(pravegaCluster *v1alpha1.PravegaCluster) map[string
 	}
 }
 
-func IsOrphan(stsName string, replicas int32) bool {
-	index := strings.LastIndexAny(stsName, "-")
+func IsOrphan(k8sObjectName string, replicas int32) bool {
+	index := strings.LastIndexAny(k8sObjectName, "-")
 	if index == -1 {
 		return false
 	}
 
-	ordinal, err := strconv.Atoi(stsName[index+1:])
+	ordinal, err := strconv.Atoi(k8sObjectName[index+1:])
 	if err != nil {
 		return false
 	}

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -110,13 +110,13 @@ func LabelsForPravegaCluster(pravegaCluster *v1alpha1.PravegaCluster) map[string
 	}
 }
 
-func PvcIsOrphan(stsPvcName string, replicas int32) bool {
-	index := strings.LastIndexAny(stsPvcName, "-")
+func IsOrphan(stsName string, replicas int32) bool {
+	index := strings.LastIndexAny(stsName, "-")
 	if index == -1 {
 		return false
 	}
 
-	ordinal, err := strconv.Atoi(stsPvcName[index+1:])
+	ordinal, err := strconv.Atoi(stsName[index+1:])
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
When we deploy PravegaCluster with external access enabled and scale down the segmentstore to a lower instance count, the service entries for the segmentstore were not getting deleted.

### Purpose of the change
Fixes #289 

### How to verify it
To reproduce the issue, deployed a sample Pravega Cluster with 3 segmentstore replicas and with external access enabled. Updated the number of segmentstore replicas in the spec to 1 and observed that while the extra segmentstore replicas were getting deleted, the extra segmentstore services were left behind.
```
$ kubectl get all
NAME                                                       READY   STATUS    RESTARTS   AGE
pod/pravega-bookie-0                                       1/1     Running   0          164m
pod/pravega-bookie-1                                       1/1     Running   0          164m
pod/pravega-bookie-2                                       1/1     Running   0          164m
pod/pravega-pravega-controller-fc6857f5-9429m              1/1     Running   0          164m
pod/pravega-pravega-segmentstore-0                         1/1     Running   0          164m

NAME                                            TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                          AGE
service/pravega-bookie-headless                 ClusterIP      None             <none>          3181/TCP                         164m
service/pravega-pravega-controller              LoadBalancer   10.100.200.216   10.247.113.80   10080:32657/TCP,9090:30330/TCP   164m
service/pravega-pravega-segmentstore-0          LoadBalancer   10.100.200.185   10.247.113.86   12345:30313/TCP                  164m
service/pravega-pravega-segmentstore-1          LoadBalancer   10.100.200.194   10.247.113.86   12345:30313/TCP                  164m
service/pravega-pravega-segmentstore-2          LoadBalancer   10.100.200.196   10.247.113.86   12345:30313/TCP                  164m
service/pravega-pravega-segmentstore-headless   ClusterIP      None             <none>          12345/TCP                        164m
```

Created a new operator image with the fix and tested the same scenario. This time, the extra segmentstore service entries were also deleted, as expected.
```
$ kubectl get all
NAME                                                       READY   STATUS    RESTARTS   AGE
pod/pravega-bookie-0                                       1/1     Running   0          11m
pod/pravega-bookie-1                                       1/1     Running   0          11m
pod/pravega-bookie-2                                       1/1     Running   0          11m
pod/pravega-pravega-controller-fc6857f5-4dnwg              1/1     Running   0          11m
pod/pravega-pravega-segmentstore-0                         1/1     Running   0          11m

NAME                                            TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                          AGE
service/pravega-bookie-headless                 ClusterIP      None             <none>          3181/TCP                         11m
service/pravega-pravega-controller              LoadBalancer   10.100.200.142   10.247.113.80   10080:30692/TCP,9090:30030/TCP   11m
service/pravega-pravega-segmentstore-0          LoadBalancer   10.100.200.118   10.247.113.86   12345:30313/TCP                  11m
service/pravega-pravega-segmentstore-headless   ClusterIP      None             <none>          12345/TCP                        11m
```
