### PR TITLE
Issue 473: Fixing charts to set the required LTS type

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: pravega-operator
 description: Pravega Operator Helm chart for Kubernetes
-version: 0.5.1
-appVersion: 0.5.1
+version: 0.5.2
+appVersion: 0.5.2
 keywords:
 - pravega
 - storage

--- a/charts/pravega-operator/README.md
+++ b/charts/pravega-operator/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the pravega-operator ch
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `image.repository` | Image repository | `pravega/pravega-operator` |
-| `image.tag` | Image tag | `0.5.1` |
+| `image.tag` | Image tag | `0.5.2` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `crd.create` | Create pravega CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |

--- a/charts/pravega-operator/templates/webhook.yaml
+++ b/charts/pravega-operator/templates/webhook.yaml
@@ -23,7 +23,11 @@ metadata:
   labels:
 {{ include "pravega-operator.commonLabels" . | indent 4 }}
   annotations:
+    {{- if .Values.webhookCert.generate }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "pravega-operator.fullname" . }}-cert
+    {{- else }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.webhookCert.certName }}
+    {{- end }}
 webhooks:
 - clientConfig:
     service:

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/pravega-operator
-  tag: 0.5.1
+  tag: 0.5.2
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `controller.resources.requests.memory` | Memory requests for controller | `1Gi` |
 | `controller.resources.limits.cpu` | CPU limits for controller | `1000m` |
 | `controller.resources.limits.memory` | Memory limits for controller | `2Gi` |
+| `controller.securityContext` | Holds pod-level security attributes and common container settings for controller | `{}` |
 | `controller.service.type` | Override the controller service type, if external access is enabled (LoadBalancer/NodePort) | |
 | `controller.service.annotations` | Annotations to add to the controller service, if external access is enabled | `{}` |
 | `controller.jvmOptions` | JVM Options for controller | `["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]` |
@@ -87,9 +88,10 @@ The following table lists the configurable parameters of the pravega chart and t
 | `segmentStore.resources.requests.memory` | Memory requests for segmentStore | `4Gi` |
 | `segmentStore.resources.limits.cpu` | CPU limits for segmentStore | `2000m` |
 | `segmentStore.resources.limits.memory` | Memory limits for segmentStore | `4Gi` |
+| `segmentStore.securityContext` | Holds pod-level security attributes and common container settings for segmentStore | `{}` |
 | `segmentStore.service.type` | Override the segmentStore service type, if external access is enabled (LoadBalancer/NodePort) | |
 | `segmentStore.service.annotations` | Annotations to add to the segmentStore service, if external access is enabled | `{}` |
-| `segmentStore.service.loadBalancerIP` |It is used to provide a LoadBalancerIP for the segmentStore service | |
+| `segmentStore.service.loadBalancerIP` | It is used to provide a LoadBalancerIP for the segmentStore service | |
 | `segmentStore.service.externalTrafficPolicy` | It is used to provide ExternalTrafficPolicy for the segmentStore service |  |
 | `segmentStore.jvmOptions` | JVM Options for segmentStore | `[]` |
 | `storage.longtermStorage.type` | Type of long term storage backend to be used (filesystem/ecs/hdfs) | `filesystem` |
@@ -99,5 +101,3 @@ The following table lists the configurable parameters of the pravega chart and t
 | `storage.cache.className` | Storage class for cache volume | `` |
 | `storage.cache.size` | Storage requests for cache volume | `20Gi` |
 | `options` | List of Pravega options | |
-| `segmentStoreSecurityContext` | Holds pod-level security attributes and common container settings | `{}` |
-| `controllerSecurityContext` | Holds pod-level security attributes and common container settings | `{}` |

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -1,3 +1,4 @@
+{{- $longTermStorageType := .Values.storage.longtermStorage.type | default "filesystem" -}}
 apiVersion: "pravega.pravega.io/v1beta1"
 kind: "PravegaCluster"
 metadata:
@@ -36,13 +37,13 @@ spec:
     {{- end }}
     {{- end }}
   pravega:
-    {{- if .Values.segmentStoreSecurityContext }}
+    {{- if .Values.segmentStore.securityContext }}
     segmentStoreSecurityContext:
-      runAsUser: {{ .Values.segmentStoreSecurityContext.runAsUser }}
+      runAsUser: {{ .Values.segmentStore.securityContext.runAsUser }}
     {{- end }}
-    {{- if .Values.controllerSecurityContext }}
+    {{- if .Values.controller.securityContext }}
     controllerSecurityContext:
-      runAsUser: {{ .Values.controllerSecurityContext.runAsUser }}
+      runAsUser: {{ .Values.controller.securityContext.runAsUser }}
     {{- end }}
     {{- if .Values.externalAccess.enabled }}
     controllerServiceAccountName: {{ .Values.serviceAccount.name }}
@@ -111,13 +112,13 @@ spec:
           storage: {{ .Values.storage.cache.size }}
     {{- end }}
     longtermStorage:
-      {{- if eq (default .Values.storage.longtermStorage.type "filesystem") "ecs" }}
+      {{- if eq $longTermStorageType "ecs" }}
       ecs:
         configUri: {{ .Values.storage.longtermStorage.ecs.configUri }}
         bucket: {{ .Values.storage.longtermStorage.ecs.bucket }}
         prefix: {{ .Values.storage.longtermStorage.ecs.prefix }}
         credentials: {{ .Values.storage.longtermStorage.ecs.credentials }}
-      {{- else if eq (default .Values.storage.longtermStorage.type "filesystem") "hdfs"}}
+      {{- else if eq $longTermStorageType "hdfs"}}
       hdfs:
         uri: {{ .Values.storage.longtermStorage.hdfs.uri }}
         root: {{ .Values.storage.longtermStorage.hdfs.root }}
@@ -125,7 +126,7 @@ spec:
       {{- else }}
       filesystem:
         persistentVolumeClaim:
-          claimName: {{ default "pravega-tier2" .Values.storage.longtermStorage.filesystem.pvc }}
+          claimName: {{ .Values.storage.longtermStorage.filesystem.pvc | default "pravega-tier2" }}
       {{- end }}
     {{- if .Values.options }}
     options:

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -24,12 +24,6 @@ externalAccess:
   type: LoadBalancer
   domainName:
 
-segmentStoreSecurityContext: {}
-  #runAsUser: 0
-
-controllerSecurityContext: {}
-  #runAsUser: 0
-
 image:
   repository: pravega/pravega
   pullPolicy: IfNotPresent
@@ -54,6 +48,8 @@ controller:
     limits:
       cpu: 1000m
       memory: 2Gi
+  securityContext: {}
+    # runAsUser: 0
   ## service type and annotations are ignored if external access is disabled
   service:
     ## used to override the service type for controller
@@ -74,13 +70,15 @@ segmentStore:
     limits:
       cpu: 2000m
       memory: 4Gi
+  securityContext: {}
+    # runAsUser: 0
   ## service type and annotations are ignored if external access is disabled
   service:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
     loadBalancerIP:
-    externalTrafficPolicy: Local
+    externalTrafficPolicy:
   jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]
 
 storage:

--- a/test/e2e/resources/bookkeeper.yaml
+++ b/test/e2e/resources/bookkeeper.yaml
@@ -160,7 +160,7 @@ spec:
       serviceAccountName: bookkeeper-operator
       containers:
         - name: bookkeeper-operator
-          image: pravega/bookkeeper-operator:latest
+          image: pravega/bookkeeper-operator:0.1.2
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Currently even when the longTermStorageType is set to `ecs` or `hdfs` within the values.yaml, the ecs or hdfs configuration is not taking effect and the longTermStorageType  of the deployed pravega cluster is getting set to filesystem in all cases.

### Purpose of the change
Fixes #473  , #470 

### How to verify it
Following use-cases have been tested :
- Deployed pravega cluster with storageType = ecs
- Deployed pravega cluster with storageType = hdfs
- Deployed pravega operator 0.4.5 with v1alpha1 pravega cluster. Upgraded the pravega operator to 0.5.2 followed by upgrading to v1beta1 pravega cluster.
- Deployed pravega operator by setting webhookCert.generate within values.yaml to true and confirmed that the correct certificate name is used.
