### PR TITLE
issue:309 fix for webhook check failure for rollback

### DIFF
--- a/pkg/apis/pravega/v1alpha1/status.go
+++ b/pkg/apis/pravega/v1alpha1/status.go
@@ -206,6 +206,14 @@ func (ps *ClusterStatus) GetLastVersion() (previousVersion string) {
 	return ps.VersionHistory[len-1]
 }
 
+func (ps *ClusterStatus) IsClusterInErrorState() bool {
+	_, errorCondition := ps.GetClusterCondition(ClusterConditionError)
+	if errorCondition != nil && errorCondition.Status == corev1.ConditionTrue {
+		return true
+	}
+	return false
+}
+
 func (ps *ClusterStatus) IsClusterInUpgradeFailedState() bool {
 	_, errorCondition := ps.GetClusterCondition(ClusterConditionError)
 	if errorCondition == nil {

--- a/pkg/apis/pravega/v1alpha1/status.go
+++ b/pkg/apis/pravega/v1alpha1/status.go
@@ -257,6 +257,14 @@ func (ps *ClusterStatus) IsClusterInRollbackFailedState() bool {
 	return false
 }
 
+func (ps *ClusterStatus) IsClusterInReadyState() bool {
+	_, readyCondition := ps.GetClusterCondition(ClusterConditionPodsReady)
+	if readyCondition != nil && readyCondition.Status == corev1.ConditionTrue {
+		return true
+	}
+	return false
+}
+
 func (ps *ClusterStatus) UpdateProgress(reason, updatedReplicas string) {
 	if ps.IsClusterInUpgradingState() {
 		// Set the upgrade condition reason to be UpgradingBookkeeperReason, message to be 0

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -106,7 +106,7 @@ func (pwh *pravegaWebhookHandler) mutatePravegaVersion(ctx context.Context, p *p
 
 	if p.Status.IsClusterInUpgradeFailedState() {
 		if requestVersion != p.Status.GetLastVersion() {
-			return fmt.Errorf("Rollback to version %s not supported. Only rollback to previous stable version is supported.", requestVersion)
+			return fmt.Errorf("Rollback to version %s not supported. Only rollback to previous stable version %s is supported.", requestVersion, p.Status.GetLastVersion())
 		}
 	}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -104,6 +104,12 @@ func (pwh *pravegaWebhookHandler) mutatePravegaVersion(ctx context.Context, p *p
 
 	requestVersion := p.Spec.Version
 
+	if p.Status.IsClusterInUpgradeFailedState() {
+		if requestVersion != p.Status.GetLastVersion() {
+			return fmt.Errorf("Rollback to version %s not supported. Only rollback to previous stable version is supported.", requestVersion)
+		}
+	}
+
 	if p.Status.IsClusterInReadyState() {
 		// Allow upgrade only if Cluster is in Ready State
 		// Check if the request has a valid Pravega version
@@ -147,11 +153,7 @@ func (pwh *pravegaWebhookHandler) mutatePravegaVersion(ctx context.Context, p *p
 			return fmt.Errorf("unsupported upgrade from version %s to %s", foundVersion, requestVersion)
 		}
 	}
-	if p.Status.IsClusterInUpgradeFailedState() {
-		if requestVersion != p.Status.GetLastVersion() {
-			return fmt.Errorf("unsupported rollback from version %s to %s", p.Status.CurrentVersion, requestVersion)
-		}
-	}
+
 	return nil
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -106,7 +106,7 @@ func (pwh *pravegaWebhookHandler) mutatePravegaVersion(ctx context.Context, p *p
 
 	if p.Status.IsClusterInUpgradeFailedState() {
 		if requestVersion != p.Status.GetLastVersion() {
-			return fmt.Errorf("Rollback to version %s not supported. Only rollback to previous stable version %s is supported.", requestVersion, p.Status.GetLastVersion())
+			return fmt.Errorf("Rollback to version %s not supported. Only rollback version %s is supported.", requestVersion, p.Status.GetLastVersion())
 		}
 	}
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -52,8 +52,6 @@ var _ = Describe("Admission webhook", func() {
 					Namespace: Namespace,
 				},
 			}
-			p.Status.Init()
-			p.Status.SetPodsReadyConditionTrue()
 			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, p)
 		})
 
@@ -283,7 +281,6 @@ var _ = Describe("Admission webhook", func() {
 				p.Spec = v1alpha1.ClusterSpec{
 					Version: "0.5.0-001",
 				}
-				p.Status.SetPodsReadyConditionFalse()
 				p.Status.SetUpgradingConditionTrue("", "")
 				client = fake.NewFakeClient(p)
 				pwh = &pravegaWebhookHandler{client: client}
@@ -339,7 +336,6 @@ var _ = Describe("Admission webhook", func() {
 				}
 				p.Status.CurrentVersion = "0.5.0-001"
 				p.Status.Init()
-				p.Status.SetPodsReadyConditionFalse()
 				p.Status.SetErrorConditionTrue("UpgradeFailed", "some error message")
 
 				client = fake.NewFakeClient(p)
@@ -354,7 +350,7 @@ var _ = Describe("Admission webhook", func() {
 					err = pwh.clusterIsAvailable(context.TODO(), p)
 					Ω(err).Should(BeNil())
 					err = pwh.mutatePravegaManifest(context.TODO(), p)
-					Ω(err).Should(MatchError("Rollback to version 0.5.0-003 not supported. Only rollback version 0.5.0-001 is supported."))
+					Ω(err).Should(MatchError("Rollback to version 0.5.0-003 not supported. Only rollback to version 0.5.0-001 is supported."))
 				})
 
 				It("should pass if version is same as previous stable version", func() {
@@ -381,7 +377,6 @@ var _ = Describe("Admission webhook", func() {
 				}
 				p.Status.CurrentVersion = "0.5.0-001"
 				p.Status.Init()
-				p.Status.SetPodsReadyConditionFalse()
 				p.Status.SetErrorConditionTrue("Some strange reason", "some error message")
 
 				client = fake.NewFakeClient(p)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Admission webhook", func() {
 					err = pwh.clusterIsAvailable(context.TODO(), p)
 					Ω(err).Should(BeNil())
 					err = pwh.mutatePravegaManifest(context.TODO(), p)
-					Ω(err).Should(MatchError("unsupported rollback from version 0.5.0-001 to 0.5.0-003"))
+					Ω(err).Should(MatchError("Rollback to version 0.5.0-003 not supported. Only rollback to previous stable version is supported."))
 				})
 
 				It("should pass if version is same as previous stable version", func() {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Admission webhook", func() {
 					err = pwh.clusterIsAvailable(context.TODO(), p)
 					Ω(err).Should(BeNil())
 					err = pwh.mutatePravegaManifest(context.TODO(), p)
-					Ω(err).Should(MatchError("Rollback to version 0.5.0-003 not supported. Only rollback to previous stable version is supported."))
+					Ω(err).Should(MatchError("Rollback to version 0.5.0-003 not supported. Only rollback version 0.5.0-001 is supported."))
 				})
 
 				It("should pass if version is same as previous stable version", func() {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -389,7 +389,7 @@ var _ = Describe("Admission webhook", func() {
 			})
 
 			Context("Sending request when cluster in error state", func() {
-				It("should not pass if cluster in error state", func() {
+				It("should not pass if cluster is in error state", func() {
 					p.Spec = v1alpha1.ClusterSpec{
 						Version: "0.5.0-033",
 					}


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

### Change log description
When checking for values updated in the `version` field it is important to consider the cluster state and then based on that decide if the updated value is correct or not.

### Purpose of the change
Fixes #309 

### What the code does
Checks for cluster state and version validation logic changes based on cluster state.
```
if ( cluster in pods ready state)
{ version change leads to upgrade, check upgrade compatibility matrix  }
else if (cluster in upgrade failed state)
{ version change should lead to rollback if (request version != last stable cluster version) reject request }
}
```
### How to verify it
Should be able to trigger rollback when version feild is updated to `0.6.1-2419.5ae9098`
when upgrade fails from version  `0.6.0-2408.7312399` to `0.6.1-2419.5ae9098`
