### PR TITLE
Changing default name of zookeeper service

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ $ helm install bar charts/pravega --set zookeeperUri=[ZOOKEEPER_HOST] --set book
 
 where:
 
-- **[ZOOKEEPER_HOST]** is the host or IP address of your Zookeeper deployment (e.g. `zk-client:2181`). Multiple Zookeeper URIs can be specified, use a comma-separated list and DO NOT leave any spaces in between (e.g. `zk-0:2181,zk-1:2181,zk-2:2181`).
-- **[BOOKKEEPER_SVC]** is the is the name of the headless service of your Bookkeeper deployment (e.g. `pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181`).
+- **[ZOOKEEPER_HOST]** is the host or IP address of your Zookeeper deployment (e.g. `zookeeper-client:2181`). Multiple Zookeeper URIs can be specified, use a comma-separated list and DO NOT leave any spaces in between (e.g. `zookeeper-0:2181,zookeeper-1:2181,zookeeper-2:2181`).
+- **[BOOKKEEPER_SVC]** is the is the name of the headless service of your Bookkeeper deployment (e.g. `bookkeeper-bookie-0.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-1.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-2.bookkeeper-bookie-headless.default.svc.cluster.local:3181`).
 - **[TIER2_NAME]** is the longtermStorage `PersistentVolumeClaim` name. `pravega-tier2` if you created the PVC above.
 
 

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -44,8 +44,8 @@ The following table lists the configurable parameters of the Pravega chart and t
 | `tls` | Pravega security configuration passed to the Pravega processes | `{}` |
 | `authentication.enabled` | Enable authentication to authorize client communication with Pravega | `false` |
 | `authentication.passwordAuthSecret` | Name of Secret containing Password based Authentication Parameters, if authentication is enabled | |
-| `zookeeperUri` | Zookeeper client service URI | `zk-client:2181` |
-| `bookkeeperUri` | Bookkeeper headless service URI | `pravega-bk-bookie-headless:3181` |
+| `zookeeperUri` | Zookeeper client service URI | `zookeeper-client:2181` |
+| `bookkeeperUri` | Bookkeeper headless service URI | `bookkeeper-bookie-headless:3181` |
 | `externalAccess.enabled` | Enable external access | `false` |
 | `externalAccess.type` | External access service type, if external access is enabled (LoadBalancer/NodePort) | `LoadBalancer` |
 | `externalAccess.domainName` | External access domain name, if external access is enabled  | |

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -15,8 +15,8 @@ authentication:
   ## passwordAuthSecret is ignored if authentication is disabled
   passwordAuthSecret:
 
-zookeeperUri: zk-client:2181
-bookkeeperUri: pravega-bk-bookie-headless:3181
+zookeeperUri: zookeeper-client:2181
+bookkeeperUri: bookkeeper-bookie-headless:3181
 
 externalAccess:
   enabled: false
@@ -30,8 +30,8 @@ image:
 
 hooks:
   image:
-    repository: bitnami/kubectl
-    tag: 1.16.3
+    repository: lachlanevenson/k8s-kubectl
+    tag: v1.16.10
   backoffLimit: 10
 
 debugLogging: false

--- a/deploy/crds/cr.yaml
+++ b/deploy/crds/cr.yaml
@@ -15,11 +15,11 @@ kind: "PravegaCluster"
 metadata:
   name: "pravega"
 spec:
-  zookeeperUri: zk-client:2181
+  zookeeperUri: zookeeper-client:2181
   externalAccess:
     enabled: true
     type: LoadBalancer
-  bookkeeperUri: "pravega-bookie-0.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-1.pravega-bookie-headless.default.svc.cluster.local:3181,pravega-bookie-2.pravega-bookie-headless.default.svc.cluster.local:3181"
+  bookkeeperUri: "bookkeeper-bookie-0.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-1.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-2.bookkeeper-bookie-headless.default.svc.cluster.local:3181"
   pravega:
     controllerReplicas: 1
     segmentStoreReplicas: 3

--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: "pravega-cluster"
 spec:
   version: 0.7.0
-  zookeeperUri: zk-client:2181
+  zookeeperUri: zookeeper-client:2181
 
   # Security configurations for Pravega
   # See https://github.com/pravega/pravega/blob/master/documentation/src/docs/security/pravega-security-configurations.md
@@ -15,7 +15,7 @@ spec:
       controllerSecret: "controller-pki"
       segmentStoreSecret: "segmentstore-pki"
 
