### PR TITLE
Issue-457: Travis build is always taking the master branch for running e2e tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ jobs:
         # ping stdout every 5 minutes or Travis kills build
         # ref: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
         - while sleep 5m; do echo hello; done &
-        - tar -czvf pravega-operator.tar.gz ../pravega-operator/
+        - cd ..
+        - tar -czvf pravega-operator.tar.gz /pravega-operator
         - curl -Lo packet-cli  https://github.com/packethost/packet-cli/releases/download/0.0.7/packet-linux-amd64 && chmod +x packet-cli && sudo mv packet-cli /usr/local/bin/
         - ssh-keygen -f ~/.ssh/id_rsa -P ""
         - pub_key=`cat ~/.ssh/id_rsa.pub`
@@ -63,15 +64,15 @@ jobs:
         - while [ "$WORKER2_STATE" != "active" ]; do WORKER2_STATE=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker2" | awk '{print $10}' | tr -d ' '`;sleep 30;done
         - CLUSTER_IP=`packet-cli device get -i $CLUSTER_ID -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
         - echo "Cluster IP is $CLUSTER_IP"
-        - scp -r pravega-operator.tar.gz  root@CLUSTER_IP:/root/
+        - scp -r pravega-operator.tar.gz  root@$CLUSTER_IP:/root/
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP /root/pravega-operator/test/e2e/resources/kubernetes_master_install.sh
         - CLUSTER_ID1=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker1" | awk '{print $2}' | tr -d ' '`
         - CLUSTER_IP1=`packet-cli device get -i $CLUSTER_ID1 -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
         - CLUSTER_ID2=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker2" | awk '{print $2}' | tr -d ' '`
         - CLUSTER_IP2=`packet-cli device get -i $CLUSTER_ID2 -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
-        - scp -r pravega-operator.tar.gz  root@CLUSTER_IP1:/root/
-        - scp -r pravega-operator.tar.gz  root@CLUSTER_IP2:/root/
+        - scp -r pravega-operator.tar.gz  root@$CLUSTER_IP1:/root/
+        - scp -r pravega-operator.tar.gz  root@$CLUSTER_IP2:/root/
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP1 "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP2 "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP1 /root/pravega-operator/test/e2e/resources/kubernetes_slave_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,15 +64,15 @@ jobs:
         - while [ "$WORKER2_STATE" != "active" ]; do WORKER2_STATE=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker2" | awk '{print $10}' | tr -d ' '`;sleep 30;done
         - CLUSTER_IP=`packet-cli device get -i $CLUSTER_ID -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
         - echo "Cluster IP is $CLUSTER_IP"
-        - scp -r pravega-operator.tar.gz  root@$CLUSTER_IP:/root/
+        - scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r pravega-operator.tar.gz  root@$CLUSTER_IP:/root/
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP /root/pravega-operator/test/e2e/resources/kubernetes_master_install.sh
         - CLUSTER_ID1=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker1" | awk '{print $2}' | tr -d ' '`
         - CLUSTER_IP1=`packet-cli device get -i $CLUSTER_ID1 -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
         - CLUSTER_ID2=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker2" | awk '{print $2}' | tr -d ' '`
         - CLUSTER_IP2=`packet-cli device get -i $CLUSTER_ID2 -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
-        - scp -r pravega-operator.tar.gz  root@$CLUSTER_IP1:/root/
-        - scp -r pravega-operator.tar.gz  root@$CLUSTER_IP2:/root/
+        - scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r pravega-operator.tar.gz  root@$CLUSTER_IP1:/root/
+        - scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r pravega-operator.tar.gz  root@$CLUSTER_IP2:/root/
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP1 "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP2 "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP1 /root/pravega-operator/test/e2e/resources/kubernetes_slave_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ jobs:
         # ping stdout every 5 minutes or Travis kills build
         # ref: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
         - while sleep 5m; do echo hello; done &
-        - cd ..
-        - tar -czvf pravega-operator.tar.gz pravega-operator
+        - cd .. && tar -czvf pravega-operator.tar.gz pravega-operator
         - curl -Lo packet-cli  https://github.com/packethost/packet-cli/releases/download/0.0.7/packet-linux-amd64 && chmod +x packet-cli && sudo mv packet-cli /usr/local/bin/
         - ssh-keygen -f ~/.ssh/id_rsa -P ""
         - pub_key=`cat ~/.ssh/id_rsa.pub`

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
         # ping stdout every 5 minutes or Travis kills build
         # ref: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
         - while sleep 5m; do echo hello; done &
+        - tar -czvf pravega-operator.tar.gz ../pravega-operator/
         - curl -Lo packet-cli  https://github.com/packethost/packet-cli/releases/download/0.0.7/packet-linux-amd64 && chmod +x packet-cli && sudo mv packet-cli /usr/local/bin/
         - ssh-keygen -f ~/.ssh/id_rsa -P ""
         - pub_key=`cat ~/.ssh/id_rsa.pub`
@@ -62,14 +63,17 @@ jobs:
         - while [ "$WORKER2_STATE" != "active" ]; do WORKER2_STATE=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker2" | awk '{print $10}' | tr -d ' '`;sleep 30;done
         - CLUSTER_IP=`packet-cli device get -i $CLUSTER_ID -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
         - echo "Cluster IP is $CLUSTER_IP"
-        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "sudo apt-get update;sudo apt-get install git -y;git clone https://github.com/pravega/pravega-operator.git; cd pravega-operator;git checkout issue-cncf-cluster"
+        - scp -r pravega-operator.tar.gz  root@CLUSTER_IP:/root/
+        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP /root/pravega-operator/test/e2e/resources/kubernetes_master_install.sh
         - CLUSTER_ID1=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker1" | awk '{print $2}' | tr -d ' '`
         - CLUSTER_IP1=`packet-cli device get -i $CLUSTER_ID1 -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
         - CLUSTER_ID2=`packet-cli device get -p 454b8b42-33d3-4e7e-8acf-1d1a5fec7e85 | grep $CLUSTER_NAME"-worker2" | awk '{print $2}' | tr -d ' '`
         - CLUSTER_IP2=`packet-cli device get -i $CLUSTER_ID2 -y | grep "\- address:" | head -1 |awk '{print $3}' | tr -d ' '`
-        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP1 "sudo apt-get update;sudo apt-get install git -y;git clone https://github.com/pravega/pravega-operator.git; cd pravega-operator;git checkout issue-cncf-cluster"
-        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP2 "sudo apt-get update;sudo apt-get install git -y;git clone https://github.com/pravega/pravega-operator.git; cd pravega-operator;git checkout issue-cncf-cluster"
+        - scp -r pravega-operator.tar.gz  root@CLUSTER_IP1:/root/
+        - scp -r pravega-operator.tar.gz  root@CLUSTER_IP2:/root/
+        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP1 "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
+        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP2 "sudo apt-get update; tar -xzvf /root/pravega-operator.tar.gz"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP1 /root/pravega-operator/test/e2e/resources/kubernetes_slave_install.sh
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP2 /root/pravega-operator/test/e2e/resources/kubernetes_slave_install.sh
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP 'kubeadm token create --print-join-command | head -2' >JOIN

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         # ref: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
         - while sleep 5m; do echo hello; done &
         - cd ..
-        - tar -czvf pravega-operator.tar.gz /pravega-operator
+        - tar -czvf pravega-operator.tar.gz pravega-operator
         - curl -Lo packet-cli  https://github.com/packethost/packet-cli/releases/download/0.0.7/packet-linux-amd64 && chmod +x packet-cli && sudo mv packet-cli /usr/local/bin/
         - ssh-keygen -f ~/.ssh/id_rsa -P ""
         - pub_key=`cat ~/.ssh/id_rsa.pub`

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,10 +57,10 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		"testCreateRecreateCluster": testCreateRecreateCluster,
-		"testScaleCluster":          testScaleCluster,
-		"testUpgradeCluster":        testUpgradeCluster,
-		"testWebhook":               testWebhook,
+		//"testCreateRecreateCluster": testCreateRecreateCluster,
+		//"testScaleCluster":          testScaleCluster,
+		"testUpgradeCluster": testUpgradeCluster,
+		//"testWebhook":               testWebhook,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,10 +57,10 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		//"testCreateRecreateCluster": testCreateRecreateCluster,
-		//"testScaleCluster":          testScaleCluster,
-		"testUpgradeCluster": testUpgradeCluster,
-		//"testWebhook":               testWebhook,
+		"testCreateRecreateCluster": testCreateRecreateCluster,
+		"testScaleCluster":          testScaleCluster,
+		"testUpgradeCluster":        testUpgradeCluster,
+		"testWebhook":               testWebhook,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -46,6 +46,7 @@ func testUpgradeCluster(t *testing.T) {
 	cluster.Spec.Version = initialVersion
 	cluster.Spec.Pravega.Image = &api.ImageSpec{
 		Repository: "pravega/pravega",
+		PullPolicy: "IfNotPresent",
 	}
 
 	pravega, err := pravega_e2eutil.CreatePravegaCluster(t, f, ctx, cluster)


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
While executing e2e tests on CNCF cluster, it is not taking the correct branch where PR is raised

### Purpose of the change
Fixes #457 

### What the code does
Following changes will ensure the travis build runs on the current branch and execute the e2e test on it

### How to verify it
Travis build should pass.