### PR TITLE
Issue-449: Rollback fails in case of only 1 Segment Store Pod

### DIFF
--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -212,7 +212,7 @@ func (r *ReconcilePravegaCluster) syncComponentsVersion(p *pravegav1beta1.Praveg
 		},
 	}
 
-	if p.Status.IsClusterInRollbackState() {
+	if p.Status.IsClusterInRollbackState() && p.Spec.Pravega.SegmentStoreReplicas > 1 {
 		startIndex := len(componentSyncFuncs) - 1
 		// update components in reverse order
 		for i := startIndex; i >= 0; i-- {

--- a/pkg/controller/pravegacluster/upgrade_test.go
+++ b/pkg/controller/pravegacluster/upgrade_test.go
@@ -752,7 +752,7 @@ var _ = Describe("Pravega Cluster Version Sync", func() {
 					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
 				})
 
-				It("should set rollback condition reason to UpdatingController and message to 0", func() {
+				It("should set rollback condition reason to UpdatingSegmentStore and message to 0", func() {
 					_, rollbackCondition := foundPravega.Status.GetClusterCondition(pravegav1beta1.ClusterConditionRollback)
 					Ω(rollbackCondition.Reason).Should(Equal(pravegav1beta1.UpdatingSegmentstoreReason))
 					Ω(rollbackCondition.Message).Should(Equal("0"))
@@ -770,7 +770,7 @@ var _ = Describe("Pravega Cluster Version Sync", func() {
 					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
 				})
 
-				It("should set rollback condition reason to UpdatingCOntroller and message to 0", func() {
+				It("should set rollback condition reason to UpdatingController and message to 0", func() {
 					_, rollbackCondition := foundPravega.Status.GetClusterCondition(pravegav1beta1.ClusterConditionRollback)
 					Ω(rollbackCondition.Reason).Should(Equal(pravegav1beta1.UpdatingControllerReason))
 					Ω(rollbackCondition.Message).Should(Equal("0"))

--- a/pkg/controller/pravegacluster/upgrade_test.go
+++ b/pkg/controller/pravegacluster/upgrade_test.go
@@ -754,7 +754,7 @@ var _ = Describe("Pravega Cluster Version Sync", func() {
 
 				It("should set rollback condition reason to UpdatingController and message to 0", func() {
 					_, rollbackCondition := foundPravega.Status.GetClusterCondition(pravegav1beta1.ClusterConditionRollback)
-					Ω(rollbackCondition.Reason).Should(Equal(pravegav1beta1.UpdatingControllerReason))
+					Ω(rollbackCondition.Reason).Should(Equal(pravegav1beta1.UpdatingSegmentstoreReason))
 					Ω(rollbackCondition.Message).Should(Equal("0"))
 				})
 			})
@@ -770,9 +770,9 @@ var _ = Describe("Pravega Cluster Version Sync", func() {
 					_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
 				})
 
-				It("should set rollback condition reason to UpdatingSegmentStore and message to 0", func() {
+				It("should set rollback condition reason to UpdatingCOntroller and message to 0", func() {
 					_, rollbackCondition := foundPravega.Status.GetClusterCondition(pravegav1beta1.ClusterConditionRollback)
-					Ω(rollbackCondition.Reason).Should(Equal(pravegav1beta1.UpdatingSegmentstoreReason))
+					Ω(rollbackCondition.Reason).Should(Equal(pravegav1beta1.UpdatingControllerReason))
 					Ω(rollbackCondition.Message).Should(Equal("0"))
 				})
 			})


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Rollback fails in case of only 1 Segment Store Pod

### Purpose of the change
Fixes #449 

### What the code does
This code changes the order of rollback in case of 1 ss i.e first the ss get's rollback then the controller which ensures readiness check doesn't fail and the rollback is successful.

### How to verify it
Deploy pravega with 1 ss pod and try and upgrade and fail the upgrade process then rollback the cluster and first ss should get rollback then the controller.