-  bookkeeperUri: "pravega-bk-bookie-0.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-1.pravega-bk-bookie-headless.default.svc.cluster.local:3181,pravega-bk-bookie-2.pravega-bk-bookie-headless.default.svc.cluster.local:3181"
+  bookkeeperUri: "bookkeeper-bookie-0.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-1.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-2.bookkeeper-bookie-headless.default.svc.cluster.local:3181"
 
   pravega:
     image:

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// DefaultZookeeperUri is the default ZooKeeper URI in the form of "hostname:port"
-	DefaultZookeeperUri = "zk-client:2181"
+	DefaultZookeeperUri = "zookeeper-client:2181"
 
 	// DefaultServiceType is the default service type for external access
 	DefaultServiceType = v1.ServiceTypeLoadBalancer
@@ -74,7 +74,7 @@ func (p *PravegaCluster) WithDefaults() (changed bool) {
 type ClusterSpec struct {
 	// ZookeeperUri specifies the hostname/IP address and port in the format
 	// "hostname:port".
-	// By default, the value "zk-client:2181" is used, that corresponds to the
+	// By default, the value "zookeeper-client:2181" is used, that corresponds to the
 	// default Zookeeper service created by the Pravega Zookkeeper operator
 	// available at: https://github.com/pravega/zookeeper-operator
 	ZookeeperUri string `json:"zookeeperUri"`

--- a/pkg/apis/pravega/v1alpha1/pravegacluster_types_test.go
+++ b/pkg/apis/pravega/v1alpha1/pravegacluster_types_test.go
@@ -51,7 +51,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			Ω(changed).Should(BeTrue())
 		})
 		It("should set zookeeper uri", func() {
-			Ω(p.Spec.ZookeeperUri).Should(Equal("zk-client:2181"))
+			Ω(p.Spec.ZookeeperUri).Should(Equal("zookeeper-client:2181"))
 		})
 		It("should set external access", func() {
 			Ω(p.Spec.ExternalAccess).ShouldNot(BeNil())

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -42,7 +42,7 @@ var Mgr manager.Manager
 
 const (
 	// DefaultZookeeperUri is the default ZooKeeper URI in the form of "hostname:port"
-	DefaultZookeeperUri = "zk-client:2181"
+	DefaultZookeeperUri = "zookeeper-client:2181"
 
 	// DefaultBookkeeperUri is the default ZooKeeper URI in the form of "hostname:port"
 	DefaultBookkeeperUri = "bookkeeper-bookie-0.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-1.bookkeeper-bookie-headless.default.svc.cluster.local:3181,bookkeeper-bookie-2.bookkeeper-bookie-headless.default.svc.cluster.local:3181"
@@ -90,7 +90,7 @@ func (p *PravegaCluster) WithDefaults() (changed bool) {
 type ClusterSpec struct {
 	// ZookeeperUri specifies the hostname/IP address and port in the format
 	// "hostname:port".
-	// By default, the value "zk-client:2181" is used, that corresponds to the
+	// By default, the value "zookeeper-client:2181" is used, that corresponds to the
 	// default Zookeeper service created by the Pravega Zookkeeper operator
 	// available at: https://github.com/pravega/zookeeper-operator
 	ZookeeperUri string `json:"zookeeperUri"`

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
@@ -52,7 +52,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 		})
 
 		It("should set zookeeper uri", func() {
-			Ω(p.Spec.ZookeeperUri).Should(Equal("zk-client:2181"))
+			Ω(p.Spec.ZookeeperUri).Should(Equal("zookeeper-client:2181"))
 		})
 
 		It("should set external access", func() {

--- a/test/e2e/resources/bk-cluster.yaml
+++ b/test/e2e/resources/bk-cluster.yaml
@@ -3,7 +3,7 @@ kind: "BookkeeperCluster"
 metadata:
   name: "bookkeeper"
 spec:
-  zookeeperUri: zk-client:2181
+  zookeeperUri: zookeeper-client:2181
   envVars: bookkeeper-configmap
   image:
       repository: pravega/bookkeeper

--- a/test/e2e/resources/bk-config-map.yaml
+++ b/test/e2e/resources/bk-config-map.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   # Configuration values can be set as key-value properties
   PRAVEGA_CLUSTER_NAME: pravega
-  WAIT_FOR: zk-client:2181
+  WAIT_FOR: zookeeper-client:2181

--- a/test/e2e/resources/zookeeper.yaml
+++ b/test/e2e/resources/zookeeper.yaml
@@ -140,7 +140,7 @@ spec:
 apiVersion: "zookeeper.pravega.io/v1beta1"
 kind: "ZookeeperCluster"
 metadata:
-  name: "zk"
+  name: "zookeeper"
 spec:
   image:
     repository: "pravega/zookeeper"


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description

Modifies the default name of the zookeeper client service from `zk-client:2181` to `zookeeper-client:2181` which is the default value created by zookeeper.