### PR TITLE
Issue300: JVM options incompatible with Java 11 environment

### DIFF
--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -36,6 +36,13 @@ This command deploys pravega on the Kubernetes cluster in its default configurat
 
 >Note: If the underlying pravega operator version is 0.4.5, bookkeeperUri should not be set, and the pravega-bk chart should be used instead of the pravega chart
 
+>Note: If the operator version is 0.5.1 or below and pravega version is 0.9.0 or above, need to set the controller and segment store Jvm options as shown below.
+```
+helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME] --set controller.jvmOptions[0]="-XX:+UseContainerSupport" --set controller.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[0]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[1]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[2]="-Xmx2g" --set segmentStore.jvmOptions[3]="-XX:MaxDirectMemorySize=2g"
+```
+Based on the cluster flavours selected ,segementstore memory requirements needs to be adjusted.
+
+
 ## Uninstalling the Chart
 
 To uninstall/delete the pravega chart, use the following command:

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -36,7 +36,7 @@ This command deploys pravega on the Kubernetes cluster in its default configurat
 
 >Note: If the underlying pravega operator version is 0.4.5, bookkeeperUri should not be set, and the pravega-bk chart should be used instead of the pravega chart
 
->Note: If the operator version is 0.5.1 or below and pravega version is 0.9.0 or above, need to set the controller and segment store Jvm options as shown below.
+>Note: If the operator version is 0.5.1 or below and pravega version is 0.9.0 or above, need to set the controller and segment store JVM options as shown below.
 ```
 helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME] --set 'controller.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions}' --set 'segmentStore.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions,-Xmx2g,-XX:MaxDirectMemorySize=2g}'
 ```

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -38,9 +38,9 @@ This command deploys pravega on the Kubernetes cluster in its default configurat
 
 >Note: If the operator version is 0.5.1 or below and pravega version is 0.9.0 or above, need to set the controller and segment store Jvm options as shown below.
 ```
-helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME] --set controller.jvmOptions[0]="-XX:+UseContainerSupport" --set controller.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[0]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[1]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[2]="-Xmx2g" --set segmentStore.jvmOptions[3]="-XX:MaxDirectMemorySize=2g"
+helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME] --set controller.jvmOptions[0]="-XX:+UseContainerSupport" --set controller.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[0]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[2]="-Xmx2g" --set segmentStore.jvmOptions[3]="-XX:MaxDirectMemorySize=2g"
 ```
-Based on the cluster flavours selected ,segementstore memory requirements needs to be adjusted.
+Based on the cluster flavours selected,segmentstore memory requirements needs to be adjusted.
 
 
 ## Uninstalling the Chart

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -38,7 +38,7 @@ This command deploys pravega on the Kubernetes cluster in its default configurat
 
 >Note: If the operator version is 0.5.1 or below and pravega version is 0.9.0 or above, need to set the controller and segment store Jvm options as shown below.
 ```
-helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME]--set 'controller.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions}' --set 'segmentStore.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions,-Xmx2g,-XX:MaxDirectMemorySize=2g}'
+helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME] --set 'controller.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions}' --set 'segmentStore.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions,-Xmx2g,-XX:MaxDirectMemorySize=2g}'
 ```
 Based on the cluster flavours selected,segmentstore memory requirements needs to be adjusted.
 

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -38,7 +38,7 @@ This command deploys pravega on the Kubernetes cluster in its default configurat
 
 >Note: If the operator version is 0.5.1 or below and pravega version is 0.9.0 or above, need to set the controller and segment store Jvm options as shown below.
 ```
-helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME] --set controller.jvmOptions[0]="-XX:+UseContainerSupport" --set controller.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[0]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[2]="-Xmx2g" --set segmentStore.jvmOptions[3]="-XX:MaxDirectMemorySize=2g"
+helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperUri=[ZOOKEEPER_HOST] --set bookkeeperUri=[BOOKKEEPER_SVC] --set storage.longtermStorage.filesystem.pvc=[TIER2_NAME]--set 'controller.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions}' --set 'segmentStore.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions,-Xmx2g,-XX:MaxDirectMemorySize=2g}'
 ```
 Based on the cluster flavours selected,segmentstore memory requirements needs to be adjusted.
 

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -116,7 +116,7 @@ NAME      VERSION   DESIRED MEMBERS   READY MEMBERS   AGE
 pravega   0.7.0     4                 0               25s
 ```
 
-**Note:** If we are installing pravega version 0.9.0 or above using operators 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
+**Note:** If we are installing pravega version 0.9.0 or above using operator version 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
 ```
 segmentStoreJVMOptions: ["-XX:+UseContainerSupport","-XX:+IgnoreUnrecognizedVMOptions"]
 

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -116,6 +116,13 @@ NAME      VERSION   DESIRED MEMBERS   READY MEMBERS   AGE
 pravega   0.7.0     4                 0               25s
 ```
 
+**Note:** If we are installing pravega version 0.9.0 or above using operators 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
+```
+segmentStoreJVMOptions: ["-XX:+UseContainerSupport","-XX:+IgnoreUnrecognizedVMOptions"]
+
+controllerjvmOptions: ["-XX:+UseContainerSupport","-XX:+IgnoreUnrecognizedVMOptions"]
+```
+
 ### Uninstall the Pravega cluster manually
 
 ```

