### PR TITLE
Fixing e2e test to allow other test to run post one test faliure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl get nodes"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "mkdir /data;kubectl create -f /root/pravega-operator/test/e2e/resources/local-storage.yaml"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash"
-        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "helm repo add stable https://kubernetes-charts.storage.googleapis.com;helm install stable/nfs-server-provisioner --generate-name;kubectl -n default create -f /root/pravega-operator/test/e2e/resources/tier2.yaml"
+        - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "helm repo add stable https://charts.helm.sh/stable;helm install stable/nfs-server-provisioner --generate-name;kubectl -n default create -f /root/pravega-operator/test/e2e/resources/tier2.yaml"
 
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create -f /root/pravega-operator/test/e2e/resources/zookeeper.yaml"
         - ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP  "kubectl -n default create -f /root/pravega-operator/test/e2e/resources/bookkeeper.yaml"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Check out the available [options for long term storage](doc/longtermstorage.md) 
 For demo purposes, you can quickly install a toy NFS server.
 
 ```
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$ helm repo add stable https://charts.helm.sh/stable
 $ helm repo update
 $ helm install stable/nfs-server-provisioner --generate-name
 ```

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -614,9 +614,13 @@ func RestartTier2(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, 
 	t.Log("restarting tier2 storage")
 	tier2 := NewTier2(namespace)
 
-	err := f.Client.Delete(goctx.TODO(), tier2)
-	if err != nil {
-		return fmt.Errorf("failed to delete tier2: %v", err)
+	_, err := f.KubeClient.CoreV1().PersistentVolumeClaims(namespace).Get(tier2.Name, metav1.GetOptions{})
+
+	if err == nil {
+		err := f.Client.Delete(goctx.TODO(), tier2)
+		if err != nil {
+			return fmt.Errorf("failed to delete tier2: %v", err)
+		}
 	}
 
 	err = wait.Poll(RetryInterval, 3*time.Minute, func() (done bool, err error) {


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Currently, all subsequent e2e-test fail once one of the e2e test fails and replaced **https://kubernetes-charts.storage.googleapis.com** with **https://charts.helm.sh/stable** for installing nfs server as it's no longer supported .

### Purpose of the change
Fixes #472 

### What the code does
code deletes tier2 storage only when it's present

### How to verify it
Travis build should run and all test should pass.