### PR TITLE
updated cr.yaml

### DIFF
--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -1,12 +1,12 @@
 apiVersion: "pravega.pravega.io/v1beta1"
 kind: "PravegaCluster"
 metadata:
-  name:  bar-pravega
+  name: "example"
   labels:
     app.kubernetes.io/name: "pravega-cluster"
 spec:
   version: 0.7.0
-  zookeeperUri: pravega-zk-client:2181
+  zookeeperUri: zk-client:2181
 
   # Security configurations for Pravega
   # See https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md
@@ -15,7 +15,7 @@ spec:
       controllerSecret: "controller-pki"
       segmentStoreSecret: "segmentstore-pki"
 
-  bookkeeperUri: pravega-bk-bookie-headless:3181
+  bookkeeperUri: "pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181"
 
   pravega:
     image:

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -1,7 +1,7 @@
 apiVersion: "pravega.pravega.io/v1beta1"
 kind: "PravegaCluster"
 metadata:
-  name: bar-pravega
+  name: pravega
   labels:
     app.kubernetes.io/name: "pravega-cluster"
 spec:

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -1,85 +1,83 @@
 apiVersion: "pravega.pravega.io/v1beta1"
 kind: "PravegaCluster"
 metadata:
-  name: "example"
+  name: bar-pravega
+  labels:
+    app.kubernetes.io/name: "pravega-cluster"
 spec:
   version: 0.7.0
-  zookeeperUri: zk-client:2181
-
-  # Security configurations for Pravega
-  # See https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md
-  tls:
-    static:
-      controllerSecret: "controller-pki"
-      segmentStoreSecret: "segmentstore-pki"
-
-  bookkeeperUri: "pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181"
-
+  zookeeperUri: pravega-zk-client:2181
+  externalAccess:
+    enabled: false
+    type: LoadBalancer
+  bookkeeperUri: pravega-bk-bookie-headless:3181
   pravega:
     image:
       repository: pravega/pravega
-
     controllerReplicas: 1
     controllerResources:
       requests:
-        memory: "1Gi"
+        memory: "2Gi"
         cpu: "1000m"
       limits:
         memory: "3Gi"
         cpu: "2000m"
-
     segmentStoreReplicas: 3
     segmentStoreResources:
       requests:
         memory: "4Gi"
-        cpu: "1000m"
-      limits:
-        memory: "4Gi"
         cpu: "2000m"
-
-    # Turn on Pravega Debug Logging
+      limits:
+        memory: "8Gi"
+        cpu: "4000m"
     debugLogging: false
-
+    cacheVolumeClaimTemplate:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: standard
+      resources:
+        requests:
+          storage: 20Gi
     longtermStorage:
       filesystem:
         persistentVolumeClaim:
           claimName: pravega-tier2
-
-#      ecs:
-#        configUri: http://10.247.10.52:9020?namespace=pravega
-#        bucket: "shared"
-#        prefix: "example"
-#        credentials: ecs-credentials
-
-#      hdfs:
-#        uri: hdfs://10.240.10.52:8020/
-#        root: /example
-#        replicationFactor: 3
-
-    # See https://github.com/pravega/pravega/blob/3f5b65084ae17e74c8ef8e6a40e78e61fa98737b/config/config.properties
-    # for available configuration properties
     options:
