### PR TITLE
Issue-322: renamed ECS config item root to prefix

### DIFF
--- a/doc/tier2.md
+++ b/doc/tier2.md
@@ -140,7 +140,7 @@ spec:
     ecs:
       uri: http://10.247.10.52:9020
       bucket: shared
-      root: "pravega/example"
+      prefix: "pravega/example"
       namespace: pravega
       credentials: ecs-secret
 ```

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -109,7 +109,7 @@ spec:
 #      ecs:
 #        uri: http://10.247.10.52:9020
 #        bucket: shared
-#        root: "pravega/example"
+#        prefix: "pravega/example"
 #        namespace: pravega
 #        credentials: ecs-credentials
 

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -297,7 +297,7 @@ type FileSystemSpec struct {
 type ECSSpec struct {
 	Uri         string `json:"uri"`
 	Bucket      string `json:"bucket"`
-	Root        string `json:"root"`
+	Prefix      string `json:"prefix"`
 	Namespace   string `json:"namespace"`
 	Credentials string `json:"credentials"`
 }

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -258,7 +258,7 @@ func getTier2StorageOptions(pravegaSpec *api.PravegaSpec) map[string]string {
 			"TIER2_STORAGE":        "EXTENDEDS3",
 			"EXTENDEDS3_BUCKET":    pravegaSpec.Tier2.Ecs.Bucket,
 			"EXTENDEDS3_URI":       pravegaSpec.Tier2.Ecs.Uri,
-			"EXTENDEDS3_ROOT":      pravegaSpec.Tier2.Ecs.Root,
+			"EXTENDEDS3_PREFIX":    pravegaSpec.Tier2.Ecs.Prefix,
 			"EXTENDEDS3_NAMESPACE": pravegaSpec.Tier2.Ecs.Namespace,
 		}
 	}

--- a/pkg/controller/pravega/pravega_segmentstore_test.go
+++ b/pkg/controller/pravega/pravega_segmentstore_test.go
@@ -108,7 +108,7 @@ var _ = Describe("PravegaSegmentstore", func() {
 							Ecs: &v1alpha1.ECSSpec{
 								Uri:         "uri",
 								Bucket:      "bucket",
-								Root:        "root",
+								Prefix:      "prefix",
 								Namespace:   "namespace",
 								Credentials: "credentials",
 							},


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

### Change log description
The ECS config item "root" is renamed to "prefix" per https://github.com/pravega/pravega/issues/4550
This is the corresponding change in operator.

### Purpose of the change
Fixes #322 

### What the code does
Replaced "root" with "prefix" in the following files:
pravega_segmentstore_test.go
cr-detailed.yaml
pravega_segmentstore.go
pravega.go
tier2.md

### How to verify it
The operator should function as usual with the new ECS config item "prefix".
