### PR TITLE
Issue 375: Generating unique names for events

### DIFF
--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -1070,9 +1070,10 @@ func (p *PravegaCluster) PravegaTargetImage() (string, error) {
 func (p *PravegaCluster) NewEvent(name string, reason string, message string, eventType string) *corev1.Event {
 	now := metav1.Now()
 	operatorName, _ := k8s.GetOperatorName()
+	generateName := name + "-"
 	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			GenerateName: generateName,
 			Namespace: p.Namespace,
 			Labels:    p.LabelsForPravegaCluster(),
 		},

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -1074,8 +1074,8 @@ func (p *PravegaCluster) NewEvent(name string, reason string, message string, ev
 	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: generateName,
-			Namespace: p.Namespace,
-			Labels:    p.LabelsForPravegaCluster(),
+			Namespace:    p.Namespace,
+			Labels:       p.LabelsForPravegaCluster(),
 		},
 		InvolvedObject: corev1.ObjectReference{
 			APIVersion:      p.APIVersion,


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The k8s events generated by Pravega Operator do not have unique names because of which KAHM is unable to consume multiple occurences of the same event, as it can only consume events which have unique names.

### Purpose of the change
Fixes #375 

### What the code does
It uses `GenerateName` field instead of the `Name` field which suffixes the name with a unique random string.

### How to verify it
The event added to kubernetes event queue, whenever  an upgrade or rollback of the pravega cluster fails is of the following format (if u notice the name of the generated event, the last five characters are random unique characters which are suffixed to the actual name, thereby producing unique event names)
```
Name:             UPGRADE_ERROR-4gklf
Namespace:        default
Labels:           app=pravega-cluster
                  pravega_cluster=bar-pravega
Annotations:      <none>
API Version:      v1
Event Time:       <nil>
First Timestamp:  2020-04-28T04:44:54Z
Involved Object:
  API Version:       pravega.pravega.io/v1beta1
  Kind:              PravegaCluster
  Name:              bar-pravega
  Namespace:         default
  Resource Version:  965398
  UID:               140a43e8-ab9d-4bb0-93b8-5621066805d9
Kind:                Event
Last Timestamp:      2020-04-28T04:44:54Z
Message:             Error Upgrading from version 0.6.0 to 0.6.1-001. failed to sync segmentstore version. pod bar-pravega-pravega-segmentstore-0 update failed because of ImagePullBackOff
Metadata:
  Creation Timestamp:  2020-04-28T04:44:54Z
  Generate Name:       UPGRADE_ERROR-
  Resource Version:    965515
  Self Link:           /api/v1/namespaces/default/events/UPGRADE_ERROR-4gklf
  UID:                 2146e361-ea1a-49df-a869-c87d9f14be22
Reason:                Upgrade Error
Reporting Component:   foo-pravega-operator
Reporting Instance:    foo-pravega-operator-b8cbf4bc6-494qw
Source:
Type:    Error
Events:  <none>
```
