### PR TITLE
Issue 311: Helm chart should allow watch namespace to be passed in.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         - CLUSTER_NAME="pravega-operator-travis-$(date +'%Y%m%d%H%M%S')"
         - CLUSTER_ZONE=us-west-2
         - CLUSTER_SIZE=3
-        - CLUSTER_NODE_TYPE=m5.xlarge
+        - CLUSTER_NODE_TYPE=m5.2xlarge
         - CLUSTER_NODE_GROUP=standard-workers
       install:
         - pip install --upgrade --user awscli

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         - CLUSTER_NAME="pravega-operator-travis-$(date +'%Y%m%d%H%M%S')"
         - CLUSTER_ZONE=us-west-2
         - CLUSTER_SIZE=3
-        - CLUSTER_NODE_TYPE=m5.2xlarge
+        - CLUSTER_NODE_TYPE=m5.xlarge
         - CLUSTER_NODE_GROUP=standard-workers
       install:
         - pip install --upgrade --user awscli

--- a/charts/pravega-operator/templates/clusterrole.yaml
+++ b/charts/pravega-operator/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
   - services
   - pods
   - configmaps
+  - persistentvolumeclaims
   verbs:
   - get
   - watch

--- a/charts/pravega-operator/templates/clusterrole.yaml
+++ b/charts/pravega-operator/templates/clusterrole.yaml
@@ -14,10 +14,13 @@ rules:
   - ""
   resources:
   - nodes
-  - services
   - pods
-  - configmaps
+  - services
+  - endpoints
   - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
   verbs:
   - get
   - watch

--- a/charts/pravega-operator/templates/clusterrole.yaml
+++ b/charts/pravega-operator/templates/clusterrole.yaml
@@ -14,14 +14,33 @@ rules:
   - ""
   resources:
   - nodes
+  - services
+  - pods
+  - configmaps
   verbs:
   - get
   - watch
   - list
+  - create
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - "*"
   verbs:
   - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
 {{- end }}

--- a/charts/pravega-operator/templates/operator.yaml
+++ b/charts/pravega-operator/templates/operator.yaml
@@ -28,9 +28,7 @@ spec:
         {{- end }}
         env:
         - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: "{{ .Values.watchNamespace }}"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -22,3 +22,8 @@ crd:
 
 # whether to enable test mode
 testmode: false
+
+#
+# Specifies which namespace the Operator should watch for new ClusterResource resources
+# Default: "" == Watch ALL namespaces
+watchNamespace: ""

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,9 +25,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -54,13 +54,38 @@ rules:
   - ""
   resources:
   - nodes
+  - services
+  - pods
+  - configmaps
   verbs:
   - get
   - watch
   - list
+  - create
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - "*"
   verbs:
   - '*'
+- apiGroups:
+  - pravega.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -57,6 +57,7 @@ rules:
   - services
   - pods
   - configmaps
+  - persistentvolumeclaims
   verbs:
   - get
   - watch

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -54,10 +54,13 @@ rules:
   - ""
   resources:
   - nodes
-  - services
   - pods
-  - configmaps
+  - services
+  - endpoints
   - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
   verbs:
   - get
   - watch


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
Configured `WATCH_NAMESPACE`  field in Helm charts.

### Purpose of the change

Fixes #311 

### What the code does

Added new configuration param in `values.yaml` file, so that WATCH_NAMESPACE can be configured. Added new cluster roles in pravega-operator so that it can install pravega-components in different name space ,other than the  one in which operator is running.

### How to verify it
Tried installing operator and pravega-components in same and different namespaces and deployments were successful.
