### PR TITLE
Issue 394: Allowing non-valid image versions to be used in non-production environments

### DIFF
--- a/charts/pravega-operator/README.md
+++ b/charts/pravega-operator/README.md
@@ -52,7 +52,8 @@ The following table lists the configurable parameters of the Pravega operator ch
 | `rbac.create` | Create RBAC resources | `true` |
 | `serviceAccount.create` | Create service account | `true` |
 | `serviceAccount.name` | Name for the service account | `pravega-operator` |
-| `testmode` | Enable test mode | `false` |
+| `testmode.enabled` | Enable test mode | `false` |
+| `testmode.version` | Major version number of the alternate pravega image we want the operator to deploy, if test mode is enabled | `""` |
 | `webhookCert.crt` | tls.crt value corresponding to the certificate | |
 | `webhookCert.key` | tls.key value corresponding to the certificate | |
 | `webhookCert.generate` | Whether to generate the certificate and the issuer (set to false while using self-signed certificates) | `false` |

--- a/charts/pravega-operator/templates/operator.yaml
+++ b/charts/pravega-operator/templates/operator.yaml
@@ -27,7 +27,7 @@ spec:
           name: metrics
         command:
         - pravega-operator
-        {{- if .Values.testmode }}
+        {{- if .Values.testmode.enabled }}
         args: [-test]
         {{- end }}
         env:

--- a/charts/pravega-operator/templates/version_map.yaml
+++ b/charts/pravega-operator/templates/version_map.yaml
@@ -20,3 +20,6 @@ data:
         0.6.2:0.6.2,0.7.0,0.7.1
         0.7.0:0.7.0,0.7.1
         0.7.1:0.7.1
+        {{- if and .Values.testmode.enabled .Values.testmode.version }}
+        {{ .Values.testmode.version }}:{{ .Values.testmode.version }}
+        {{- end }}

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -22,7 +22,7 @@ crd:
 
 testmode:
   ## Whether to enable test mode.
-  enabled: true
+  enabled: false
   ## version of pravega that you wish to deploy
   ## mention the major version number
   ## eg. enter 0.8.0 if u wish to deploy version 0.8.0-2500.efe501a

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -20,8 +20,13 @@ serviceAccount:
 crd:
   create: true
 
-## Whether to enable test mode.
-testmode: false
+testmode:
+  ## Whether to enable test mode.
+  enabled: true
+  ## version of pravega that you wish to deploy
+  ## mention the major version number
+  ## eg. enter 0.8.0 if u wish to deploy version 0.8.0-2500.efe501a
+  version: ""
 
 webhookCert:
   crt:


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The pravega-operator should provide users a way to deploy a non-valid image version in non-production environments, since currently there doesn't seem to be any way to use the pravega-operator charts (without modifying them) to deploy pravega versions that are not already part of the version map.

### Purpose of the change
Fixes #394 

### What the code does
When test-mode is enabled in the pravega-operator, the major version that is provided by the user within `testmode.version` is added to the supported-versions configmap that is created by the operator.

### How to verify it
Provide the image version (major version number) that you wish to deploy which is not part of `version_map.yaml` by first enabling test-mode in the pravega-operator values.yaml file in the following way
```
testmode:
  enabled: true
  version: "0.8.2"
```
This adds `0.8.2` to the configmap that is created by the operator
```
$ kubectl describe cm supported-versions-map
Name:         supported-versions-map
Namespace:    default
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=pravega-operator
              app.kubernetes.io/version=0.5.1
              helm.sh/chart=pravega-operator-0.5.1
Annotations:  meta.helm.sh/release-name: pravega-operator
              meta.helm.sh/release-namespace: default

Data
====
keys:
----
0.1.0:0.1.0
0.2.0:0.2.0
0.3.0:0.3.0,0.3.1,0.3.2
0.3.1:0.3.1,0.3.2
0.3.2:0.3.2
0.4.0:0.4.0
0.5.0:0.5.0,0.5.1,0.6.0,0.6.1,0.6.2,0.7.0,0.7.1
0.5.1:0.5.1,0.6.0,0.6.1,0.6.2,0.7.0,0.7.1
0.6.0:0.6.0,0.6.1,0.6.2,0.7.0,0.7.1
0.6.1:0.6.1,0.6.2,0.7.0,0.7.1
0.6.2:0.6.2,0.7.0,0.7.1
0.7.0:0.7.0,0.7.1
0.7.1:0.7.1
0.8.2:0.8.2
```
This way, pravega-operator will be able to successfully deploy pravega version `0.8.2-xxxx.xxxx`