### PR TITLE
Issue 404 : Added Readiness check for controller

### DIFF
--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -100,7 +100,7 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 							Command: util.ControllerReadinessCheck(10080),
 						},
 					},
-					// Controller pods start fast. We give it up to 60 seconds to become ready.
+					// Controller pods start fast. We give it up to 20 seconds to become ready.
 					InitialDelaySeconds: 20,
 					TimeoutSeconds:      60,
 					SuccessThreshold:    3,

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -97,12 +97,13 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: util.ReadinessHealthcheckCommand(10080),
+							Command: util.ControllerReadinessCheck(10080),
 						},
 					},
 					// Controller pods start fast. We give it up to 1 minute to become ready.
-					PeriodSeconds:    5,
-					FailureThreshold: 12,
+					InitialDelaySeconds: 60,
+					TimeoutSeconds:      10,
+					SuccessThreshold:    3,
 				},
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -130,7 +131,6 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 			},
 		},
 	}
-
 	if p.Spec.Pravega.ControllerServiceAccountName != "" {
 		podSpec.ServiceAccountName = p.Spec.Pravega.ControllerServiceAccountName
 	}

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -101,7 +101,7 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 						},
 					},
 					// Controller pods start fast. We give it up to 1 minute to become ready.
-					InitialDelaySeconds: 60,
+					InitialDelaySeconds: 20,
 					TimeoutSeconds:      10,
 					SuccessThreshold:    3,
 				},

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -97,7 +97,7 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: util.HealthcheckCommand(9090),
+							Command: util.ReadinessHealthcheckCommand(10080),
 						},
 					},
 					// Controller pods start fast. We give it up to 1 minute to become ready.

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -100,9 +100,9 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 							Command: util.ControllerReadinessCheck(10080),
 						},
 					},
-					// Controller pods start fast. We give it up to 1 minute to become ready.
+					// Controller pods start fast. We give it up to 60 seconds to become ready.
 					InitialDelaySeconds: 20,
-					TimeoutSeconds:      10,
+					TimeoutSeconds:      60,
 					SuccessThreshold:    3,
 				},
 				LivenessProbe: &corev1.Probe{

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -64,6 +64,10 @@ func HealthcheckCommand(port int32) []string {
 	return []string{"/bin/sh", "-c", fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)}
 }
 
+func ReadinessHealthcheckCommand(port int32) []string {
+	return []string{"/bin/sh", "-c", fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json'", port)}
+}
+
 // Min returns the smaller of x or y.
 func Min(x, y int32) int32 {
 	if x > y {

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -64,8 +64,8 @@ func HealthcheckCommand(port int32) []string {
 	return []string{"/bin/sh", "-c", fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)}
 }
 
-func ReadinessHealthcheckCommand(port int32) []string {
-	return []string{"/bin/sh", "-c", fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'", port)}
+func ControllerReadinessCheck(port int32) []string {
+	return []string{"/bin/sh", "-c", fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep 'system'", port)}
 }
 
 // Min returns the smaller of x or y.

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -65,7 +65,7 @@ func HealthcheckCommand(port int32) []string {
 }
 
 func ReadinessHealthcheckCommand(port int32) []string {
-	return []string{"/bin/sh", "-c", fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json'", port)}
+	return []string{"/bin/sh", "-c", fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'", port)}
 }
 
 // Min returns the smaller of x or y.

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -175,8 +175,8 @@ var _ = Describe("pravegacluster", func() {
 		})
 
 	})
-	Context("ReadinessHealthcheckCommand()", func() {
-		out := ReadinessHealthcheckCommand(1234)
+	Context("ControllerReadinessCheck()", func() {
+		out := ControllerReadinessCheck(1234)
 		It("Should not be Empty", func() {
 			Ω(len(out)).ShouldNot(Equal(0))
 		})

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -175,6 +175,12 @@ var _ = Describe("pravegacluster", func() {
 		})
 
 	})
+	Context("ReadinessHealthcheckCommand()", func() {
+		out := ReadinessHealthcheckCommand(1234)
+		It("Should not be Empty", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+	})
 	Context("Min()", func() {
 
 		It("Min should be 10", func() {


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Pravega-operator marks pravega deployment as Ready before pravega is operational so a readiness check is needed to ensure pravega deployment doesn't mark pravega ready before it actually is.

### Purpose of the change
This pr fixes #404 

### What the code does
This code introduce readiness check for the controller pod and will only mark controller ready when it's actually ready and is able to create scopes and streams.

### How to verify it
1) To verify this I have deployed pravega and it marked controller in ready state only when the 
 controller is able to create stream and scopes.

2) I have also verified by deploying pravega where the controller was not able to create scope and 
 in that case, pravega deployment didn't mark the deployment ready.
