### PR TITLE
Issue 432: Controller Readiness probe is failing in case of ingress

### DIFF
--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -97,7 +97,7 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: util.ControllerReadinessCheck(10080, p.Spec.Authentication.IsEnabled(), p.Spec.TLS.IsSecureController()),
+							Command: util.ControllerReadinessCheck(10080, p.Spec.Authentication.IsEnabled()),
 						},
 					},
 					// Controller pods start fast. We give it up to 20 seconds to become ready.

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -65,10 +65,19 @@ func HealthcheckCommand(port int32) []string {
 }
 
 func ControllerReadinessCheck(port int32, authflag bool) []string {
+	// This is to check the readiness of controller in case auth is Enabled
+	// here we are using login credential as testtls:testtls which should
+	// not be used as auth credential and we depend on controller giving us
+	// 401 error which means controller is properly configured with auth
+	// it checks both cases when tls is enabled as well as tls dissabled
+	// with auth enabled
 	if authflag == true {
 		return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 || (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) ||  (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) || (curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 )", port, port, port, port)}
 	}
-	return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'|| (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system') ", port, port, port, port)}
+	// This is to check the readiness in case auth is not enabled
+	// and it covers both the cases with tls enabled and tls dissabled
+	// along with auth dissabled
+	return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'|| (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system') ", port, port, port, port)}
 }
 
 // Min returns the smaller of x or y.

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -69,14 +69,14 @@ func ControllerReadinessCheck(port int32, authflag bool) []string {
 	// here we are using login credential as testtls:testtls which should
 	// not be used as auth credential and we depend on controller giving us
 	// 401 error which means controller is properly configured with auth
-	// it checks both cases when tls is enabled as well as tls dissabled
+	// it checks both cases when tls is enabled as well as tls disabled
 	// with auth enabled
 	if authflag == true {
 		return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 || (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) ||  (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) || (curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 )", port, port, port, port)}
 	}
 	// This is to check the readiness in case auth is not enabled
-	// and it covers both the cases with tls enabled and tls dissabled
-	// along with auth dissabled
+	// and it covers both the cases with tls enabled and tls disabled
+	// along with auth disabled
 	return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'|| (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system') ", port, port, port, port)}
 }
 

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -64,17 +64,11 @@ func HealthcheckCommand(port int32) []string {
 	return []string{"/bin/sh", "-c", fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)}
 }
 
-func ControllerReadinessCheck(port int32, authflag bool, tlsflag bool) []string {
-	if authflag == true && tlsflag == true {
-		return []string{"/bin/sh", "-c", fmt.Sprintf("curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401", port)}
-	}
+func ControllerReadinessCheck(port int32, authflag bool) []string {
 	if authflag == true {
-		return []string{"/bin/sh", "-c", fmt.Sprintf("curl -v -k -u testauth:testauth -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401", port)}
+		return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 || (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) ||  (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) || (curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 )", port, port, port, port)}
 	}
-	if tlsflag == true {
-		return []string{"/bin/sh", "-c", fmt.Sprintf("curl -v -k -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep '_system'", port)}
-	}
-	return []string{"/bin/sh", "-c", fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'", port)}
+	return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'|| (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system') ", port, port, port, port)}
 }
 
 // Min returns the smaller of x or y.

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -64,11 +64,11 @@ func HealthcheckCommand(port int32) []string {
 	return []string{"/bin/sh", "-c", fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)}
 }
 
-//This functions check for the readiness of the controller in the following cases
-//1) Auth and TLS Enabled- in this case we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
+//This function check for the readiness of the controller in the following cases
+//1) Auth and TLS Enabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
 //2) Auth Enabled and TLS Disabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
-//3) Auth Disabled and Tls Enabled- in this case we check if the controller is able to create scopes or not by checking if _system scope is present or not
-//4) Auth and TLs Disabled- in this case we check if the controller is able to create scopes or not by checking if _system scope is present or not
+//3) Auth Disabled and TLS Enabled- in this case, we check if the controller can create scopes or not by checking if _system scope is present or not
+//4) Auth and TLS Disabled- in this case, we check if the controller can create scopes or not by checking if _system scope is present or not
 func ControllerReadinessCheck(port int32, authflag bool) []string {
 	// This is to check the readiness of controller in case auth is Enabled
 	// here we are using login credential as testtls:testtls which should

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -64,6 +64,11 @@ func HealthcheckCommand(port int32) []string {
 	return []string{"/bin/sh", "-c", fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)}
 }
 
+//This functions check for the readiness of the controller in the following cases
+//1) Auth and TLS Enabled- in this case we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
+//2) Auth Enabled and TLS Disabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
+//3) Auth Disabled and Tls Enabled- in this case we check if the controller is able to create scopes or not by checking if _system scope is present or not
+//4) Auth and TLs Disabled- in this case we check if the controller is able to create scopes or not by checking if _system scope is present or not
 func ControllerReadinessCheck(port int32, authflag bool) []string {
 	// This is to check the readiness of controller in case auth is Enabled
 	// here we are using login credential as testtls:testtls which should

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -176,19 +176,11 @@ var _ = Describe("pravegacluster", func() {
 
 	})
 	Context("ControllerReadinessCheck()", func() {
-		out := ControllerReadinessCheck(1234, true, true)
+		out := ControllerReadinessCheck(1234, true)
 		It("Should not be Empty", func() {
 			Ω(len(out)).ShouldNot(Equal(0))
 		})
-		out = ControllerReadinessCheck(1234, true, false)
-		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
-		})
-		out = ControllerReadinessCheck(1234, false, true)
-		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
-		})
-		out = ControllerReadinessCheck(1234, false, false)
+		out = ControllerReadinessCheck(1234, false)
 		It("Should not be Empty", func() {
 			Ω(len(out)).ShouldNot(Equal(0))
 		})


### PR DESCRIPTION
### Change log description
 The controller Readiness probe is failing in case of ingress

### Purpose of the change
fixes #432 

### What the code does
The code here does a readiness check for controller in the following 4 cases 
1) Auth and TLS Enabled- in this case we check for the controller is properly enabled with authentication or not and we do a get on controller and with Dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
2) Auth Enabled and TLS Disabled- in this case, we check for the controller is properly enabled with authentication or not and we do a get on controller and with Dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
3) Auth Disabled and Tls Enabled- in this case we check if the controller is able to create scopes or not by checking if system scope is present or not
4) Auth and TLs Disabled- in this case we check if the controller is able to create scopes or not by checking if system scope is present or not

### How to verify it
To verify try and check for all the above 4 cases and see if the controller pod is marked as ready or not post-deployment

### TODO
For the case of Auth, when we get an API at the pravega side which would do the check for the presence of system scope then we can probably call that in our readiness probe to solve the case of controller pod being marked ready even though it can't create scope and stream.