### PR TITLE
Issue-468: Run pravega segmentstore sts with runAsUser = 0

### DIFF
--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -294,110 +294,9 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  controllerServiceAccountName:
-                    description: ControllerServiceAccountName configures the service
-                      account used on controller instances. If not specified, Kubernetes
-                      will automatically assign the default service account in the
-                      namespace default
-                    type: string
-                  controllerSvcAnnotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to be added to the external service
-                    type: object
-                  controllerjvmOptions:
-                    description: ControllerJvmOptions is the JVM options for controller.
-                      It will be passed to the JVM for performance tuning. If this
-                      field is not specified, the operator will use a set of default
-                      options that is good enough for general deployment.
-                    items:
-                      type: string
-                    type: array
-                  debugLogging:
-                    description: DebugLogging indicates whether or not debug level
-                      logging is enabled. Defaults to false.
-                    type: boolean
-                  image:
-                    description: Image defines the Pravega Docker image to use. By
-                      default, "pravega/pravega" will be used.
-                    properties:
-                      pullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
-                        enum:
-                        - Always
-                        - Never
-                        - IfNotPresent
-                        type: string
-                      repository:
-                        type: string
-                    type: object
-                  longtermStorage:
-                    description: LongTermStorage is the configuration of Pravega's
-                      tier 2 storage. If no configuration is provided, it will assume
-                      that a PersistentVolumeClaim called "pravega-longterm" is present
-                      and it will use it as Tier 2
-                    properties:
-                      ecs:
-                        description: Ecs is used to configure a Dell EMC ECS system
-                          as a Tier 2 backend
-                        properties:
-                          bucket:
-                            type: string
-                          configUri:
-                            type: string
-                          credentials:
-                            type: string
-                          prefix:
-                            type: string
-                        type: object
-                      filesystem:
-                        description: FileSystem is used to configure a pre-created
-                          Persistent Volume Claim as Tier 2 backend. It is default
-                          Tier 2 mode.
-                        properties:
-                          persistentVolumeClaim:
-                            description: PersistentVolumeClaimVolumeSource references
-                              the user's PVC in the same namespace default
-                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
-                              is, essentially, a wrapper around another type of volume
-                              that is owned by someone else (the system).
-                            properties:
-                              claimName:
-                                description: 'ClaimName is the name of a PersistentVolumeClaim
-                                  in the same namespace default
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                type: string
-                              readOnly:
-                                description: Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
-                                type: boolean
-                            required:
-                            - claimName
-                            type: object
-                        type: object
-                      hdfs:
-                        description: Hdfs is used to configure an HDFS system as a
-                          Tier 2 backend
-                        properties:
-                          replicationFactor:
-                            format: int32
-                            type: integer
-                          root:
-                            type: string
-                          uri:
-                            type: string
-                        type: object
-                    type: object
-                  options:
-                    additionalProperties:
-                      type: string
-                    description: 'Options is the Pravega configuration that is passed
-                      to the Pravega processes as JAVA_OPTS. See the following file
-                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
-                    type: object
-                  securityContext:
-                    description: SecurityContext
+                  controllerSecurityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to
@@ -518,6 +417,108 @@ spec:
                             type: string
                         type: object
                     type: object
+                  controllerServiceAccountName:
+                    description: ControllerServiceAccountName configures the service
+                      account used on controller instances. If not specified, Kubernetes
+                      will automatically assign the default service account in the
+                      namespace default
+                    type: string
+                  controllerSvcAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the external service
+                    type: object
+                  controllerjvmOptions:
+                    description: ControllerJvmOptions is the JVM options for controller.
+                      It will be passed to the JVM for performance tuning. If this
+                      field is not specified, the operator will use a set of default
+                      options that is good enough for general deployment.
+                    items:
+                      type: string
+                    type: array
+                  debugLogging:
+                    description: DebugLogging indicates whether or not debug level
+                      logging is enabled. Defaults to false.
+                    type: boolean
+                  image:
+                    description: Image defines the Pravega Docker image to use. By
+                      default, "pravega/pravega" will be used.
+                    properties:
+                      pullPolicy:
+                        description: PullPolicy describes a policy for if/when to
+                          pull a container image
+                        enum:
+                        - Always
+                        - Never
+                        - IfNotPresent
+                        type: string
+                      repository:
+                        type: string
+                    type: object
+                  longtermStorage:
+                    description: LongTermStorage is the configuration of Pravega's
+                      tier 2 storage. If no configuration is provided, it will assume
+                      that a PersistentVolumeClaim called "pravega-longterm" is present
+                      and it will use it as Tier 2
+                    properties:
+                      ecs:
+                        description: Ecs is used to configure a Dell EMC ECS system
+                          as a Tier 2 backend
+                        properties:
+                          bucket:
+                            type: string
+                          configUri:
+                            type: string
+                          credentials:
+                            type: string
+                          prefix:
+                            type: string
+                        type: object
+                      filesystem:
+                        description: FileSystem is used to configure a pre-created
+                          Persistent Volume Claim as Tier 2 backend. It is default
+                          Tier 2 mode.
+                        properties:
+                          persistentVolumeClaim:
+                            description: PersistentVolumeClaimVolumeSource references
+                              the user's PVC in the same namespace default
+                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
+                              is, essentially, a wrapper around another type of volume
+                              that is owned by someone else (the system).
+                            properties:
+                              claimName:
+                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  in the same namespace default
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                        type: object
+                      hdfs:
+                        description: Hdfs is used to configure an HDFS system as a
+                          Tier 2 backend
+                        properties:
+                          replicationFactor:
+                            format: int32
+                            type: integer
+                          root:
+                            type: string
+                          uri:
+                            type: string
+                        type: object
+                    type: object
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: 'Options is the Pravega configuration that is passed
+                      to the Pravega processes as JAVA_OPTS. See the following file
+                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
+                    type: object
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured
@@ -593,6 +594,129 @@ spec:
                         description: Secret specifies the name of Secret which needs
                           to be configured
                         type: string
