### PR TITLE
Issue 491: Handling config key name changes

### DIFF
--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -39,11 +39,11 @@ spec:
   pravega:
     {{- if .Values.segmentStore.securityContext }}
     segmentStoreSecurityContext:
-      runAsUser: {{ .Values.segmentStore.securityContext.runAsUser }}
+{{ toYaml .Values.segmentStore.securityContext | indent 6 }}
     {{- end }}
     {{- if .Values.controller.securityContext }}
     controllerSecurityContext:
-      runAsUser: {{ .Values.controller.securityContext.runAsUser }}
+{{ toYaml .Values.controller.securityContext | indent 6 }}
     {{- end }}
     {{- if .Values.controller.affinity }}
     controllerPodAffinity:

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -1028,132 +1028,205 @@ func (p *PravegaCluster) validateConfigMap() error {
 			return fmt.Errorf("failed to get configmap (%s): %v", configmap.Name, err)
 		}
 	}
+	data := strings.Split(configmap.Data["JAVA_OPTS"]," ")
+	eq := false
 	if val, ok := p.Spec.Pravega.Options["controller.containerCount"]; ok {
-		checkstring := fmt.Sprintf("-Dcontroller.containerCount=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		key := fmt.Sprintf("-Dcontroller.containerCount=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
 		if !eq {
-			return fmt.Errorf("controller.containerCount should not be changed ")
+			return fmt.Errorf("controller.containerCount should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["controller.container.count"]; ok {
-		checkstring := fmt.Sprintf("-Dcontroller.container.count=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dcontroller.containerCount=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("controller.container.count should not be changed ")
+		old_key := fmt.Sprintf("-Dcontroller.containerCount=%v", val)
+		new_key := fmt.Sprintf("-Dcontroller.container.count=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("controller.container.count should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.containerCount"]; ok {
-		checkstring := fmt.Sprintf("-Dpravegaservice.containerCount=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		key := fmt.Sprintf("-Dpravegaservice.containerCount=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
 		if !eq {
-			return fmt.Errorf("pravegaservice.containerCount should not be changed ")
+			return fmt.Errorf("pravegaservice.containerCount should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.container.count"]; ok {
-		checkstring := fmt.Sprintf("-Dpravegaservice.container.count=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dpravegaservice.containerCount=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("pravegaservice.container.count should not be changed ")
+		old_key := fmt.Sprintf("-Dpravegaservice.containerCount=%v", val)
+		new_key := fmt.Sprintf("-Dpravegaservice.container.count=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("pravegaservice.container.count should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["bookkeeper.bkLedgerPath"]; ok {
-		checkstring := fmt.Sprintf("-Dbookkeeper.bkLedgerPath=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		key := fmt.Sprintf("-Dbookkeeper.bkLedgerPath=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
 		if !eq {
-			return fmt.Errorf("bookkeeper.bkLedgerPath should not be changed ")
+			return fmt.Errorf("bookkeeper.bkLedgerPath should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["bookkeeper.ledger.path"]; ok {
-		checkstring := fmt.Sprintf("-Dbookkeeper.ledger.path=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dbookkeeper.bkLedgerPath=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("bookkeeper.ledger.path should not be changed ")
+		old_key := fmt.Sprintf("-Dbookkeeper.bkLedgerPath=%v", val)
+		new_key := fmt.Sprintf("-Dbookkeeper.ledger.path=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("bookkeeper.ledger.path should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["controller.retention.bucketCount"]; ok {
-		checkstring := fmt.Sprintf("-Dcontroller.retention.bucketCount=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		key := fmt.Sprintf("-Dcontroller.retention.bucketCount=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
 		if !eq {
-			return fmt.Errorf("controller.retention.bucketCount should not be changed ")
+			return fmt.Errorf("controller.retention.bucketCount should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["controller.retention.bucket.count"]; ok {
-		checkstring := fmt.Sprintf("-Dcontroller.retention.bucket.count=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dcontroller.retention.bucketCount=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("controller.retention.bucket.count should not be changed ")
+		old_key := fmt.Sprintf("-Dcontroller.retention.bucketCount=%v", val)
+		new_key := fmt.Sprintf("-Dcontroller.retention.bucket.count=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("controller.retention.bucket.count should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["controller.watermarking.bucketCount"]; ok {
-		checkstring := fmt.Sprintf("-Dcontroller.watermarking.bucketCount=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		key := fmt.Sprintf("-Dcontroller.watermarking.bucketCount=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
 		if !eq {
-			return fmt.Errorf("controller.watermarking.bucketCount should not be changed ")
+			return fmt.Errorf("controller.watermarking.bucketCount should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["controller.watermarking.bucket.count"]; ok {
-		checkstring := fmt.Sprintf("-Dcontroller.watermarking.bucket.count=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dcontroller.watermarking.bucketCount=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("controller.watermarking.bucket.count should not be changed ")
+		old_key := fmt.Sprintf("-Dcontroller.watermarking.bucketCount=%v", val)
+		new_key := fmt.Sprintf("-Dcontroller.watermarking.bucket.count=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("controller.watermarking.bucket.count should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.dataLogImplementation"]; ok {
-		checkstring := fmt.Sprintf("-Dpravegaservice.dataLogImplementation=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		key := fmt.Sprintf("-Dpravegaservice.dataLogImplementation=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
 		if !eq {
-			return fmt.Errorf("pravegaservice.dataLogImplementation should not be changed ")
+			return fmt.Errorf("pravegaservice.dataLogImplementation should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.dataLog.impl.name"]; ok {
-		checkstring := fmt.Sprintf("-Dpravegaservice.dataLog.impl.name=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dpravegaservice.dataLogImplementation=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("pravegaservice.dataLog.impl.name should not be changed ")
+		old_key := fmt.Sprintf("-Dpravegaservice.dataLogImplementation=%v", val)
+		new_key := fmt.Sprintf("-Dpravegaservice.dataLog.impl.name=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("pravegaservice.dataLog.impl.name should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.storageImplementation"]; ok {
-		checkstring := fmt.Sprintf("-Dpravegaservice.storageImplementation=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		key := fmt.Sprintf("-Dpravegaservice.storageImplementation=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
 		if !eq {
-			return fmt.Errorf("pravegaservice.storageImplementation should not be changed ")
+			return fmt.Errorf("pravegaservice.storageImplementation should not be modified")
 		}
 	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.storage.impl.name"]; ok {
-		checkstring := fmt.Sprintf("-Dpravegaservice.storage.impl.name=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dpravegaservice.storageImplementation=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("pravegaservice.storage.impl.name should not be changed ")
+		old_key := fmt.Sprintf("-Dpravegaservice.storageImplementation=%v", val)
+		new_key := fmt.Sprintf("-Dpravegaservice.storage.impl.name=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
 		}
-	}
-	if val, ok := p.Spec.Pravega.Options["storageextra.storageNoOpMode"]; ok {
-		checkstring := fmt.Sprintf("-Dstorageextra.storageNoOpMode=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
 		if !eq {
-			return fmt.Errorf("storageextra.storageNoOpMode should not be changed ")
+			return fmt.Errorf("pravegaservice.storage.impl.name should not be modified")
 		}
 	}
+	eq = false
+	if val, ok := p.Spec.Pravega.Options["storageextra.storageNoOpMode"]; ok {
+		key := fmt.Sprintf("-Dstorageextra.storageNoOpMode=%v", val)
+		for _, checkstring := range data {
+			if checkstring == key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("storageextra.storageNoOpMode should not be modified")
+		}
+	}
+	eq = false
 	if val, ok := p.Spec.Pravega.Options["storageextra.noOp.mode.enable"]; ok {
-		checkstring := fmt.Sprintf("-Dstorageextra.noOp.mode.enable=%v", val)
-		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		checkstring = fmt.Sprintf("-Dstorageextra.storageNoOpMode=%v", val)
-		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !(eq_old || eq_new) {
-			return fmt.Errorf("storageextra.noOp.mode.enable should not be changed ")
+		old_key := fmt.Sprintf("-Dstorageextra.storageNoOpMode=%v", val)
+		new_key := fmt.Sprintf("-Dstorageextra.noOp.mode.enable=%v", val)
+		for _, checkstring := range data {
+			if checkstring == old_key || checkstring == new_key {
+				eq = true
+			}
+		}
+		if !eq {
+			return fmt.Errorf("storageextra.noOp.mode.enable should not be modified")
 		}
 	}
 	log.Print("validateConfigMap:: No error found...returning...")

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -1028,7 +1028,7 @@ func (p *PravegaCluster) validateConfigMap() error {
 			return fmt.Errorf("failed to get configmap (%s): %v", configmap.Name, err)
 		}
 	}
-	data := strings.Split(configmap.Data["JAVA_OPTS"]," ")
+	data := strings.Split(configmap.Data["JAVA_OPTS"], " ")
 	eq := false
 	if val, ok := p.Spec.Pravega.Options["controller.containerCount"]; ok {
 		key := fmt.Sprintf("-Dcontroller.containerCount=%v", val)

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -1037,8 +1037,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["controller.container.count"]; ok {
 		checkstring := fmt.Sprintf("-Dcontroller.container.count=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dcontroller.containerCount=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("controller.container.count should not be changed ")
 		}
 	}
@@ -1051,8 +1053,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.container.count"]; ok {
 		checkstring := fmt.Sprintf("-Dpravegaservice.container.count=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dpravegaservice.containerCount=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("pravegaservice.container.count should not be changed ")
 		}
 	}
@@ -1065,8 +1069,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["bookkeeper.ledger.path"]; ok {
 		checkstring := fmt.Sprintf("-Dbookkeeper.ledger.path=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dbookkeeper.bkLedgerPath=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("bookkeeper.ledger.path should not be changed ")
 		}
 	}
@@ -1079,8 +1085,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["controller.retention.bucket.count"]; ok {
 		checkstring := fmt.Sprintf("-Dcontroller.retention.bucket.count=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dcontroller.retention.bucketCount=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("controller.retention.bucket.count should not be changed ")
 		}
 	}
@@ -1093,8 +1101,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["controller.watermarking.bucket.count"]; ok {
 		checkstring := fmt.Sprintf("-Dcontroller.watermarking.bucket.count=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dcontroller.watermarking.bucketCount=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("controller.watermarking.bucket.count should not be changed ")
 		}
 	}
@@ -1107,8 +1117,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.dataLog.impl.name"]; ok {
 		checkstring := fmt.Sprintf("-Dpravegaservice.dataLog.impl.name=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dpravegaservice.dataLogImplementation=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("pravegaservice.dataLog.impl.name should not be changed ")
 		}
 	}
@@ -1121,8 +1133,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["pravegaservice.storage.impl.name"]; ok {
 		checkstring := fmt.Sprintf("-Dpravegaservice.storage.impl.name=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dpravegaservice.storageImplementation=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("pravegaservice.storage.impl.name should not be changed ")
 		}
 	}
@@ -1135,8 +1149,10 @@ func (p *PravegaCluster) validateConfigMap() error {
 	}
 	if val, ok := p.Spec.Pravega.Options["storageextra.noOp.mode.enable"]; ok {
 		checkstring := fmt.Sprintf("-Dstorageextra.noOp.mode.enable=%v", val)
-		eq := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
-		if !eq {
+		eq_new := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		checkstring = fmt.Sprintf("-Dstorageextra.storageNoOpMode=%v", val)
+		eq_old := strings.Contains(configmap.Data["JAVA_OPTS"], checkstring)
+		if !(eq_old || eq_new) {
 			return fmt.Errorf("storageextra.noOp.mode.enable should not be changed ")
 		}
 	}

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -492,7 +492,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 					Ω(err).Should(BeNil())
 					Ω(strings.Contains(foundCm.Data["JAVA_OPTS"], "-XX:MaxDirectMemorySize=1g")).Should(BeTrue())
 					Ω(strings.Contains(foundCm.Data["JAVA_OPTS"], "-XX:MaxRAMFraction=1")).Should(BeTrue())
-
 					Ω(strings.Contains(foundCm.Data["JAVA_OPTS"], "-XX:MaxRAMFraction=2")).Should(BeFalse())
 				})
 			})
@@ -548,7 +547,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 					Ω(err).Should(BeNil())
 					Ω(strings.Contains(foundCm.Data["JAVA_OPTS"], "-XX:MaxDirectMemorySize=1g")).Should(BeTrue())
 					Ω(strings.Contains(foundCm.Data["JAVA_OPTS"], "-XX:MaxRAMFraction=1")).Should(BeTrue())
-
 					Ω(strings.Contains(foundCm.Data["JAVA_OPTS"], "-XX:MaxRAMFraction=2")).Should(BeFalse())
 				})
 			})


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Pravega webhook fails upgrade even when just the name of the configuration keys is modified as per the new naming convention (ref. https://github.com/pravega/pravega/pull/4713)

### Purpose of the change
Fixes #491 

### How to verify it
Upgrade pravega from version 0.7.0 to 0.8.0 and along with it also modify the name of the pravega option name from `controller.containerCount` to `controller.container.count` without modifying its value. The upgrade should be allowed and you should not see the following error message
```
cannot patch "nautilus" with kind PravegaCluster: admission webhook "pravegawebhook.pravega.io" denied the request: controller.container.count should not be changed
```
