### PR TITLE
issue-464:Added support for JvmOption customization

### DIFF
--- a/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
@@ -11,6 +11,8 @@
 package v1beta1_test
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -95,6 +97,221 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			Ω(p.Spec.ExternalAccess.DomainName).Should(Equal(""))
 		})
 	})
+
+	Context("ValidatePravegaVersion", func() {
+		var (
+			p     *v1beta1.PravegaCluster
+			file1 *os.File
+		)
+		BeforeEach(func() {
+			p = &v1beta1.PravegaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			}
+			p.WithDefaults()
+			file1, _ = os.Create("filename")
+			file1, _ = os.OpenFile("filename", os.O_RDWR, 0644)
+			file1.WriteString("0.1.0:0.1.0 \n")
+			file1.WriteString("0.2.0:0.2.0 \n")
+			file1.WriteString("0.3.0:0.3.0,0.3.1,0.3.2 \n")
+			file1.WriteString("0.3.1:0.3.1,0.3.2 \n")
+			file1.WriteString("0.4.0:0.4.0 \n")
+			file1.WriteString("0.5.0:0.5.0,0.5.1,0.6.0,0.6.1,0.6.2,0.7.0,0.7.1 \n")
+			file1.WriteString("0.5.1:0.5.1,0.6.0,0.6.1,0.6.2,0.7.0,0.7.1 \n")
+			file1.WriteString("0.6.0:0.6.0,0.6.1,0.6.2,0.7.0,0.7.1 \n")
+			file1.WriteString("0.6.1:0.6.1,0.6.2,0.7.0,0.7.1  \n")
+			file1.WriteString("0.6.2:0.6.2,0.7.0,0.7.1 \n")
+			file1.WriteString("0.7.0:0.7.0,0.7.1 \n")
+			file1.WriteString("0.7.1:0.7.1 \n")
+			file1.WriteString("0.7.2:0.7.1 \n")
+		})
+		Context("Spec version empty", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Spec.Version = ""
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return nil", func() {
+				Ω(err).To(BeNil())
+			})
+		})
+		Context("Version not in valid format", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Spec.Version = "999"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "request version is not in valid format")).Should(Equal(true))
+			})
+		})
+
+		Context("Version not supported", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Spec.Version = "0.9.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "unsupported Bookkeeper cluster version")).Should(Equal(true))
+			})
+		})
+		Context("Spec version and current version same", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Spec.Version = "0.7.0"
+				p.Status.CurrentVersion = "0.7.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return nil", func() {
+				Ω(err).To(BeNil())
+			})
+		})
+		Context("Unsupported current version", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Spec.Version = "0.7.0"
+				p.Status.CurrentVersion = "0.9.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "failed to find current cluster version in the supported versions")).Should(Equal(true))
+			})
+
+		})
+		Context("current version not in correct format", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Spec.Version = "0.7.0"
+				p.Status.CurrentVersion = "999"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "found version is not in valid format")).Should(Equal(true))
+			})
+
+		})
+		Context("unsupported upgrade to a version", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Status.CurrentVersion = "0.7.0"
+				p.Spec.Version = "0.7.2"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "unsupported upgrade from version")).Should(Equal(true))
+			})
+
+		})
+		Context("supported upgrade to a version", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Status.CurrentVersion = "0.7.0"
+				p.Spec.Version = "0.7.1"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return nil", func() {
+				Ω(err).To(BeNil())
+			})
+		})
+		Context("validation while cluster upgrade in progress", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Status.SetUpgradingConditionTrue(" ", " ")
+				p.Spec.Version = "0.7.1"
+				p.Status.TargetVersion = "0.7.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "failed to process the request, cluster is upgrading")).Should(Equal(true))
+			})
+		})
+		Context("validation while cluster rollback in progress", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Status.CurrentVersion = "0.7.0"
+				p.Status.Init()
+				p.Status.AddToVersionHistory("0.6.0")
+				p.Status.SetRollbackConditionTrue(" ", " ")
+				p.Spec.Version = "0.7.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "failed to process the request, rollback in progress")).Should(Equal(true))
+			})
+		})
+		Context("validation while cluster in error state", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Status.SetErrorConditionTrue("some err", " ")
+				p.Spec.Version = "0.7.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "failed to process the request, cluster is in error state")).Should(Equal(true))
+			})
+		})
+		Context("validation while cluster in upgradefailed state", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Status.CurrentVersion = "0.7.0"
+				p.Status.Init()
+				p.Status.AddToVersionHistory("0.6.0")
+				p.Status.SetErrorConditionTrue("UpgradeFailed", " ")
+				p.Spec.Version = "0.7.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "Rollback to version 0.7.0 not supported")).Should(Equal(true))
+			})
+		})
+		Context("validation while cluster in upgradefailed state and supported rollback version", func() {
+			var (
+				err error
+			)
+			BeforeEach(func() {
+				p.Status.CurrentVersion = "0.6.0"
+				p.Status.Init()
+				p.Status.AddToVersionHistory("0.6.0")
+				p.Status.SetErrorConditionTrue("UpgradeFailed", " ")
+				p.Spec.Version = "0.6.0"
+				err = p.ValidatePravegaVersion("filename")
+			})
+			It("should return nil", func() {
+				Ω(err).To(BeNil())
+			})
+		})
+		AfterEach(func() {
+			file1.Close()
+			os.Remove("filename")
+		})
+	})
+
 	Context("Setting TLS and Autentication to nil", func() {
 		BeforeEach(func() {
 			p.Spec.Version = "0.6.0"

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -12,6 +12,7 @@ package pravega
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
@@ -200,6 +201,8 @@ func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	for name, value := range p.Spec.Pravega.Options {
 		javaOpts = append(javaOpts, fmt.Sprintf("-D%v=%v", name, value))
 	}
+
+	sort.Strings(javaOpts)
 
 	authEnabledStr := fmt.Sprint(p.Spec.Authentication.IsEnabled())
 	configData := map[string]string{

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -12,6 +12,7 @@ package pravega
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
@@ -220,6 +221,9 @@ func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 	for name, value := range p.Spec.Pravega.Options {
 		javaOpts = append(javaOpts, fmt.Sprintf("-D%v=%v", name, value))
 	}
+
+	sort.Strings(javaOpts)
+
 	authEnabledStr := fmt.Sprint(p.Spec.Authentication.IsEnabled())
 	configData := map[string]string{
 		"AUTHORIZATION_ENABLED": authEnabledStr,

--- a/pkg/controller/pravegacluster/pravegacluster_controller.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller.go
@@ -511,8 +511,11 @@ func (r *ReconcilePravegaCluster) restartPod(podList *corev1.PodList) error {
 		if err != nil {
 			return err
 		} else {
-			time.Sleep(10 * time.Second)
 			pod := &corev1.Pod{}
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: podItem.ObjectMeta.Name, Namespace: podItem.ObjectMeta.Namespace}, pod)
+			for util.IsPodReady(pod) {
+				err = r.client.Get(context.TODO(), types.NamespacedName{Name: podItem.ObjectMeta.Name, Namespace: podItem.ObjectMeta.Namespace}, pod)
+			}
 			err = r.client.Get(context.TODO(), types.NamespacedName{Name: podItem.ObjectMeta.Name, Namespace: podItem.ObjectMeta.Namespace}, pod)
 			for !util.IsPodReady(pod) {
 				err = r.client.Get(context.TODO(), types.NamespacedName{Name: podItem.ObjectMeta.Name, Namespace: podItem.ObjectMeta.Namespace}, pod)

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -48,7 +48,6 @@ func IsVersionBelow07(ver string) bool {
 }
 
 func CompareConfigMap(cm1 *corev1.ConfigMap, cm2 *corev1.ConfigMap) bool {
-
 	eq := reflect.DeepEqual(cm1.Data, cm2.Data)
 	if eq {
 		return true

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -12,6 +12,7 @@ package util
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -41,6 +42,15 @@ func IsVersionBelow07(ver string) bool {
 	}
 	result, _ := CompareVersions(ver, "0.7.0", "<")
 	if result {
+		return true
+	}
+	return false
+}
+
+func CompareConfigMap(cm1 *corev1.ConfigMap, cm2 *corev1.ConfigMap) bool {
+
+	eq := reflect.DeepEqual(cm1.Data, cm2.Data)
+	if eq {
 		return true
 	}
 	return false

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -258,6 +259,48 @@ var _ = Describe("pravegacluster", func() {
 
 		})
 	})
+	Context("CompareConfigMap", func() {
+		var output1, output2 bool
+		BeforeEach(func() {
+			configData1 := map[string]string{
+				"TEST_DATA": "testdata",
+			}
+			configData2 := map[string]string{
+				"TEST_DATA": "testdata1",
+			}
+			configMap1 := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: configData1,
+			}
+			configMap2 := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: configData1,
+			}
+			configMap3 := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: configData2,
+			}
+			output1 = CompareConfigMap(configMap1, configMap2)
+			output2 = CompareConfigMap(configMap1, configMap3)
+		})
+
+		It("output1 should be true", func() {
+			Ω(output1).To(Equal(true))
+		})
+		It("output2 should be false", func() {
+			Ω(output2).To(Equal(false))
+		})
+	})
+
 	Context("GetPodVersion", func() {
 		var out string
 		BeforeEach(func() {
@@ -272,5 +315,4 @@ var _ = Describe("pravegacluster", func() {
 			Ω(out).To(Equal("0.7.0"))
 		})
 	})
-
 })

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	pravega_e2eutil "github.com/pravega/pravega-operator/pkg/test/e2e/e2eutil"
+)
+
+func testCMUpgradeCluster(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	doCleanup := true
+	ctx := framework.NewTestCtx(t)
+	defer func() {
+		if doCleanup {
+			ctx.Cleanup()
+		}
+	}()
+
+	namespace, err := ctx.GetNamespace()
+	g.Expect(err).NotTo(HaveOccurred())
+	f := framework.Global
+
+	//creating the setup for running the test
+	err = pravega_e2eutil.InitialSetup(t, f, ctx, namespace)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cluster := pravega_e2eutil.NewDefaultCluster(namespace)
+
+	cluster.WithDefaults()
+
+	pravega, err := pravega_e2eutil.CreatePravegaCluster(t, f, ctx, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// A default Pravega cluster should have 2 pods:  1 controller, 1 segment store
+	podSize := 2
+	err = pravega_e2eutil.WaitForPravegaClusterToBecomeReady(t, f, ctx, pravega, podSize)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// This is to get the latest Pravega cluster object
+	pravega, err = pravega_e2eutil.GetPravegaCluster(t, f, ctx, pravega)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	//updating pravega option
+	pravega.Spec.Pravega.Options["bookkeeper.bkAckQuorumSize"] = "2"
+
+	//updating pravegacluster
+	err = pravega_e2eutil.UpdatePravegaCluster(t, f, ctx, pravega)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	//checking if the upgrade of options was successfull
+	err = pravega_e2eutil.WaitForCMPravegaClusterToUpgrade(t, f, ctx, pravega)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Delete cluster
+	err = pravega_e2eutil.DeletePravegaCluster(t, f, ctx, pravega)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// No need to do cleanup since the cluster CR has already been deleted
+	doCleanup = false
+
+	err = pravega_e2eutil.WaitForPravegaClusterToTerminate(t, f, ctx, pravega)
+	g.Expect(err).NotTo(HaveOccurred())
+
+}

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -63,7 +63,7 @@ func testCMUpgradeCluster(t *testing.T) {
 	err = pravega_e2eutil.UpdatePravegaCluster(t, f, ctx, pravega)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	//checking if the upgrade of options was successfull
+	//checking if the upgrade of options was successful
 	err = pravega_e2eutil.WaitForCMPravegaClusterToUpgrade(t, f, ctx, pravega)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -77,7 +77,7 @@ func testCMUpgradeCluster(t *testing.T) {
 	//updating pravegacluster
 	err = pravega_e2eutil.UpdatePravegaCluster(t, f, ctx, pravega)
 
-	//should give an errors
+	//should give an error
 	g.Expect(strings.ContainsAny(err.Error(), "controller.containerCount should not be changed")).To(Equal(true))
 
 	// Delete cluster

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -61,6 +61,7 @@ func testPravegaCluster(t *testing.T) {
 		"testScaleCluster":          testScaleCluster,
 		"testUpgradeCluster":        testUpgradeCluster,
 		"testWebhook":               testWebhook,
+		"testCMUpgradeCluster":      testCMUpgradeCluster,
 	}
 
 	for name, f := range testFuncs {


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
This pr will enable the user to modify both controller and sgmentstore JVMOptions as well as options during runtime

### Purpose of the change
Fixes #464 

### What the code does
The code looks for any change in the jvm option or option in either of controller or segmentstore and if there is a change i.e user has changed any of the jvmOptions or options or has added a new value, in that case, we update the configmap and restart each pod one by one.
I am doing validation as well and is done by the method **validateConfigMap()** which ensures user doesn't change any of the following values:-
1) controller.containerCount
2) controller.container.count
3) pravegaservice.containerCount
4) pravegaservice.container.count
5) bookkeeper.bkLedgerPath
6) bookkeeper.ledger.path
7) controller.retention.bucketCount
8) controller.retention.bucket.count
9) controller.watermarking.bucketCount
10) controller.watermarking.bucket.count
11) pravegaservice.dataLogImplementation
12) pravegaservice.dataLog.impl.name
13) pravegaservice.storageImplementation
14) pravegaservice.storage.impl.name
15) storageextra.storageNoOpMode
16) storageextra.noOp.mode.enable

### How to verify it
1) Deploy Pravega cluster and update segmentstore JVM Option we should see that segmentstore configmap should get updated and each pod should restart sequentially.
2)  Deploy Pravega cluster and update controller JVM Option we should see that controller configmap should get updated and each pod should restart sequentially.
3) Deploy Pravega cluster and update Option we should see that controller and segmentstore configmap should get updated and each of the controller and ss pod should restart sequentially.
4) Try changing any of the above 16 values that the user is not supposed to change and the operator should error saying that the parameter is not supposed to be changed.