+                    type: object
+                  segmentStoreSecurityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
                     type: object
                   segmentStoreServiceAccountName:
                     description: SegmentStoreServiceAccountName configures the service

--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -396,6 +396,128 @@ spec:
                       to the Pravega processes as JAVA_OPTS. See the following file
                       for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
                     type: object
+                  securityContext:
+                    description: SecurityContext
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -99,4 +99,5 @@ The following table lists the configurable parameters of the pravega chart and t
 | `storage.cache.className` | Storage class for cache volume | `` |
 | `storage.cache.size` | Storage requests for cache volume | `20Gi` |
 | `options` | List of Pravega options | |
-| `securityContext.runAsUser` | The UID to run the entrypoint of the container process | `0` | 
+| `segmentStoreSecurityContext.runAsUser` | The UID to run the entrypoint of the container process | `0` |
+| `controllerSecurityContext.runAsUser` | The UID to run the entrypoint of the container process | `0` |

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -99,3 +99,4 @@ The following table lists the configurable parameters of the pravega chart and t
 | `storage.cache.className` | Storage class for cache volume | `` |
 | `storage.cache.size` | Storage requests for cache volume | `20Gi` |
 | `options` | List of Pravega options | |
+| `securityContext.runAsUser` | The UID to run the entrypoint of the container process | `0` | 

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -99,5 +99,5 @@ The following table lists the configurable parameters of the pravega chart and t
 | `storage.cache.className` | Storage class for cache volume | `` |
 | `storage.cache.size` | Storage requests for cache volume | `20Gi` |
 | `options` | List of Pravega options | |
-| `segmentStoreSecurityContext.runAsUser` | The UID to run the entrypoint of the container process | `0` |
-| `controllerSecurityContext.runAsUser` | The UID to run the entrypoint of the container process | `0` |
+| `segmentStoreSecurityContext` | Holds pod-level security attributes and common container settings | `{}` |
+| `controllerSecurityContext` | Holds pod-level security attributes and common container settings | `{}` |

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -36,9 +36,13 @@ spec:
     {{- end }}
     {{- end }}
   pravega:
-    {{- if .Values.securityContext }}
-    securityContext:
-      runAsUser: {{ .Values.securityContext.runAsUser }}
+    {{- if .Values.segmentStoreSecurityContext }}
+    segmentStoreSecurityContext:
+      runAsUser: {{ .Values.segmentStoreSecurityContext.runAsUser }}
+    {{- end }}
+    {{- if .Values.controllerSecurityContext }}
+    controllerSecurityContext:
+      runAsUser: {{ .Values.controllerSecurityContext.runAsUser }}
     {{- end }}
     {{- if .Values.externalAccess.enabled }}
     controllerServiceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -36,6 +36,10 @@ spec:
     {{- end }}
     {{- end }}
   pravega:
+    {{- if .Values.securityContext }}
+    securityContext:
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+    {{- end }}
     {{- if .Values.externalAccess.enabled }}
     controllerServiceAccountName: {{ .Values.serviceAccount.name }}
     segmentStoreServiceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -24,7 +24,10 @@ externalAccess:
   type: LoadBalancer
   domainName:
 
-securityContext: {}
+segmentStoreSecurityContext: {}
+  #runAsUser: 0
+
+controllerSecurityContext: {}
   #runAsUser: 0
 
 image:

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -24,6 +24,9 @@ externalAccess:
   type: LoadBalancer
   domainName:
 
+securityContext: {}
+  #runAsUser: 0
+
 image:
   repository: pravega/pravega
   pullPolicy: IfNotPresent