-      pravegaservice.containerCount: "4"
-      pravegaservice.cacheMaxSize: "1073741824"
-      pravegaservice.zkSessionTimeoutMs: "10000"
-      attributeIndex.readBlockSize: "1048576"
-      readIndex.storageReadAlignment: "1048576"
-      durableLog.checkpointMinCommitCount: "300"
-      bookkeeper.bkAckQuorumSize: "3"
-      metrics.dynamicCacheSize: "100000"
-      metrics.enableStatistics: "true"
-      metrics.statsdHost: "telegraph.default"
-      metrics.statsdPort: "8125"
-      # The mount dir for secrets is /etc/secret-volume
-      controller.auth.tlsEnabled: "true"
-      controller.auth.tlsCertFile: "/etc/secret-volume/controller01.pem"
-      controller.auth.tlsKeyFile: "/etc/secret-volume/controller01.key.pem"
-      controller.rest.tlsKeyStoreFile: "/etc/secret-volume/controller01.jks"
-      controller.rest.tlsKeyStorePasswordFile: "/etc/secret-volume/password"
-      pravegaservice.enableTls: "true"
-      pravegaservice.certFile: "/etc/secret-volume/segmentStore01.pem"
-      pravegaservice.keyFile: "/etc/secret-volume/segmentStore01.key.pem"
-
-    # Pass the JVM options to controller and segmentstore
-    controllerJvmOptions: ["-XX:MaxDirectMemorySize=1g"]
-    segmentStoreJVMOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]
+      bookkeeper.bkEnsembleSize:   "3"
+      bookkeeper.bkWriteQuorumSize:   "3"
+      bookkeeper.bkAckQuorumSize:   "3"
+      bookkeeper.bkWriteTimeoutMillis:   "60000"
+      bookkeeper.maxOutstandingBytes:   "33554432"
+      pravegaservice.cacheMaxSize:   '3221225472   '
+      pravegaservice.cacheMaxTimeSeconds:   "600"
+      writer.flushThresholdBytes:   "67108864"
+      writer.flushThresholdMillis:   "2000"
+      writer.maxFlushSizeBytes:   "67108864"
+      writer.minReadTimeoutMillis:   "200"
+      hdfs.blockSize:   "67108864"
+      pravegaservice.containerCount:   "32"
+      controller.containerCount:   "32"
+      pravegaservice.threadPoolSize:   "30"
+      controller.retention.bucketCount:   "10"
+      controller.service.asyncTaskPoolSize:   "20"
+      controller.retention.threadCount:   "4"
+      log.level:   INFO
+      metrics.dynamicCacheSize:   "100000"
+      metrics.enableStatistics:   "true"
+      metrics.enableStatsDReporter:   "false"
+      metrics.statsdHost:   telegraph.default
+      metrics.statsdPort:   "8125"
+      metrics.enableInfluxDBReporter:   "true"
+      metrics.outputFrequencySeconds:   "10"
+      metrics.influxDBURI:   http://172.28.60.13:8086
+      controller.metrics.dynamicCacheSize:   "100000"
+      controller.metrics.enableStatistics:   "true"
+      controller.metrics.enableStatsDReporter:   "false"
+      controller.metrics.statsdHost:   telegraph.default
+      controller.metrics.statsdPort:   "8125"
+      controller.metrics.enableInfluxDBReporter:   "true"
+      controller.metrics.outputFrequencySeconds:   "10"
+      controller.metrics.influxDBURI:   http://172.28.60.13:8086
+      controller.transaction.maxLeaseValue:  "86400000"
+    segmentStoreJVMOptions:
+    - -Xmx4g
+    - -XX:MaxDirectMemorySize=4g

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -1,83 +1,87 @@
 apiVersion: "pravega.pravega.io/v1beta1"
 kind: "PravegaCluster"
 metadata:
-  name: pravega
+  name:  bar-pravega
   labels:
     app.kubernetes.io/name: "pravega-cluster"
 spec:
   version: 0.7.0
   zookeeperUri: pravega-zk-client:2181
-  externalAccess:
-    enabled: false
-    type: LoadBalancer
+
+  # Security configurations for Pravega
+  # See https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md
+  tls:
+    static:
+      controllerSecret: "controller-pki"
+      segmentStoreSecret: "segmentstore-pki"
+
   bookkeeperUri: pravega-bk-bookie-headless:3181
+
   pravega:
     image:
       repository: pravega/pravega
+
     controllerReplicas: 1
     controllerResources:
       requests:
-        memory: "2Gi"
+        memory: "1Gi"
         cpu: "1000m"
       limits:
         memory: "3Gi"
         cpu: "2000m"
+
     segmentStoreReplicas: 3
     segmentStoreResources:
       requests:
         memory: "4Gi"
-        cpu: "2000m"
+        cpu: "1000m"
       limits:
-        memory: "8Gi"
-        cpu: "4000m"
+        memory: "4Gi"
+        cpu: "2000m"
+
+    # Turn on Pravega Debug Logging
     debugLogging: false
-    cacheVolumeClaimTemplate:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: standard
-      resources:
-        requests:
-          storage: 20Gi
+
     longtermStorage:
       filesystem:
         persistentVolumeClaim:
           claimName: pravega-tier2
+
+#      ecs:
+#        configUri: http://10.247.10.52:9020?namespace=pravega
+#        bucket: "shared"
+#        prefix: "example"
+#        credentials: ecs-credentials
+
+#      hdfs:
+#        uri: hdfs://10.240.10.52:8020/
+#        root: /example
+#        replicationFactor: 3
+
+    # See https://github.com/pravega/pravega/blob/3f5b65084ae17e74c8ef8e6a40e78e61fa98737b/config/config.properties
+    # for available configuration properties
     options:
