### PR TITLE
Issue 359: Updating charts to use latest operator version

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ helm install charts/pravega --name bar --set zookeeperUri=[ZOOKEEPER_HOST] --s
 where:
 
 - **[ZOOKEEPER_HOST]** is the host or IP address of your Zookeeper deployment (e.g. `zk-client:2181`). Multiple Zookeeper URIs can be specified, use a comma-separated list and DO NOT leave any spaces in between (e.g. `zk-0:2181,zk-1:2181,zk-2:2181`).
-- **[BOOKKEEPER_SVC]** is the is the name of the headless service of your Bookkeeper deployment (e.g. `pravega-bookie-0.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-1.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-2.pravega-bookie-headless.default.svc.cluster.local:3181`).
+- **[BOOKKEEPER_SVC]** is the is the name of the headless service of your Bookkeeper deployment (e.g. `pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181`).
 - **[TIER2_NAME]** is the Tier 2 `PersistentVolumeClaim` name. `pravega-tier2` if you created the PVC above.
 
 

--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -1,6 +1,6 @@
 name: pravega-operator
-version: 0.4.0
-appVersion: 0.4.0
+version: latest
+appVersion: latest
 description: pravega operator Helm chart for Kubernetes
 keywords:
 - pravega

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/pravega-operator
-  tag: 0.4.0
+  tag: latest
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings

--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -1,6 +1,6 @@
 name: pravega
-version: 0.5.0
-appVersion: 0.5.0
+version: 0.7.0
+appVersion: 0.7.0
 description: pravega Helm chart for Kubernetes
 keywords:
 - pravega

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -12,7 +12,7 @@ externalAccess:
 serviceAccount:
   name: pravega-components
 
-bookkeeperUri: "pravega-bookie-0.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-1.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-2.pravega-bookie-headless.default.svc.cluster.local:3181"
+bookkeeperUri: "pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181"
 
 pravega:
   image:

--- a/deploy/crds/pravega_v1alpha1_pravegacluster_cr.yaml
+++ b/deploy/crds/pravega_v1alpha1_pravegacluster_cr.yaml
@@ -19,7 +19,7 @@ spec:
   externalAccess:
     enabled: true
     type: LoadBalancer
-  bookkeeperUri: "pravega-bookie-0.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-1.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-2.pravega-bookie-headless.default.svc.cluster.local:3181"
+  bookkeeperUri: "pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181"
   pravega:
     controllerReplicas: 1
     segmentStoreReplicas: 3
@@ -31,7 +31,7 @@ spec:
           storage: 20Gi
     image:
       repository: pravega/pravega
-      tag: latest
+      tag: 0.7.0
       pullPolicy: IfNotPresent
     tier2:
       filesystem:

--- a/doc/rbac.md
+++ b/doc/rbac.md
@@ -2,19 +2,9 @@
 
 ### Use non-default service accounts
 
-You can optionally configure non-default service accounts for the Bookkeeper, Pravega Controller, and Pravega Segment Store pods.
+You can optionally configure non-default service accounts for Pravega Controller and Pravega Segment Store pods.
 
-For BookKeeper, set the `serviceAccountName` field under the `bookkeeper` block.
-
-```
-...
-spec:
-  bookkeeper:
-    serviceAccountName: bk-service-account
-...
-```
-
-For Pravega, set the `controllerServiceAccountName` and `segmentStoreServiceAccountName` fields under the `pravega` block.
+Set the `controllerServiceAccountName` and `segmentStoreServiceAccountName` fields under the `pravega` block.
 
 ```
 ...
@@ -88,9 +78,6 @@ pravega   28m
 ```
 $ kubectl -n pravega-io get pods -l pravega_cluster=pravega
 NAME                                          READY     STATUS    RESTARTS   AGE
-pravega-bookie-0                              1/1       Running   0          29m
-pravega-bookie-1                              1/1       Running   0          29m
-pravega-bookie-2                              1/1       Running   0          29m
 pravega-pravega-controller-6c54fdcdf5-947nw   1/1       Running   0          29m
 pravega-pravega-segmentstore-0                1/1       Running   0          29m
 pravega-pravega-segmentstore-1                1/1       Running   0          29m

--- a/doc/rollback-cluster.md
+++ b/doc/rollback-cluster.md
@@ -95,7 +95,7 @@ Status:
     Type:                  Error
     Last Update Time:      2019-09-20T10:45:12Z
     Message:               1
-    Reason:                Updating Bookkeeper
+    Reason:                Updating Segmentstore
     Status:                True
     Type:                  RollbackInProgress
 . . .
@@ -107,7 +107,6 @@ The operator rolls back components following the reverse upgrade order :
 
 1. Pravega Controller
 2. Pravega Segment Store
-3. BookKeeper
 
 A `versionHistory` field in the PravegaClusterSpec maintains the history of upgrades.
 
@@ -168,7 +167,7 @@ Status:
     Type:                  PodsReady
     Last Transition Time:  2019-09-20T09:46:24Z
     Last Update Time:      2019-09-20T09:50:57Z
-    Message:               failed to sync bookkeeper version. pod pravega-bookie-0 update failed because of ImagePullBackOff
+    Message:               failed to sync segmentstore version. pod pravega-pravega-segmentstore-0 update failed because of ImagePullBackOff
     Reason:                RollbackFailed
     Status:                True
     Type:                  Error

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -13,7 +13,7 @@ spec:
       controllerSecret: "controller-pki"
       segmentStoreSecret: "segmentstore-pki"
 
-  bookkeeperUri: "pravega-bookie-0.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-1.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-2.pravega-bookie-headless.default.svc.cluster.local:3181"
+  bookkeeperUri: "pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181"
 
   pravega:
     image:

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -98,9 +98,9 @@ type ClusterSpec struct {
 	// BookkeeperUri specifies the hostname/IP address and port in the format
 	// "hostname:port".
 	// comma delimited list of BK server URLs
-	//pravega-bookie-0.pravega-bookie-headless.default:3181,
-	//pravega-bookie-1.pravega-bookie-headless.default:3181,
-	//pravega-bookie-2.pravega-bookie-headless.default:3181
+	//pravega-bk-bookie-0.pravega-bk-bookie-headless.default:3181,
+	//pravega-bk-bookie-1.pravega-bk-bookie-headless.default:3181,
+	//pravega-bk-bookie-2.pravega-bk-bookie-headless.default:3181
 	BookkeeperUri string `json:"bookkeeperUri"`
 
 	// Pravega configuration


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Updates the pravega operator version to `latest` inside the charts repo.

### Purpose of the change
Fixes #359 

### What the code does
Updates the pravega operator version to `latest` inside the charts repo.

### How to verify it
The latest operator version should get installed when we run the following command
```
$helm install charts/pravega-operator
```
