### PR TITLE
Issue 445: Reuse values for helm releases in post-upgrade script

### DIFF
--- a/doc/operator-upgrade.md
+++ b/doc/operator-upgrade.md
@@ -121,7 +121,7 @@ kubectl describe PravegaCluster
 ```
 Execute the script `post-upgrade.sh` inside the [scripts](https://github.com/pravega/pravega-operator/blob/master/scripts) folder. The format of the command is
 ```
-./post-upgrade.sh <PravegaCluster resource name> <PravegaCluster release name> <BookkeeperCluster release name> <version> <namespace> <zookeeper svc name>
+./post-upgrade.sh <PravegaCluster resource name> <PravegaCluster release name> <BookkeeperCluster release name> <version> <namespace> <zookeeper svc name> <bookkeeper replica count>
 ```
 This script patches the `PravegaCluster` and `BookkeeperCluster` resources with the required annotations and labels, and updates their corresponding helm releases. This script needs the following arguments
 1. Name of the PravegaCluster or BookkeeperCluster resource (check the output of `kubectl get PravegaCluster` to obtain this name).
@@ -130,6 +130,7 @@ This script patches the `PravegaCluster` and `BookkeeperCluster` resources with 
 4. Version of the PravegaCluster or BookkeeperCluster resources (check the output of `kubectl get PravegaCluster` to obtain the version number).
 5. Namespace in which PravegaCluster and BookkeeperCluster resources are deployed (this is an optional parameter and its default value is `default`).
 6. Name of the zookeeper client service (this is an optional parameter and its default value is `zookeeper-client`).
+7. Number of replicas in the BookkeeperCluster (this is an optional parameter and its default value is 3).
 
 #### Upgrade manually
 

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -36,8 +36,9 @@ To understand the valid upgrade paths for a pravega cluster, refer to the [versi
 
 The upgrade can be triggered via helm using the following command
 ```
-$ helm upgrade <pravega cluster release name> <location of modified charts> --timeout 600s
+$ helm upgrade <pravega cluster release name> <location of modified charts> --reuse-values --timeout 600s
 ```
+By specifying the `--reuse-values` option, the values of all parameters are retained across upgrades. However if some values need to be modified during the upgrade, the `--set` flag can be used to specify the new values of these parameters.
 
 ### Upgrading manually
 

--- a/scripts/post-upgrade.sh
+++ b/scripts/post-upgrade.sh
@@ -47,6 +47,6 @@ kubectl label ConfigMap $name-configmap app.kubernetes.io/managed-by=Helm -n $na
 helm repo add pravega https://charts.pravega.io
 helm repo update
 echo "Upgrading the pravega charts"
-helm upgrade $pname pravega/pravega --version=$version --set fullnameOverride=$name --set zookeeperUri="$zksvc:2181" --set bookkeeperUri="$name-bookie-headless:3181" --reuse-values
+helm upgrade $pname pravega/pravega --version=$version --set fullnameOverride=$name --set zookeeperUri="$zksvc:2181" --set bookkeeperUri="$name-bookie-headless:3181" -n $namespace --reuse-values
 echo "Installing the bookkeeper charts"
-helm install $bkname pravega/bookkeeper --version=$version --set fullnameOverride=$name --set zookeeperUri="$zksvc:2181" --set pravegaClusterName=$name --set replicas=$replicas --set options.journalDirectories="/bk/journal" --set options.ledgerDirectories="/bk/ledgers"
+helm install $bkname pravega/bookkeeper --version=$version --set fullnameOverride=$name --set zookeeperUri="$zksvc:2181" --set pravegaClusterName=$name --set replicas=$replicas --set options.journalDirectories="/bk/journal" --set options.ledgerDirectories="/bk/ledgers" -n $namespace

--- a/scripts/pre-upgrade.sh
+++ b/scripts/pre-upgrade.sh
@@ -13,3 +13,4 @@ namespace=$2
 kubectl annotate Service pravega-webhook-svc meta.helm.sh/release-name=$name -n $namespace --overwrite
 kubectl annotate Service pravega-webhook-svc meta.helm.sh/release-namespace=$namespace -n $namespace --overwrite
 kubectl label Service pravega-webhook-svc app.kubernetes.io/managed-by=Helm -n $namespace --overwrite
+kubectl delete cm pravega-operator-lock

--- a/tools/operatorUpgrade.sh
+++ b/tools/operatorUpgrade.sh
@@ -25,7 +25,7 @@ local temp_string_for_dns=pravega-webhook-svc.${namespace}
 
 sed -i "s/pravega-webhook-svc.default/${temp_string_for_dns}"/ ./manifest_files/secret.yaml
 
-#Installing the secrets 
+#Installing the secrets
 kubectl apply -f  ./manifest_files/secret.yaml
 
 #reverting the changes back in the secret.yaml file
@@ -65,9 +65,11 @@ sed -i "s/value:.*/value: $op_name "/ ./manifest_files/patch.yaml
 
 sed -i "/imagePullPolicy:.*/{n;s/name.*/name: $op_name/}" ./manifest_files/patch.yaml
 
+kubectl delete cm pravega-operator-lock
+
 #updating the operator using patch file
 kubectl patch deployment $op_name --namespace ${namespace} --type merge --patch "$(cat ./manifest_files/patch.yaml)"
 
 }
 
-UpgradingToPoperator $1 $2 $3 
+UpgradingToPoperator $1 $2 $3


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
After upgrading the pravega operator from 0.4.5 to 0.5.1 via helm, the post-upgrade script which is used to upgrade the corresponding pravega release, does not reuse the values of its parameters from the existing setup. Instead, all these parameters are reset to their default values that have been specified in the new helm charts, which is undesirable.

### Purpose of the change
Fixes #445 

### What the code does
- Accepts the bookkeeper replica count as an additional parameter in the post-upgrade script.
- Uses the `reuse-values` option while upgrading the pravega helm chart in order to preserve the properties that were set at the time of initial installation.

### How to verify it
After the operator upgrade completes, run the post-upgrade script in the following way
```
$ ./post-upgrade.sh <name of pravega cluster> <pravega release name> <bookkeeper release name> <version of pravega cluster> <namespace> <zookeeper svc name> <bookkeeper replica count>
```
After this script executes successfully, the pravega release and the newly created bookkeeper release will be created, while retaining their previous configuration.