--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -41,7 +41,7 @@ Default Controller JVM Options
 if Pravega version is greater or equal 0.4, then the followings are also added to the default Controller JVM Options
 ```
 "-XX:+UnlockExperimentalVMOptions",
-"-XX:+UseCGroupMemoryLimitForHeap",
+"-XX:+UseContainerSupport",
 "-XX:MaxRAMFraction=2"
 ```
 
@@ -56,7 +56,7 @@ Default Segmenstore JVM Options
 if Pravega version is greater or equal to 0.4, then the followings are also added to the default Segmenstore JVM Options
 ```
 "-XX:+UnlockExperimentalVMOptions",
-"-XX:+UseCGroupMemoryLimitForHeap",
+"-XX:+UseContainerSupport",
 "-XX:MaxRAMFraction=2"
 ```
 

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -40,7 +40,7 @@ $ helm upgrade [PRAVEGA_RELEASE_NAME] pravega/pravega --version=[NEW_VERSION] --
 ```
 **Note:** By specifying the `--reuse-values` option, the configuration of all parameters are retained across upgrades. However if some values need to be modified during the upgrade, the `--set` flag can be used to specify the new configuration for these parameters. Also, by skipping the `reuse-values` flag, the values of all parameters are reset to the default configuration that has been specified in the published charts for version [NEW_VERSION].
 
-**Note:** If the operator version is 0.5.1 or below and we are upgrading pravega version to 0.9.0 or above, we have to set controller and segmentstore Jvm options as follows.
+**Note:** If the operator version is 0.5.1 or below and we are upgrading pravega version to 0.9.0 or above, we have to set controller and segmentstore JVM options as follows.
 
 ```
 $ helm upgrade [PRAVEGA_RELEASE_NAME] pravega/pravega --version=[NEW_VERSION] --set version=[NEW_VERSION] --set 'controller.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions}' --set 'segmentStore.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions,-Xmx2g,-XX:MaxDirectMemorySize=2g}'  --reuse-values --timeout 600s

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -40,6 +40,13 @@ $ helm upgrade [PRAVEGA_RELEASE_NAME] pravega/pravega --version=[NEW_VERSION] --
 ```
 **Note:** By specifying the `--reuse-values` option, the configuration of all parameters are retained across upgrades. However if some values need to be modified during the upgrade, the `--set` flag can be used to specify the new configuration for these parameters. Also, by skipping the `reuse-values` flag, the values of all parameters are reset to the default configuration that has been specified in the published charts for version [NEW_VERSION].
 
+**Note:** If the operator version is 0.5.1 or below and we are upgrading pravega version to 0.9.0 or above, we have to set controller and segmentstore Jvm options as follows.
+
+```
+$ helm upgrade [PRAVEGA_RELEASE_NAME] pravega/pravega --version=[NEW_VERSION] --set version=[NEW_VERSION] --set controller.jvmOptions[0]="-XX:+UseContainerSupport" --set controller.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[0]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[1]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[2]="-Xmx2g" --set segmentStore.jvmOptions[3]="-XX:MaxDirectMemorySize=2g" --reuse-values --timeout 600s
+```
+Based on the cluster flavours selected ,segementstore memory requirements needs to be adjusted.
+
 ### Upgrading manually
 
 To initiate the upgrade process manually, a user has to update the `spec.version` field on the `PravegaCluster` custom resource. This can be done in three different ways using the `kubectl` command.
@@ -86,6 +93,12 @@ To summarize the way in which the segmentstore pod memory is distributed:
 ```
 POD_MEM_LIMIT = JVM Heap + Direct Memory
 Direct Memory = pravegaservice.cache.size.max + 1GB/2GB (other uses)
