### PR TITLE
Issue 477: Handling Segmentstore STS upgrade

### DIFF
--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -13,6 +13,7 @@ package pravegacluster
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	pravegav1beta1 "github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
@@ -654,6 +655,10 @@ func (r *ReconcilePravegaCluster) getOneOutdatedPod(sts *appsv1.StatefulSet, ver
 	if err != nil {
 		return nil, err
 	}
+
+	sort.SliceStable(podList.Items, func(i int, j int) bool {
+		return podList.Items[i].Name < podList.Items[j].Name
+	})
 
 	for _, podItem := range podList.Items {
 		if util.GetPodVersion(&podItem) == version {


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
With the upgrade of controller runtime, the updated `client.List` method does not return the list of pods in a sorted order, which was breaking the sequential one-pod-at-a-time upgrade logic that had been implemented in the operator for the segmentstore statefulset.

### Purpose of the change
Fixes #477 

### What the code does
The list of pods returned by the `client.List` method is sorted by name before doing any further processing, to maintain consistency with the previous segmentstore upgrade logic.

### How to verify it
Upgrade the pravega cluster from one version to another and ensure that not more than one segmentstore pod is upgraded at any given time.
