### PR TITLE
Issue 307: Operator uninstall documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,13 @@ $ kubectl delete -f ./example/pvc-tier2.yaml
 
 > Note that the Pravega clusters managed by the Pravega operator will NOT be deleted even if the operator is uninstalled.
 
-If you want to delete Pravega clusters, make sure to do it before uninstalling the operator.
-
 ```
 $ helm delete foo --purge
+```
+
+If you want to delete the Pravega clusters, make sure to do it before uninstalling the operator. Also, once the Pravega cluster has been deleted, make sure to check that the zookeeper metadata has been cleaned up before proceeding with the deletion of the operator. This can be confirmed with the presence of the following log message in the operator logs.
+```
+zookeeper metadata deleted
 ```
 
 ### Manual installation

--- a/pkg/controller/pravegacluster/pravegacluster_controller.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller.go
@@ -419,6 +419,7 @@ func (r *ReconcilePravegaCluster) cleanUpZookeeperMeta(p *pravegav1alpha1.Praveg
 	if err = util.DeleteAllZnodes(p); err != nil {
 		return fmt.Errorf("failed to delete zookeeper znodes for (%s): %v", p.Name, err)
 	}
+	fmt.Println("zookeeper metadata deleted")
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Adds a log message to be printed once zookeeper metadata has been cleaned up. Also, updates the README stating that the Pravega Operator should not be deleted till this log has been printed to the operator logs indicating that the zookeeper metadata has been cleaned up.

### Purpose of the change
Fixes #307 
