### PR TITLE
Pravega Operator API Resource Hook.

### DIFF
--- a/charts/pravega-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/pravega-operator/templates/post-install-upgrade-hooks.yaml
@@ -72,15 +72,6 @@ data:
     if [ -z "$(kubectl api-resources | grep PravegaCluster)" ]; then
         exit 1
     fi
-
-    readyReplicas=`kubectl get deployment {{ template "pravega-operator.fullname" . }} \
-      -n {{ .Release.Namespace }} \
-      -o jsonpath='{.status.readyReplicas}'`
-    echo "PravegaCluster readyReplicas: $readyReplicas"
-
-    if [ -z $readyReplicas ] || [ $readyReplicas -le 0 ]; then
-        exit 1
-    fi
 ---
 
 apiVersion: batch/v1

--- a/charts/pravega-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/pravega-operator/templates/post-install-upgrade-hooks.yaml
@@ -1,0 +1,116 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+rules:
+- apiGroups:
+  - pravega.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resources:
+  - "deployments"
+  verbs:
+  - get
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+subjects:
+- kind: ServiceAccount
+  name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+  namespace: {{.Release.Namespace}}
+roleRef:
+  kind: Role
+  name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+      "helm.sh/hook": post-install, post-upgrade
+      "helm.sh/hook-weight": "1"
+      "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+data:
+  validations.sh: |
+    #!/bin/sh
+    set -e
+    sleep 30
+
+    if [ -z "$(kubectl api-resources | grep PravegaCluster)" ]; then
+        exit 1
+    fi
+
+    readyReplicas=`kubectl get deployment {{ template "pravega-operator.fullname" . }} \
+      -n {{ .Release.Namespace }} \
+      -o jsonpath='{.status.readyReplicas}'`
+    echo "PravegaCluster readyReplicas: $readyReplicas"
+
+    if [ -z $readyReplicas ] || [ $readyReplicas -le 0 ]; then
+        exit 1
+    fi
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+    spec:
+      serviceAccountName: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+      restartPolicy: Never
+      containers:
+      - name: post-install-upgrade-job
+        image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+        command:
+          - /scripts/validations.sh
+        volumeMounts:
+          - name: sh
+            mountPath: /scripts
+            readOnly: true
+      volumes:
+        - name: sh
+          configMap:
+            name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade
+            defaultMode: 0555

--- a/charts/pravega-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/pravega-operator/templates/post-install-upgrade-hooks.yaml
@@ -84,7 +84,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 spec:
-  backoffLimit: 3
+  backoffLimit: {{ .Values.hooks.backoffLimit }}
   template:
     metadata:
       name: {{ template "pravega-operator.fullname" . }}-post-install-upgrade

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -42,7 +42,7 @@ webhookCert:
 watchNamespace: ""
 
 hooks:
+  backoffLimit: 10
   image:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.16.10
-  backoffLimit: 10

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -40,3 +40,9 @@ webhookCert:
 ## Specifies which namespace the Operator should watch over.
 ## An empty string means all namespaces.
 watchNamespace: ""
+
+hooks:
+  image:
+    repository: lachlanevenson/k8s-kubectl
+    tag: v1.16.10
+  backoffLimit: 10


### PR DESCRIPTION
### Change log description

* Adds a manifest which defines a post-install/upgrade hook to make sure the `pravegacluster` resource exists.

### Purpose of the change

* If one is unlucky with the timings when install the `pravega-operator` chart, directly followed by the `pravega` chart, the api-resource `PravegaCluster` may not exist by the time the pravega chart tries to create a `PravegaCluster`.

### What the code does

* See above.

### How to verify it

Run many install/uninstall cycles of the mentioned charts -- see that the pravega chart does not start before its resource dependency is registered.