+```
+**Note:** If we are upgrading pravega version to 0.9 or above using operators 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
+```
+segmentStoreJVMOptions: ["-XX:+UseContainerSupport","-XX:+IgnoreUnrecognizedVMOptions"]
+
+controllerjvmOptions: ["-XX:+UseContainerSupport","-XX:+IgnoreUnrecognizedVMOptions"]
 ```
 
 ## Upgrade process

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -43,9 +43,9 @@ $ helm upgrade [PRAVEGA_RELEASE_NAME] pravega/pravega --version=[NEW_VERSION] --
 **Note:** If the operator version is 0.5.1 or below and we are upgrading pravega version to 0.9.0 or above, we have to set controller and segmentstore Jvm options as follows.
 
 ```
-$ helm upgrade [PRAVEGA_RELEASE_NAME] pravega/pravega --version=[NEW_VERSION] --set version=[NEW_VERSION] --set controller.jvmOptions[0]="-XX:+UseContainerSupport" --set controller.jvmOptions[1]="-XX:+IgnoreUnrecognizedVMOptions" --set segmentStore.jvmOptions[0]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[1]="-XX:+UseContainerSupport" --set segmentStore.jvmOptions[2]="-Xmx2g" --set segmentStore.jvmOptions[3]="-XX:MaxDirectMemorySize=2g" --reuse-values --timeout 600s
+$ helm upgrade [PRAVEGA_RELEASE_NAME] pravega/pravega --version=[NEW_VERSION] --set version=[NEW_VERSION] --set 'controller.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions}' --set 'segmentStore.jvmOptions={-XX:+UseContainerSupport,-XX:+IgnoreUnrecognizedVMOptions,-Xmx2g,-XX:MaxDirectMemorySize=2g}'  --reuse-values --timeout 600s
 ```
-Based on the cluster flavours selected ,segementstore memory requirements needs to be adjusted.
+Based on the cluster flavours selected,segmentstore memory requirements needs to be adjusted.
 
 ### Upgrading manually
 
@@ -94,7 +94,7 @@ To summarize the way in which the segmentstore pod memory is distributed:
 POD_MEM_LIMIT = JVM Heap + Direct Memory
 Direct Memory = pravegaservice.cache.size.max + 1GB/2GB (other uses)
 ```
-**Note:** If we are upgrading pravega version to 0.9 or above using operators 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
+**Note:** If we are upgrading pravega version to 0.9 or above using operator version 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
 ```
 segmentStoreJVMOptions: ["-XX:+UseContainerSupport","-XX:+IgnoreUnrecognizedVMOptions"]
 

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -190,7 +190,7 @@ func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		// Pravega < 0.4 uses a Java version that does not support the options below
 		jvmOpts = append(jvmOpts,
 			"-XX:+UnlockExperimentalVMOptions",
-			"-XX:+UseCGroupMemoryLimitForHeap",
+			"-XX:+UseContainerSupport",
 			"-XX:MaxRAMFraction=2",
 		)
 	}

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -210,7 +210,7 @@ func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		// Pravega < 0.4 uses a Java version that does not support the options below
 		jvmOpts = append(jvmOpts,
 			"-XX:+UnlockExperimentalVMOptions",
-			"-XX:+UseCGroupMemoryLimitForHeap",
+			"-XX:+UseContainerSupport",
 			"-XX:MaxRAMFraction=2",
 		)
 	}


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Removed the deprecated JVM option `UseCGroupMemoryLimitForHeap` and replaced with `UseContainerSupport`
### Purpose of the change

 Fixes #300

### What the code does
Replaced the deprecated JVM option and made documentation changes.

### How to verify it

Install pravega 0.9.0 using 0.5.1 operator by setting IgnoreUnrecognizedVMOptions
Install pravega 0.9.0 using 0.5.2 operator 