### PR TITLE
Issue 324: Added testmode flag in charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 foo-pravega-operator     1         1         1            1           17s
 ```
 
-> Note:  We can run operator in testmode by passing `testmode: true` in `values.yaml` file. This will be useful if we want to run pravega on minikube or cluster with limited resources. In test mode, operator will allow us to run pravega with single bookkeeper instance.
+> Note:  The Operator can be run in a "test" mode if we want to create pravega on minikube or on a cluster with very limited resources by  enabling `testmode: true` in `vlaues.yaml` file. Operator running in test mode skips minimum replica requirement checks on Pravega components. "Test" mode ensures a bare minimum setup of pravega and is not recommended to be used in production environments.
 ### Upgrade the Operator
 Pravega operator can be upgraded by modifying the image tag using
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 foo-pravega-operator     1         1         1            1           17s
 ```
 
+> Note:  We can run operator in testmode by passing `testmode: true` in `values.yaml` file. This will be useful if we want to run pravega on minikube or cluster with limited resources. In test mode, operator will allow us to run pravega with single bookkeeper instance.
 ### Upgrade the Operator
 Pravega operator can be upgraded by modifying the image tag using
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The project is currently alpha. While no breaking API changes are currently plan
  * [Requirements](#requirements)
  * [Quickstart](#quickstart)    
     * [Install the Operator](#install-the-operator)
-       * [Deploying in Test Mode](#test-mode)
+       * [Deploying in Test Mode](#deploying-in-test-mode)
     * [Upgrade the Operator](#upgrade-the-operator)
     * [Install a sample Pravega Cluster](#install-a-sample-pravega-cluster)
     * [Scale a Pravega Cluster](#scale-a-pravega-cluster)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The project is currently alpha. While no breaking API changes are currently plan
  * [Requirements](#requirements)
  * [Quickstart](#quickstart)    
     * [Install the Operator](#install-the-operator)
+       * [Deploying in Test Mode](#test-mode)
     * [Upgrade the Operator](#upgrade-the-operator)
     * [Install a sample Pravega Cluster](#install-a-sample-pravega-cluster)
     * [Scale a Pravega Cluster](#scale-a-pravega-cluster)
@@ -60,7 +61,9 @@ NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 foo-pravega-operator     1         1         1            1           17s
 ```
 
-> Note:  The Operator can be run in a "test" mode if we want to create pravega on minikube or on a cluster with very limited resources by  enabling `testmode: true` in `vlaues.yaml` file. Operator running in test mode skips minimum replica requirement checks on Pravega components. "Test" mode ensures a bare minimum setup of pravega and is not recommended to be used in production environments.
+#### Deploying in Test Mode
+ The Operator can be run in a "test" mode if we want to create pravega on minikube or on a cluster with very limited resources by  enabling `testmode: true` in `vlaues.yaml` file. Operator running in test mode skips minimum replica requirement checks on Pravega components. "Test" mode ensures a bare minimum setup of pravega and is not recommended to be used in production environments.
+
 ### Upgrade the Operator
 Pravega operator can be upgraded by modifying the image tag using
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ foo-pravega-operator     1         1         1            1           17s
 ```
 
 #### Deploying in Test Mode
- The Operator can be run in a "test" mode if we want to create pravega on minikube or on a cluster with very limited resources by  enabling `testmode: true` in `vlaues.yaml` file. Operator running in test mode skips minimum replica requirement checks on Pravega components. "Test" mode ensures a bare minimum setup of pravega and is not recommended to be used in production environments.
+ The Operator can be run in a "test" mode if we want to create pravega on minikube or on a cluster with very limited resources by  enabling `testmode: true` in `values.yaml` file. Operator running in test mode skips minimum replica requirement checks on Pravega components. "Test" mode ensures a bare minimum setup of pravega and is not recommended to be used in production environments.
 
 ### Upgrade the Operator
 Pravega operator can be upgraded by modifying the image tag using

--- a/charts/pravega-operator/templates/operator.yaml
+++ b/charts/pravega-operator/templates/operator.yaml
@@ -23,6 +23,9 @@ spec:
           name: metrics
         command:
         - pravega-operator
+        {{- if .Values.testmode }}
+        args: [-test]
+        {{- end }}
         env:
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -19,3 +19,6 @@ serviceAccount:
 # Whether to create custom resource
 crd:
   create: true
+
+# whether to enable test mode
+testmode: false

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -30,7 +30,10 @@ Install the operator.
 $ kubectl create -f deploy/operator.yaml
 ```
 
-> Note:  We can enable testmode on operator by passing an argument `-test` in `operator.yaml` file.This will be useful if we want to run pravega on minikube or cluster with limited resources. In test mode, operator will allow us to run pravega with single bookkeeper instance.
+#### Deploying in Test Mode
+ We can enable test mode on operator by passing an argument `-test` in `operator.yaml` file. Operator running in test mode skips minimum replica requirement checks on Pravega components.We do not want to encourage users to use "test mode" as it is supposed to be used only in extreme cases where we have severe resource constraints in the environment where Pravega is being deployed.
+>Note: Pravega with a single BK, controller and SSS is not recommended and has not been tested extensively. Its just a bare minimum toy setup for Pravega.
+
 ```
 containers:
   - name: pravega-operator

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -30,6 +30,19 @@ Install the operator.
 $ kubectl create -f deploy/operator.yaml
 ```
 
+> Note:  We can enable testmode on operator by passing an argument `-test` in `operator.yaml` file.This will be useful if we want to run pravega on minikube or cluster with limited resources. In test mode, operator will allow us to run pravega with single bookkeeper instance.
+```
+containers:
+  - name: pravega-operator
+    image: pravega/pravega-operator:0.4.3-rc1
+    ports:
+    - containerPort: 60000
+      name: metrics
+    command:
+    - pravega-operator
+    imagePullPolicy: Always
+    args: [-test]
+```
 ### Set up Tier 2 Storage
 
 Pravega requires a long term storage provider known as Tier 2 storage.

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -31,7 +31,8 @@ $ kubectl create -f deploy/operator.yaml
 ```
 
 ### Deploying in Test Mode
- We can enable test mode on operator by passing an argument `-test` in `operator.yaml` file. Check out [test mode](../README.md#test-mode)
+ We can enable test mode on operator by passing an argument `-test` in `operator.yaml` file.
+ Check out [test mode](../README.md#deploying-in-test-mode)
 
 ```
 containers:

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -30,9 +30,8 @@ Install the operator.
 $ kubectl create -f deploy/operator.yaml
 ```
 
-#### Deploying in Test Mode
- We can enable test mode on operator by passing an argument `-test` in `operator.yaml` file. Operator running in test mode skips minimum replica requirement checks on Pravega components.We do not want to encourage users to use "test mode" as it is supposed to be used only in extreme cases where we have severe resource constraints in the environment where Pravega is being deployed.
->Note: Pravega with a single BK, controller and SSS is not recommended and has not been tested extensively. Its just a bare minimum toy setup for Pravega.
+### Deploying in Test Mode
+ We can enable test mode on operator by passing an argument `-test` in `operator.yaml` file. Check out [test mode](../README.md#test-mode)
 
 ```
 containers:


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Added a flag `testmode` in  `values.yaml` file, so that user can run operator in test mode if required.
Added documentation.
### Purpose of the change

Fixes #324

### What the code does

Added a flag `testmode` in  `values.yaml` file, so that user can run operator in test mode if required.
Added documentation.

### How to verify it

Able to deploy operator in `testmode` by changing `operator.yaml` file for manual installation and by changing `charts/values.yaml` for  installation via charts.
