### PR TITLE
Issue-325: started using configUri for ECS tier-2

### DIFF
--- a/doc/tier2.md
+++ b/doc/tier2.md
@@ -138,7 +138,7 @@ Follow the [instructions to deploy Pravega manually](manual-installation.md#inst
 spec:
   tier2:
     ecs:
-      uri: http://10.247.10.52:9020?namespace=pravega
+      configUri: http://10.247.10.52:9020?namespace=pravega
       bucket: "shared"
       prefix: "pravega/example"
       credentials: ecs-credentials

--- a/doc/tier2.md
+++ b/doc/tier2.md
@@ -140,7 +140,7 @@ spec:
     ecs:
       configUri: http://10.247.10.52:9020?namespace=pravega
       bucket: "shared"
-      prefix: "pravega/example"
+      prefix: "example"
       credentials: ecs-credentials
 ```
 

--- a/doc/tier2.md
+++ b/doc/tier2.md
@@ -118,17 +118,17 @@ Create a file with the secret definition containing your access and secret keys.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ecs-secret
+  name: ecs-credentials
 type: Opaque
 stringData:
   ACCESS_KEY_ID: QWERTY@ecstestdrive.emc.com
   SECRET_KEY: 0123456789
 ```
 
-Assuming that the file is named `ecs-secret.yaml`.
+Assuming that the file is named `ecs-credentials.yaml`.
 
 ```
-$ kubectl create -f ecs-secret.yaml
+$ kubectl create -f ecs-credentials.yaml
 ```
 
 Follow the [instructions to deploy Pravega manually](manual-installation.md#install-the-pravega-cluster-manually) and configure the Tier 2 block in your `PravegaCluster` manifest with your ECS connection details and a reference to the secret above.
@@ -138,11 +138,10 @@ Follow the [instructions to deploy Pravega manually](manual-installation.md#inst
 spec:
   tier2:
     ecs:
-      uri: http://10.247.10.52:9020
-      bucket: shared
+      uri: http://10.247.10.52:9020?namespace=pravega
+      bucket: "shared"
       prefix: "pravega/example"
-      namespace: pravega
-      credentials: ecs-secret
+      credentials: ecs-credentials
 ```
 
 ### Use HDFS as Tier 2

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -107,10 +107,9 @@ spec:
           claimName: pravega-tier2
 
 #      ecs:
-#        uri: http://10.247.10.52:9020
+#        configUri: http://10.247.10.52:9020?namespace=pravega
 #        bucket: shared
 #        prefix: "pravega/example"
-#        namespace: pravega
 #        credentials: ecs-credentials
 
 #      hdfs:

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -108,8 +108,8 @@ spec:
 
 #      ecs:
 #        configUri: http://10.247.10.52:9020?namespace=pravega
-#        bucket: shared
-#        prefix: "pravega/example"
+#        bucket: "shared"
+#        prefix: "example"
 #        credentials: ecs-credentials
 
 #      hdfs:

--- a/pkg/apis/pravega/v1alpha1/pravega.go
+++ b/pkg/apis/pravega/v1alpha1/pravega.go
@@ -295,10 +295,9 @@ type FileSystemSpec struct {
 
 // ECSSpec contains the connection details to a Dell EMC ECS system
 type ECSSpec struct {
-	Uri         string `json:"uri"`
+	ConfigUri   string `json:"configUri"`
 	Bucket      string `json:"bucket"`
 	Prefix      string `json:"prefix"`
-	Namespace   string `json:"namespace"`
 	Credentials string `json:"credentials"`
 }
 

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -273,20 +273,19 @@ func getTier2StorageOptions(pravegaSpec *api.PravegaSpec) map[string]string {
 
 func updateECSConfigUri(pravegaSpec *api.PravegaSpec) string {
 
-	environment := []corev1.EnvFromSource{
-		{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: util.ConfigMapNameForSegmentstore(p.Name),
-				},
-			},
-		},
-	}
+    environment := []corev1.EnvFromSource{
+        {
+            ConfigMapRef: &corev1.ConfigMapEnvSource{
+                LocalObjectReference: corev1.LocalObjectReference{
+                    Name: util.ConfigMapNameForSegmentstore(p.Name),
+                },
+            },
+        },
+    }
 	environment = configureTier2Secrets(environment, pravegaSpec)
 
     u, _ := url.Parse(pravegaSpec.Tier2.Ecs.ConfigUri)
     parameters, _ := url.ParseQuery(u.RawQuery)
-    ecsCredential := retrieveECSCredential()
 
     _, identityExists := parameters["identity"]
     if !identityExists {

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -13,7 +13,6 @@ package pravega
 import (
 	"fmt"
 	"strings"
-	"net/url"
 
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/util"
@@ -76,6 +75,8 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 			},
 		},
 	}
+
+	environment = configureTier2Secrets(environment, p.Spec.Pravega)
 
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -252,9 +253,10 @@ func getTier2StorageOptions(pravegaSpec *api.PravegaSpec) map[string]string {
 	}
 
 	if pravegaSpec.Tier2.Ecs != nil {
+		// EXTENDEDS3_ACCESS_KEY_ID & EXTENDEDS3_SECRET_KEY will come from secret storage
 		return map[string]string{
 			"TIER2_STORAGE":        "EXTENDEDS3",
-			"EXTENDEDS3_CONFIGURI": updateECSConfigUri(pravegaSpec),
+			"EXTENDEDS3_CONFIGURI": pravegaSpec.Tier2.Ecs.ConfigUri,
 			"EXTENDEDS3_BUCKET":    pravegaSpec.Tier2.Ecs.Bucket,
 			"EXTENDEDS3_PREFIX":    pravegaSpec.Tier2.Ecs.Prefix,
 		}
@@ -269,35 +271,6 @@ func getTier2StorageOptions(pravegaSpec *api.PravegaSpec) map[string]string {
 	}
 
 	return make(map[string]string)
-}
-
-func updateECSConfigUri(pravegaSpec *api.PravegaSpec) string {
-
-    environment := []corev1.EnvFromSource{
-        {
-            ConfigMapRef: &corev1.ConfigMapEnvSource{
-                LocalObjectReference: corev1.LocalObjectReference{
-                    Name: util.ConfigMapNameForSegmentstore(p.Name),
-                },
-            },
-        },
-    }
-	environment = configureTier2Secrets(environment, pravegaSpec)
-
-    u, _ := url.Parse(pravegaSpec.Tier2.Ecs.ConfigUri)
-    parameters, _ := url.ParseQuery(u.RawQuery)
-
-    _, identityExists := parameters["identity"]
-    if !identityExists {
-        parameters.Add("identity", environment["EXTENDEDS3_ACCESS_KEY_ID"])
-    }
-    _, secretExists := parameters["secretKey"]
-    if !secretExists {
-        parameters.Add("secretKey", environment["EXTENDEDS3_SECRET_KEY"])
-    }
-
-    u.RawQuery = parameters.Encode()
-    return u.Scheme + "://" + u.Host + "?" + u.RawQuery
 }
 
 func configureTier2Secrets(environment []corev1.EnvFromSource, pravegaSpec *api.PravegaSpec) []corev1.EnvFromSource {

--- a/pkg/controller/pravega/pravega_segmentstore_test.go
+++ b/pkg/controller/pravega/pravega_segmentstore_test.go
@@ -106,10 +106,9 @@ var _ = Describe("PravegaSegmentstore", func() {
 						},
 						Tier2: &v1alpha1.Tier2Spec{
 							Ecs: &v1alpha1.ECSSpec{
-								Uri:         "uri",
+								ConfigUri:   "configUri",
 								Bucket:      "bucket",
 								Prefix:      "prefix",
-								Namespace:   "namespace",
 								Credentials: "credentials",
 							},
 						},


### PR DESCRIPTION
Signed-off-by: kevinhan88 <kevinhan88@gmail.com>

### Change log description
Started using configUri for ECS client side configuration

### Purpose of the change
Closes #325 

### What the code does
tier2.md, cr-detailed.yaml: rename "uri" to "configUri"; removed namespace as it should now show up as part of configUri
pravega.go, pravega_segmentstore.go, pravega_segmentstore_test.go: refactored ECSSpec struct - renamed "uri" to "configUri" and removed namespace




_(Detailed description of the code changes)_
The Pravega Operator syncs up the ECS configUri in the following way:
If "identity" and "secretKey" are present in the ECS configUri, then operator will pass the uri directly into Pravega, ignoring ecs-credentials if any;
If "identity" or "secretKey" is not present on ECS configUri, then operator will look into K8S secret. If ecs credentials are found inside k8s secret, operator will append the credentials onto configUri and pass the uri into Pravega.

If "identiy" or "secretKey" cannot be found from either configUri or secret, Pravega will eventually throw exception for the missing credentials.

### How to verify it
_(Steps to verify that the changes are effective)_
In a Pravega deployment handled by operator with ECS as tier02, the ECS credential, if not present on the configUri, will be added onto the configUri automatically. No more system properties for ECS credentials.