-      bookkeeper.bkEnsembleSize:   "3"
-      bookkeeper.bkWriteQuorumSize:   "3"
-      bookkeeper.bkAckQuorumSize:   "3"
-      bookkeeper.bkWriteTimeoutMillis:   "60000"
-      bookkeeper.maxOutstandingBytes:   "33554432"
-      pravegaservice.cacheMaxSize:   '3221225472   '
-      pravegaservice.cacheMaxTimeSeconds:   "600"
-      writer.flushThresholdBytes:   "67108864"
-      writer.flushThresholdMillis:   "2000"
-      writer.maxFlushSizeBytes:   "67108864"
-      writer.minReadTimeoutMillis:   "200"
-      hdfs.blockSize:   "67108864"
-      pravegaservice.containerCount:   "32"
-      controller.containerCount:   "32"
-      pravegaservice.threadPoolSize:   "30"
-      controller.retention.bucketCount:   "10"
-      controller.service.asyncTaskPoolSize:   "20"
-      controller.retention.threadCount:   "4"
-      log.level:   INFO
-      metrics.dynamicCacheSize:   "100000"
-      metrics.enableStatistics:   "true"
-      metrics.enableStatsDReporter:   "false"
-      metrics.statsdHost:   telegraph.default
-      metrics.statsdPort:   "8125"
-      metrics.enableInfluxDBReporter:   "true"
-      metrics.outputFrequencySeconds:   "10"
-      metrics.influxDBURI:   http://172.28.60.13:8086
-      controller.metrics.dynamicCacheSize:   "100000"
-      controller.metrics.enableStatistics:   "true"
-      controller.metrics.enableStatsDReporter:   "false"
-      controller.metrics.statsdHost:   telegraph.default
-      controller.metrics.statsdPort:   "8125"
-      controller.metrics.enableInfluxDBReporter:   "true"
-      controller.metrics.outputFrequencySeconds:   "10"
-      controller.metrics.influxDBURI:   http://172.28.60.13:8086
-      controller.transaction.maxLeaseValue:  "86400000"
-    segmentStoreJVMOptions:
-    - -Xmx4g
-    - -XX:MaxDirectMemorySize=4g
+      pravegaservice.containerCount: "4"
+      pravegaservice.cacheMaxSize: "1073741824"
+      pravegaservice.zkSessionTimeoutMs: "10000"
+      attributeIndex.readBlockSize: "1048576"
+      readIndex.storageReadAlignment: "1048576"
+      durableLog.checkpointMinCommitCount: "300"
+      bookkeeper.bkAckQuorumSize: "3"
+      metrics.dynamicCacheSize: "100000"
+      metrics.enableStatistics: "true"
+      metrics.statsdHost: "telegraph.default"
+      metrics.statsdPort: "8125"
+      # The mount dir for secrets is /etc/secret-volume
+      controller.auth.tlsEnabled: "true"
+      controller.auth.tlsCertFile: "/etc/secret-volume/controller01.pem"
+      controller.auth.tlsKeyFile: "/etc/secret-volume/controller01.key.pem"
+      controller.rest.tlsKeyStoreFile: "/etc/secret-volume/controller01.jks"
+      controller.rest.tlsKeyStorePasswordFile: "/etc/secret-volume/password"
+      pravegaservice.enableTls: "true"
+      pravegaservice.certFile: "/etc/secret-volume/segmentStore01.pem"
+      pravegaservice.keyFile: "/etc/secret-volume/segmentStore01.key.pem"
+
+    # Pass the JVM options to controller and segmentstore
+    segmentStoreJVMOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]
+    controllerjvmOptions: ["-XX:MaxDirectMemorySize=1g"]

--- a/go.sum
+++ b/go.sum
@@ -781,6 +781,7 @@ gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20181126151915-b503174bad59 h1:uXjIvSvNtNUQjqpBznXm29/Ntx/6Aezf/wa0yAFryWE=
 k8s.io/api v0.0.0-20181126151915-b503174bad59/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -101,7 +101,7 @@ type PravegaSpec struct {
 	// CacheVolumeClaimTemplate is the spec to describe PVC for the Pravega cache.
 	// This field is optional. If no PVC spec, stateful containers will use
 	// emptyDir as volume
-	CacheVolumeClaimTemplate *v1.PersistentVolumeClaimSpec `json:"cacheVolumeClaimTemplate"`
+	CacheVolumeClaimTemplate *v1.PersistentVolumeClaimSpec `json:"cacheVolumeClaimTemplate,omitempty"`
 
 	// LongTermStorage is the configuration of Pravega's tier 2 storage. If no configuration
 	// is provided, it will assume that a PersistentVolumeClaim called "pravega-longterm"


### PR DESCRIPTION
### Change log description
updated cr-detailed.yaml file and made the cacheVolumeClaimTemplate optional

### Purpose of the change
To provide a sample manifest file 

### What the code does
Now the **cacheVolumeClaimTemplate**  is made optional so there is no need to provide it in case pravega version is >=0.7

### How to verify it
Deploy the manifest file  **example/cr-detailed.yaml** 