### PR TITLE
Issue 425: Readinesscheck for only auth added

### DIFF
--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -65,13 +65,15 @@ func HealthcheckCommand(port int32) []string {
 }
 
 func ControllerReadinessCheck(port int32, authflag bool, tlsflag bool) []string {
-	if authflag == true {
+	if authflag == true && tlsflag == true {
 		return []string{"/bin/sh", "-c", fmt.Sprintf("curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401", port)}
+	}
+	if authflag == true {
+		return []string{"/bin/sh", "-c", fmt.Sprintf("curl -v -k -u testauth:testauth -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401", port)}
 	}
 	if tlsflag == true {
 		return []string{"/bin/sh", "-c", fmt.Sprintf("curl -v -k -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep '_system'", port)}
 	}
-
 	return []string{"/bin/sh", "-c", fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'", port)}
 }
 


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>
### Change log description
ReadinessCheck in case of only auth enabled is added

### Purpose of the change
fixes #425 

### What the code does
It checks if the controller pod is ready in case only auth is enabled.

### How to verify it
Deploy pravega cluster with only Auth enabled and check for the controller pod to become ready 