--- a/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -290,110 +290,9 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  controllerServiceAccountName:
-                    description: ControllerServiceAccountName configures the service
-                      account used on controller instances. If not specified, Kubernetes
-                      will automatically assign the default service account in the
-                      namespace default
-                    type: string
-                  controllerSvcAnnotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to be added to the external service
-                    type: object
-                  controllerjvmOptions:
-                    description: ControllerJvmOptions is the JVM options for controller.
-                      It will be passed to the JVM for performance tuning. If this
-                      field is not specified, the operator will use a set of default
-                      options that is good enough for general deployment.
-                    items:
-                      type: string
-                    type: array
-                  debugLogging:
-                    description: DebugLogging indicates whether or not debug level
-                      logging is enabled. Defaults to false.
-                    type: boolean
-                  image:
-                    description: Image defines the Pravega Docker image to use. By
-                      default, "pravega/pravega" will be used.
-                    properties:
-                      pullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
-                        enum:
-                        - Always
-                        - Never
-                        - IfNotPresent
-                        type: string
-                      repository:
-                        type: string
-                    type: object
-                  longtermStorage:
-                    description: LongTermStorage is the configuration of Pravega's
-                      tier 2 storage. If no configuration is provided, it will assume
-                      that a PersistentVolumeClaim called "pravega-longterm" is present
-                      and it will use it as Tier 2
-                    properties:
-                      ecs:
-                        description: Ecs is used to configure a Dell EMC ECS system
-                          as a Tier 2 backend
-                        properties:
-                          bucket:
-                            type: string
-                          configUri:
-                            type: string
-                          credentials:
-                            type: string
-                          prefix:
-                            type: string
-                        type: object
-                      filesystem:
-                        description: FileSystem is used to configure a pre-created
-                          Persistent Volume Claim as Tier 2 backend. It is default
-                          Tier 2 mode.
-                        properties:
-                          persistentVolumeClaim:
-                            description: PersistentVolumeClaimVolumeSource references
-                              the user's PVC in the same namespace default
-                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
-                              is, essentially, a wrapper around another type of volume
-                              that is owned by someone else (the system).
-                            properties:
-                              claimName:
-                                description: 'ClaimName is the name of a PersistentVolumeClaim
-                                  in the same namespace default
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                type: string
-                              readOnly:
-                                description: Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
-                                type: boolean
-                            required:
-                            - claimName
-                            type: object
-                        type: object
-                      hdfs:
-                        description: Hdfs is used to configure an HDFS system as a
-                          Tier 2 backend
-                        properties:
-                          replicationFactor:
-                            format: int32
-                            type: integer
-                          root:
-                            type: string
-                          uri:
-                            type: string
-                        type: object
-                    type: object
-                  options:
-                    additionalProperties:
-                      type: string
-                    description: 'Options is the Pravega configuration that is passed
-                      to the Pravega processes as JAVA_OPTS. See the following file
-                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
-                    type: object
-                  securityContext:
-                    description: SecurityContext
+                  controllerSecurityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to
@@ -514,6 +413,108 @@ spec:
                             type: string
                         type: object
                     type: object
+                  controllerServiceAccountName:
+                    description: ControllerServiceAccountName configures the service
+                      account used on controller instances. If not specified, Kubernetes
+                      will automatically assign the default service account in the
+                      namespace default
+                    type: string
+                  controllerSvcAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the external service
+                    type: object
+                  controllerjvmOptions:
+                    description: ControllerJvmOptions is the JVM options for controller.
+                      It will be passed to the JVM for performance tuning. If this
+                      field is not specified, the operator will use a set of default
+                      options that is good enough for general deployment.
+                    items:
+                      type: string
+                    type: array
+                  debugLogging:
+                    description: DebugLogging indicates whether or not debug level
+                      logging is enabled. Defaults to false.
+                    type: boolean
+                  image:
+                    description: Image defines the Pravega Docker image to use. By
+                      default, "pravega/pravega" will be used.
+                    properties:
+                      pullPolicy:
+                        description: PullPolicy describes a policy for if/when to
+                          pull a container image
+                        enum:
+                        - Always
+                        - Never
+                        - IfNotPresent
+                        type: string
+                      repository:
+                        type: string
+                    type: object
+                  longtermStorage:
+                    description: LongTermStorage is the configuration of Pravega's
+                      tier 2 storage. If no configuration is provided, it will assume
+                      that a PersistentVolumeClaim called "pravega-longterm" is present
+                      and it will use it as Tier 2
+                    properties:
+                      ecs:
+                        description: Ecs is used to configure a Dell EMC ECS system
+                          as a Tier 2 backend
+                        properties:
+                          bucket:
+                            type: string
+                          configUri:
+                            type: string
+                          credentials:
+                            type: string
+                          prefix:
+                            type: string
+                        type: object
+                      filesystem:
+                        description: FileSystem is used to configure a pre-created
+                          Persistent Volume Claim as Tier 2 backend. It is default
+                          Tier 2 mode.
+                        properties:
+                          persistentVolumeClaim:
+                            description: PersistentVolumeClaimVolumeSource references
+                              the user's PVC in the same namespace default
+                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
+                              is, essentially, a wrapper around another type of volume
+                              that is owned by someone else (the system).
+                            properties:
+                              claimName:
+                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  in the same namespace default
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                        type: object
+                      hdfs:
+                        description: Hdfs is used to configure an HDFS system as a
+                          Tier 2 backend
+                        properties:
+                          replicationFactor:
+                            format: int32
+                            type: integer
+                          root:
+                            type: string
+                          uri:
+                            type: string
+                        type: object
+                    type: object
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: 'Options is the Pravega configuration that is passed
+                      to the Pravega processes as JAVA_OPTS. See the following file
+                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
+                    type: object
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured
@@ -589,6 +590,129 @@ spec:
                         description: Secret specifies the name of Secret which needs
                           to be configured
                         type: string
