### PR TITLE
Fixed typo in the pravega.yaml file

### DIFF
--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -41,7 +41,7 @@ spec:
       resources:
         requests:
           storage: {{ .Values.pravega.cacheVolumeRequest }}
-    longTermStorage:
+    longtermStorage:
       filesystem:
         persistentVolumeClaim:
           claimName: {{ .Values.pravega.longtermStorage }}


### PR DESCRIPTION
### Change log description
Fixed typo in the pravega.yaml file

### Purpose of the change
longtermStorage had a typo in it and needed to be changed 

### What the code does
It will ensure we have correct long term storage deployed

### How to verify it
deploy pravega cluster using charts
