### PR TITLE
Issue 390: Segment store pvcs are not getting deleted  even after pravega cluster deletion

### DIFF
--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -53,7 +53,7 @@ func MakeSegmentStoreStatefulSet(p *api.PravegaCluster) *appsv1.StatefulSet {
 		},
 	}
 	if util.IsVersionBelow07(p.Spec.Version) {
-		statefulSet.Spec.VolumeClaimTemplates = makeCacheVolumeClaimTemplate(p.Spec.Pravega)
+		statefulSet.Spec.VolumeClaimTemplates = makeCacheVolumeClaimTemplate(p)
 	}
 	return statefulSet
 }
@@ -258,13 +258,14 @@ func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	}
 }
 
-func makeCacheVolumeClaimTemplate(pravegaSpec *api.PravegaSpec) []corev1.PersistentVolumeClaim {
+func makeCacheVolumeClaimTemplate(p *api.PravegaCluster) []corev1.PersistentVolumeClaim {
 	return []corev1.PersistentVolumeClaim{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: cacheVolumeName,
+				Name:      cacheVolumeName,
+				Namespace: p.Namespace,
 			},
-			Spec: *pravegaSpec.CacheVolumeClaimTemplate,
+			Spec: *p.Spec.Pravega.CacheVolumeClaimTemplate,
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
With the newer controller run time library, setting owner reference to cachevolume template was failing with error `failed to set ownerref: cluster-scoped resource must not have a namespace-scoped owner, owner's namespace default`. Due to which while deleting cluster pvc's are not deleted. Made the changes to create volumeclaim template in cluster namespace, so that owner reference is set correctly.

### Purpose of the change

Fixes #390

### What the code does

Created cache volumeclaims in the same namespace where pravega cluster is created

### How to verify it

Verified that owner reference is set correctly and pvcs are getting deleted while deleting cluster