+                    type: object
+                  segmentStoreSecurityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
                     type: object
                   segmentStoreServiceAccountName:
                     description: SegmentStoreServiceAccountName configures the service

--- a/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -392,6 +392,128 @@ spec:
                       to the Pravega processes as JAVA_OPTS. See the following file
                       for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
                     type: object
+                  securityContext:
+                    description: SecurityContext
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -174,7 +174,6 @@ type PravegaSpec struct {
 
 	// SecurityContext holds security configuration that will be applied to a container
 	ControllerSecurityContext *corev1.PodSecurityContext `json:"controllerSecurityContext,omitempty"`
-
 }
 
 func (s *PravegaSpec) withDefaults() (changed bool) {

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pravega/pravega-operator/pkg/controller/config"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	corev1 "k8s.io/api/core/v1"
+
 )
 
 const (
@@ -167,6 +169,9 @@ type PravegaSpec struct {
 
 	// SegmentStoreExternalTrafficPolicy defines the ExternalTrafficPolicy it can have cluster or local
 	SegmentStoreExternalTrafficPolicy string `json:"segmentStoreExternalTrafficPolicy,omitempty"`
+
+	// SecurityContext
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 }
 
 func (s *PravegaSpec) withDefaults() (changed bool) {

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -13,9 +13,8 @@ package v1beta1
 import (
 	"github.com/pravega/pravega-operator/pkg/controller/config"
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	corev1 "k8s.io/api/core/v1"
-
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -169,10 +169,10 @@ type PravegaSpec struct {
 	// SegmentStoreExternalTrafficPolicy defines the ExternalTrafficPolicy it can have cluster or local
 	SegmentStoreExternalTrafficPolicy string `json:"segmentStoreExternalTrafficPolicy,omitempty"`
 
-	// SecurityContext holds security configuration that will be applied to a container
+	// SegmentStoreSecurityContext holds security configuration that will be applied to a container
 	SegmentStoreSecurityContext *corev1.PodSecurityContext `json:"segmentStoreSecurityContext,omitempty"`
 
-	// SecurityContext holds security configuration that will be applied to a container
+	// ControllerSecurityContext holds security configuration that will be applied to a container
 	ControllerSecurityContext *corev1.PodSecurityContext `json:"controllerSecurityContext,omitempty"`
 }
 

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -170,7 +170,11 @@ type PravegaSpec struct {
 	SegmentStoreExternalTrafficPolicy string `json:"segmentStoreExternalTrafficPolicy,omitempty"`
 
 	// SecurityContext holds security configuration that will be applied to a container
-	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	SegmentStoreSecurityContext *corev1.PodSecurityContext `json:"segmentStoreSecurityContext,omitempty"`
+
+	// SecurityContext holds security configuration that will be applied to a container
+	ControllerSecurityContext *corev1.PodSecurityContext `json:"controllerSecurityContext,omitempty"`
+
 }
 
 func (s *PravegaSpec) withDefaults() (changed bool) {

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -169,7 +169,7 @@ type PravegaSpec struct {
 	// SegmentStoreExternalTrafficPolicy defines the ExternalTrafficPolicy it can have cluster or local
 	SegmentStoreExternalTrafficPolicy string `json:"segmentStoreExternalTrafficPolicy,omitempty"`
 
-	// SecurityContext
+	// SecurityContext holds security configuration that will be applied to a container
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 }
 

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -72,11 +72,7 @@ type PravegaClusterList struct {
 	Items           []PravegaCluster `json:"items"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
-
 // Generate CRD using kubebuilder
-
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
@@ -87,6 +83,9 @@ type PravegaClusterList struct {
 // +kubebuilder:printcolumn:name="Ready Members",type=integer,JSONPath=`.status.readyReplicas`,description="The number of ready pravega members"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // PravegaCluster is the Schema for the pravegaclusters API
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
 type PravegaCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/pravega/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pravega/v1beta1/zz_generated.deepcopy.go
@@ -371,6 +371,16 @@ func (in *PravegaSpec) DeepCopyInto(out *PravegaSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.SegmentStoreSecurityContext != nil {
+		in, out := &in.SegmentStoreSecurityContext, &out.SegmentStoreSecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ControllerSecurityContext != nil {
+		in, out := &in.ControllerSecurityContext, &out.ControllerSecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/pravega/v1beta1/zz_generated_deepcopy_test.go
+++ b/pkg/apis/pravega/v1beta1/zz_generated_deepcopy_test.go
@@ -10,6 +10,8 @@
 package v1beta1_test
 
 import (
+	"fmt"
+
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -46,6 +48,12 @@ var _ = Describe("PravegaCluster DeepCopy", func() {
 			}
 			p1.WithDefaults()
 			p1.Status.Init()
+			no := int64(0)
+			securitycontext := corev1.PodSecurityContext{
+				RunAsUser: &no,
+			}
+			p1.Spec.Pravega.SegmentStoreSecurityContext = &securitycontext
+			p1.Spec.Pravega.ControllerSecurityContext = &securitycontext
 			temp := *p1.DeepCopy()
 			p2 = &temp
 			str1 = p1.Spec.Pravega.Image.Repository
@@ -128,7 +136,6 @@ var _ = Describe("PravegaCluster DeepCopy", func() {
 		It("checking status conditions", func() {
 			Ω(p2.Status.Conditions[0].Reason).To(Equal(p1.Status.Conditions[0].Reason))
 		})
-
 		It("checking  version history", func() {
 			Ω(p2.Status.VersionHistory[0]).To(Equal("0.6.0"))
 		})
@@ -149,6 +156,12 @@ var _ = Describe("PravegaCluster DeepCopy", func() {
 		})
 		It("checking  image  repository", func() {
 			Ω(p2.Spec.Pravega.Image.Repository).To(Equal("pravega/exmple"))
+		})
+		It("checking SegmentStoreSecurityContext", func() {
+			Ω(fmt.Sprintf("%v", *p2.Spec.Pravega.SegmentStoreSecurityContext.RunAsUser)).To(Equal("0"))
+		})
+		It("checking ControllerSecurityContext", func() {
+			Ω(fmt.Sprintf("%v", *p2.Spec.Pravega.ControllerSecurityContext.RunAsUser)).To(Equal("0"))
 		})
 
 		It("checking  pravega options", func() {

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -136,6 +136,10 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 		podSpec.ServiceAccountName = p.Spec.Pravega.ControllerServiceAccountName
 	}
 
+	if p.Spec.Pravega.ControllerSecurityContext != nil {
+		podSpec.SecurityContext = p.Spec.Pravega.ControllerSecurityContext
+	}
+
 	configureControllerTLSSecrets(podSpec, p)
 	configureAuthSecrets(podSpec, p)
 	return podSpec

--- a/pkg/controller/pravega/pravega_controller_test.go
+++ b/pkg/controller/pravega/pravega_controller_test.go
@@ -11,6 +11,7 @@
 package pravega_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
@@ -107,6 +108,11 @@ var _ = Describe("Controller", func() {
 					},
 				}
 				p.WithDefaults()
+				no := int64(0)
+				securitycontext := corev1.PodSecurityContext{
+					RunAsUser: &no,
+				}
+				p.Spec.Pravega.ControllerSecurityContext = &securitycontext
 			})
 
 			Context("Controller", func() {
@@ -139,6 +145,10 @@ var _ = Describe("Controller", func() {
 				It("should create the service with external access type loadbalancer", func() {
 					svc := pravega.MakeControllerService(p)
 					Ω(svc.Spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
+				})
+				It("should have runAsUser value as 0", func() {
+					podTemplate := pravega.MakeControllerPodTemplate(p)
+					Ω(fmt.Sprintf("%v", *podTemplate.Spec.SecurityContext.RunAsUser)).To(Equal("0"))
 				})
 			})
 			Context("Controller with external service type empty", func() {

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -166,6 +166,10 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 		podSpec.ServiceAccountName = p.Spec.Pravega.SegmentStoreServiceAccountName
 	}
 
+	if p.Spec.Pravega.SecurityContext != nil {
+		podSpec.SecurityContext = p.Spec.Pravega.SecurityContext
+	}
+
 	configureSegmentstoreSecret(&podSpec, p)
 
 	configureSegmentstoreTLSSecret(&podSpec, p)

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -166,8 +166,8 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 		podSpec.ServiceAccountName = p.Spec.Pravega.SegmentStoreServiceAccountName
 	}
 
-	if p.Spec.Pravega.SecurityContext != nil {
-		podSpec.SecurityContext = p.Spec.Pravega.SecurityContext
+	if p.Spec.Pravega.SegmentStoreSecurityContext != nil {
+		podSpec.SecurityContext = p.Spec.Pravega.SegmentStoreSecurityContext
 	}
 
 	configureSegmentstoreSecret(&podSpec, p)

--- a/pkg/controller/pravega/pravega_segmentstore_test.go
+++ b/pkg/controller/pravega/pravega_segmentstore_test.go
@@ -11,6 +11,7 @@
 package pravega_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
@@ -117,6 +118,11 @@ var _ = Describe("PravegaSegmentstore", func() {
 					},
 				}
 				p.WithDefaults()
+				no := int64(0)
+				securitycontext := corev1.PodSecurityContext{
+					RunAsUser: &no,
+				}
+				p.Spec.Pravega.SegmentStoreSecurityContext = &securitycontext
 			})
 
 			Context("First reconcile", func() {
@@ -153,6 +159,10 @@ var _ = Describe("PravegaSegmentstore", func() {
 				})
 				It("should set external access service type to LoadBalancer", func() {
 					Ω(p.Spec.ExternalAccess.Type).Should(Equal(corev1.ServiceTypeClusterIP))
+				})
+				It("should have runAsUser value as 0", func() {
+					podTemplate := pravega.MakeSegmentStorePodTemplate(p)
+					Ω(fmt.Sprintf("%v", *podTemplate.Spec.SecurityContext.RunAsUser)).To(Equal("0"))
 				})
 			})
 		})

--- a/test/e2e/resources/crd.yaml
+++ b/test/e2e/resources/crd.yaml
@@ -290,110 +290,9 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  controllerServiceAccountName:
-                    description: ControllerServiceAccountName configures the service
-                      account used on controller instances. If not specified, Kubernetes
-                      will automatically assign the default service account in the
-                      namespace default
-                    type: string
-                  controllerSvcAnnotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to be added to the external service
-                    type: object
-                  controllerjvmOptions:
-                    description: ControllerJvmOptions is the JVM options for controller.
-                      It will be passed to the JVM for performance tuning. If this
-                      field is not specified, the operator will use a set of default
-                      options that is good enough for general deployment.
-                    items:
-                      type: string
-                    type: array
-                  debugLogging:
-                    description: DebugLogging indicates whether or not debug level
-                      logging is enabled. Defaults to false.
-                    type: boolean
-                  image:
-                    description: Image defines the Pravega Docker image to use. By
-                      default, "pravega/pravega" will be used.
-                    properties:
-                      pullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
-                        enum:
-                        - Always
-                        - Never
-                        - IfNotPresent
-                        type: string
-                      repository:
-                        type: string
-                    type: object
-                  longtermStorage:
-                    description: LongTermStorage is the configuration of Pravega's
-                      tier 2 storage. If no configuration is provided, it will assume
-                      that a PersistentVolumeClaim called "pravega-longterm" is present
-                      and it will use it as Tier 2
-                    properties:
-                      ecs:
-                        description: Ecs is used to configure a Dell EMC ECS system
-                          as a Tier 2 backend
-                        properties:
-                          bucket:
-                            type: string
-                          configUri:
-                            type: string
-                          credentials:
-                            type: string
-                          prefix:
-                            type: string
-                        type: object
-                      filesystem:
-                        description: FileSystem is used to configure a pre-created
-                          Persistent Volume Claim as Tier 2 backend. It is default
-                          Tier 2 mode.
-                        properties:
-                          persistentVolumeClaim:
-                            description: PersistentVolumeClaimVolumeSource references
-                              the user's PVC in the same namespace default
-                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
-                              is, essentially, a wrapper around another type of volume
-                              that is owned by someone else (the system).
-                            properties:
-                              claimName:
-                                description: 'ClaimName is the name of a PersistentVolumeClaim
-                                  in the same namespace default
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                type: string
-                              readOnly:
-                                description: Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
-                                type: boolean
-                            required:
-                            - claimName
-                            type: object
-                        type: object
-                      hdfs:
-                        description: Hdfs is used to configure an HDFS system as a
-                          Tier 2 backend
-                        properties:
-                          replicationFactor:
-                            format: int32
-                            type: integer
-                          root:
-                            type: string
-                          uri:
-                            type: string
-                        type: object
-                    type: object
-                  options:
-                    additionalProperties:
-                      type: string
-                    description: 'Options is the Pravega configuration that is passed
-                      to the Pravega processes as JAVA_OPTS. See the following file
-                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
-                    type: object
-                  securityContext:
-                    description: SecurityContext
+                  controllerSecurityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to
@@ -514,6 +413,108 @@ spec:
                             type: string
                         type: object
                     type: object
+                  controllerServiceAccountName:
+                    description: ControllerServiceAccountName configures the service
+                      account used on controller instances. If not specified, Kubernetes
+                      will automatically assign the default service account in the
+                      namespace default
+                    type: string
+                  controllerSvcAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the external service
+                    type: object
+                  controllerjvmOptions:
+                    description: ControllerJvmOptions is the JVM options for controller.
+                      It will be passed to the JVM for performance tuning. If this
+                      field is not specified, the operator will use a set of default
+                      options that is good enough for general deployment.
+                    items:
+                      type: string
+                    type: array
+                  debugLogging:
+                    description: DebugLogging indicates whether or not debug level
+                      logging is enabled. Defaults to false.
+                    type: boolean
+                  image:
+                    description: Image defines the Pravega Docker image to use. By
+                      default, "pravega/pravega" will be used.
+                    properties:
+                      pullPolicy:
+                        description: PullPolicy describes a policy for if/when to
+                          pull a container image
+                        enum:
+                        - Always
+                        - Never
+                        - IfNotPresent
+                        type: string
+                      repository:
+                        type: string
+                    type: object
+                  longtermStorage:
+                    description: LongTermStorage is the configuration of Pravega's
+                      tier 2 storage. If no configuration is provided, it will assume
+                      that a PersistentVolumeClaim called "pravega-longterm" is present
+                      and it will use it as Tier 2
+                    properties:
+                      ecs:
+                        description: Ecs is used to configure a Dell EMC ECS system
+                          as a Tier 2 backend
+                        properties:
+                          bucket:
+                            type: string
+                          configUri:
+                            type: string
+                          credentials:
+                            type: string
+                          prefix:
+                            type: string
+                        type: object
+                      filesystem:
+                        description: FileSystem is used to configure a pre-created
+                          Persistent Volume Claim as Tier 2 backend. It is default
+                          Tier 2 mode.
+                        properties:
+                          persistentVolumeClaim:
+                            description: PersistentVolumeClaimVolumeSource references
+                              the user's PVC in the same namespace default
+                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
+                              is, essentially, a wrapper around another type of volume
+                              that is owned by someone else (the system).
+                            properties:
+                              claimName:
+                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  in the same namespace default
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                        type: object
+                      hdfs:
+                        description: Hdfs is used to configure an HDFS system as a
+                          Tier 2 backend
+                        properties:
+                          replicationFactor:
+                            format: int32
+                            type: integer
+                          root:
+                            type: string
+                          uri:
+                            type: string
+                        type: object
+                    type: object
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: 'Options is the Pravega configuration that is passed
+                      to the Pravega processes as JAVA_OPTS. See the following file
+                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
+                    type: object
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured
@@ -589,6 +590,129 @@ spec:
                         description: Secret specifies the name of Secret which needs
                           to be configured
                         type: string
+                    type: object
+                  segmentStoreSecurityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
                     type: object
                   segmentStoreServiceAccountName:
                     description: SegmentStoreServiceAccountName configures the service

--- a/test/e2e/resources/crd.yaml
+++ b/test/e2e/resources/crd.yaml
@@ -392,6 +392,128 @@ spec:
                       to the Pravega processes as JAVA_OPTS. See the following file
                       for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
                     type: object
+                  securityContext:
+                    description: SecurityContext
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured

--- a/tools/manifest_files/crd.yaml
+++ b/tools/manifest_files/crd.yaml
@@ -291,110 +291,9 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  controllerServiceAccountName:
-                    description: ControllerServiceAccountName configures the service
-                      account used on controller instances. If not specified, Kubernetes
-                      will automatically assign the default service account in the
-                      namespace default
-                    type: string
-                  controllerSvcAnnotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to be added to the external service
-                    type: object
-                  controllerjvmOptions:
-                    description: ControllerJvmOptions is the JVM options for controller.
-                      It will be passed to the JVM for performance tuning. If this
-                      field is not specified, the operator will use a set of default
-                      options that is good enough for general deployment.
-                    items:
-                      type: string
-                    type: array
-                  debugLogging:
-                    description: DebugLogging indicates whether or not debug level
-                      logging is enabled. Defaults to false.
-                    type: boolean
-                  image:
-                    description: Image defines the Pravega Docker image to use. By
-                      default, "pravega/pravega" will be used.
-                    properties:
-                      pullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
-                        enum:
-                        - Always
-                        - Never
-                        - IfNotPresent
-                        type: string
-                      repository:
-                        type: string
-                    type: object
-                  longtermStorage:
-                    description: LongTermStorage is the configuration of Pravega's
-                      tier 2 storage. If no configuration is provided, it will assume
-                      that a PersistentVolumeClaim called "pravega-longterm" is present
-                      and it will use it as Tier 2
-                    properties:
-                      ecs:
-                        description: Ecs is used to configure a Dell EMC ECS system
-                          as a Tier 2 backend
-                        properties:
-                          bucket:
-                            type: string
-                          configUri:
-                            type: string
-                          credentials:
-                            type: string
-                          prefix:
-                            type: string
-                        type: object
-                      filesystem:
-                        description: FileSystem is used to configure a pre-created
-                          Persistent Volume Claim as Tier 2 backend. It is default
-                          Tier 2 mode.
-                        properties:
-                          persistentVolumeClaim:
-                            description: PersistentVolumeClaimVolumeSource references
-                              the user's PVC in the same namespace default
-                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
-                              is, essentially, a wrapper around another type of volume
-                              that is owned by someone else (the system).
-                            properties:
-                              claimName:
-                                description: 'ClaimName is the name of a PersistentVolumeClaim
-                                  in the same namespace default
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                type: string
-                              readOnly:
-                                description: Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
-                                type: boolean
-                            required:
-                            - claimName
-                            type: object
-                        type: object
-                      hdfs:
-                        description: Hdfs is used to configure an HDFS system as a
-                          Tier 2 backend
-                        properties:
-                          replicationFactor:
-                            format: int32
-                            type: integer
-                          root:
-                            type: string
-                          uri:
-                            type: string
-                        type: object
-                    type: object
-                  options:
-                    additionalProperties:
-                      type: string
-                    description: 'Options is the Pravega configuration that is passed
-                      to the Pravega processes as JAVA_OPTS. See the following file
-                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
-                    type: object
-                  securityContext:
-                    description: SecurityContext
+                  controllerSecurityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to
@@ -514,7 +413,109 @@ spec:
                               disabled with the WindowsRunAsUserName feature flag.
                             type: string
                         type: object
-                    type: object  
+                    type: object
+                  controllerServiceAccountName:
+                    description: ControllerServiceAccountName configures the service
+                      account used on controller instances. If not specified, Kubernetes
+                      will automatically assign the default service account in the
+                      namespace default
+                    type: string
+                  controllerSvcAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the external service
+                    type: object
+                  controllerjvmOptions:
+                    description: ControllerJvmOptions is the JVM options for controller.
+                      It will be passed to the JVM for performance tuning. If this
+                      field is not specified, the operator will use a set of default
+                      options that is good enough for general deployment.
+                    items:
+                      type: string
+                    type: array
+                  debugLogging:
+                    description: DebugLogging indicates whether or not debug level
+                      logging is enabled. Defaults to false.
+                    type: boolean
+                  image:
+                    description: Image defines the Pravega Docker image to use. By
+                      default, "pravega/pravega" will be used.
+                    properties:
+                      pullPolicy:
+                        description: PullPolicy describes a policy for if/when to
+                          pull a container image
+                        enum:
+                        - Always
+                        - Never
+                        - IfNotPresent
+                        type: string
+                      repository:
+                        type: string
+                    type: object
+                  longtermStorage:
+                    description: LongTermStorage is the configuration of Pravega's
+                      tier 2 storage. If no configuration is provided, it will assume
+                      that a PersistentVolumeClaim called "pravega-longterm" is present
+                      and it will use it as Tier 2
+                    properties:
+                      ecs:
+                        description: Ecs is used to configure a Dell EMC ECS system
+                          as a Tier 2 backend
+                        properties:
+                          bucket:
+                            type: string
+                          configUri:
+                            type: string
+                          credentials:
+                            type: string
+                          prefix:
+                            type: string
+                        type: object
+                      filesystem:
+                        description: FileSystem is used to configure a pre-created
+                          Persistent Volume Claim as Tier 2 backend. It is default
+                          Tier 2 mode.
+                        properties:
+                          persistentVolumeClaim:
+                            description: PersistentVolumeClaimVolumeSource references
+                              the user's PVC in the same namespace default
+                              the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
+                              is, essentially, a wrapper around another type of volume
+                              that is owned by someone else (the system).
+                            properties:
+                              claimName:
+                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  in the same namespace default
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                        type: object
+                      hdfs:
+                        description: Hdfs is used to configure an HDFS system as a
+                          Tier 2 backend
+                        properties:
+                          replicationFactor:
+                            format: int32
+                            type: integer
+                          root:
+                            type: string
+                          uri:
+                            type: string
+                        type: object
+                    type: object
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: 'Options is the Pravega configuration that is passed
+                      to the Pravega processes as JAVA_OPTS. See the following file
+                      for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
+                    type: object
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured
@@ -591,6 +592,129 @@ spec:
                           to be configured
                         type: string
                     type: object
+                  segmentStoreSecurityContext:
+                      description: SecurityContext holds security configuration that
+                        will be applied to a container
+                      properties:
+                        fsGroup:
+                          description: "A special supplemental group that applies to
+                            all containers in a pod. Some volume types allow the Kubelet
+                            to change the ownership of that volume to be owned by the
+                            pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                            bit is set (new files created in the volume will be owned
+                            by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                            \n If unset, the Kubelet will not modify the ownership and
+                            permissions of any volume."
+                          format: int64
+                          type: integer
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in SecurityContext.  If set
+                            in both SecurityContext and PodSecurityContext, the value
+                            specified in SecurityContext takes precedence for that container.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence
+                            for that container.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's primary
+                            GID.  If unspecified, no groups will be added to any container.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field. This field is alpha-level
+                                and is only honored by servers that enable the WindowsGMSA
+                                feature flag.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use. This field is alpha-level
+                                and is only honored by servers that enable the WindowsGMSA
+                                feature flag.
+                              type: string
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. This field is beta-level and may be
+                                disabled with the WindowsRunAsUserName feature flag.
+                              type: string
+                          type: object
+                      type: object
                   segmentStoreServiceAccountName:
                     description: SegmentStoreServiceAccountName configures the service
                       account used on segment store instances. If not specified, Kubernetes

--- a/tools/manifest_files/crd.yaml
+++ b/tools/manifest_files/crd.yaml
@@ -393,6 +393,128 @@ spec:
                       to the Pravega processes as JAVA_OPTS. See the following file
                       for a complete list of options: https://github.com/pravega/pravega/blob/master/config/config.properties'
                     type: object
+                  securityContext:
+                    description: SecurityContext
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
+                        format: int64
+                        type: integer
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object  
                   segmentStoreEnvVars:
                     description: Provides the name of the configmap created by the
                       user to provide additional key-value pairs that need to be configured


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Pravega with ECS as LTS is failing to deploy in Openshift environment, as container needs to inject cert bundle into trust store, but the security context selected by openshift is preventing it.
To solve the above problem we have to set runAsUser = 0 for  pravega segmentstore sts.

### Purpose of the change
Fixes #468 

### What the code does
These changes allow the segmentstore pod's to run as root user. For enabling this user has to give the following things in the manifest file while deploying it manually

```
 pravega:
   segmenStoreSecurityContext: 
    runAsUser: 0  
```
If he is using charts he needs to uncomment the line in the values.yaml in the pravega charts:-

```
segmentStoreSecurityContext: 
  runAsUser: 0

```
For controller he needs to set like this:-

```
controllerSecurityContext:
   runAsUser: 0
```

### How to verify it
Deploy the pravega cluster with **runAsUser: 0** and check the segment store sts and controller deployment post-deployment  it should have the following in it's described output

```
      securityContext:
        runAsUser: 0
```
