### PR TITLE
Issue-497: Added changes for configuring PDB

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,6 +111,7 @@ jobs:
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create -f /root/pravega-operator/deploy/certificate.yaml"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create -f /root/pravega-operator/deploy/webhook.yaml"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl create -f /root/pravega-operator/test/e2e/resources/crd.yaml"
+        ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "kubectl -n default create secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=testpravegaop --docker-password=c155d654-3c09-48aa-a62d-2d5178454784 --docker-email=prabhaker.saxena75g@gmail.com"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/operator-sdk-$OPERATOR_SDK_VERSION-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/"
         ssh -o StrictHostKeyChecking=no root@$CLUSTER_IP "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer);source /root/.gvm/scripts/gvm;gvm install go1.13.8 --binary;gvm use go1.13.8 --default"
 

--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1131,9 +1131,13 @@ spec:
                         type: object
                     type: object
                   maxUnavailableControllerReplicas:
+                    description: MaxUnavailableControllerReplicas defines the MaxUnavailable
+                      Controller Replicas Default is 1.
                     format: int32
                     type: integer
                   maxUnavailableSegmentStoreReplicas:
+                    description: MaxUnavailableSegmentStoreReplicas defines the MaxUnavailable
+                      SegmentStore Replicas Default is 1.
                     format: int32
                     type: integer
                   options:

--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1133,7 +1133,7 @@ spec:
                   maxUnavailableControllerReplicas:
                     format: int32
                     type: integer
-                  maxUnavailableSgmentStoreReplicas:
+                  maxUnavailableSegmentStoreReplicas:
                     format: int32
                     type: integer
                   options:

--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1130,6 +1130,12 @@ spec:
                             type: string
                         type: object
                     type: object
+                  maxUnavailableControllerReplicas:
+                    format: int32
+                    type: integer
+                  maxUnavailableSgmentStoreReplicas:
+                    format: int32
+                    type: integer
                   options:
                     additionalProperties:
                       type: string

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `debugLogging` | Enable debug logging | `false` |
 | `serviceAccount.name` | Service account to be used | `pravega-components` |
 | `controller.replicas` | Number of controller replicas | `1` |
+| `controller.maxUnavailableControllerReplicas` | Number of maxUnavailableControllerReplicas possible for controller pdb | `1` |
 | `controller.resources.requests.cpu` | CPU requests for controller | `500m` |
 | `controller.resources.requests.memory` | Memory requests for controller | `1Gi` |
 | `controller.resources.limits.cpu` | CPU limits for controller | `1000m` |
@@ -83,6 +84,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `controller.service.annotations` | Annotations to add to the controller service, if external access is enabled | `{}` |
 | `controller.jvmOptions` | JVM Options for controller | `["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]` |
 | `segmentStore.replicas` | Number of segmentStore replicas | `1` |
+| `segmentStore.maxUnavailableSegmentStoreReplicas` | Number of maxUnavailableSegmentStoreReplicas possible for segmentstore pdb | `1` |
 | `segmentStore.secret` | Secret configuration for the segmentStore | `{}` |
 | `segmentStore.env` | Name of configmap containing environment variables to be added to the segmentStore | |
 | `segmentStore.resources.requests.cpu` | CPU requests for segmentStore | `1000m` |

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -81,11 +81,13 @@ spec:
       repository: {{ .Values.image.repository }}
       pullPolicy: {{ .Values.image.pullPolicy }}
     controllerReplicas: {{ .Values.controller.replicas }}
+    maxUnavailableControllerReplicas: {{ .Values.controller.maxUnavailableControllerReplicas }}
     {{- if .Values.controller.resources }}
     controllerResources:
 {{ toYaml .Values.controller.resources | indent 6 }}
     {{- end }}
     segmentStoreReplicas: {{ .Values.segmentStore.replicas }}
+    maxUnavailableSegmentStoreReplicas: {{ .Values.segmentStore.maxUnavailableSegmentStoreReplicas }}
     {{- if .Values.segmentStore.resources }}
     segmentStoreResources:
 {{ toYaml .Values.segmentStore.resources | indent 6 }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -41,6 +41,7 @@ serviceAccount:
 
 controller:
   replicas: 1
+  maxUnavailableControllerReplicas: 1
   resources:
     requests:
       cpu: 500m
@@ -60,6 +61,7 @@ controller:
 
 segmentStore:
   replicas: 1
+  maxUnavailableSegmentStoreReplicas: 1
   secret: {}
     # name:
     # path:

--- a/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1119,9 +1119,13 @@ spec:
                         type: object
                     type: object
                   maxUnavailableControllerReplicas:
+                    description: MaxUnavailableControllerReplicas defines the MaxUnavailable
+                      Controller Replicas Default is 1.
                     format: int32
                     type: integer
                   maxUnavailableSegmentStoreReplicas:
+                    description: MaxUnavailableSegmentStoreReplicas defines the MaxUnavailable
+                      SegmentStore Replicas Default is 1.
                     format: int32
                     type: integer
                   options:

--- a/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1118,6 +1118,12 @@ spec:
                             type: string
                         type: object
                     type: object
+                  maxUnavailableControllerReplicas:
+                    format: int32
+                    type: integer
+                  maxUnavailableSgmentStoreReplicas:
+                    format: int32
+                    type: integer                    
                   options:
                     additionalProperties:
                       type: string

--- a/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1121,9 +1121,9 @@ spec:
                   maxUnavailableControllerReplicas:
                     format: int32
                     type: integer
-                  maxUnavailableSgmentStoreReplicas:
+                  maxUnavailableSegmentStoreReplicas:
                     format: int32
-                    type: integer                    
+                    type: integer
                   options:
                     additionalProperties:
                       type: string

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -81,7 +81,7 @@ type PravegaSpec struct {
 	// +optional
 	SegmentStoreReplicas int32 `json:"segmentStoreReplicas"`
 
-	MaxUnavailableSegmentStoreReplicas int32 `json:"maxUnavailableSgmentStoreReplicas"`
+	MaxUnavailableSegmentStoreReplicas int32 `json:"maxUnavailableSegmentStoreReplicas"`
 
 	MaxUnavailableControllerReplicas int32 `json:"maxUnavailableControllerReplicas"`
 

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -81,6 +81,10 @@ type PravegaSpec struct {
 	// +optional
 	SegmentStoreReplicas int32 `json:"segmentStoreReplicas"`
 
+	MaxUnavailableSegmentStoreReplicas int32 `json:"maxUnavailableSgmentStoreReplicas"`
+
+	MaxUnavailableControllerReplicas int32 `json:"maxUnavailableControllerReplicas"`
+
 	// DebugLogging indicates whether or not debug level logging is enabled.
 	// Defaults to false.
 	// +optional
@@ -192,6 +196,16 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 	if !config.TestMode && s.SegmentStoreReplicas < 1 {
 		changed = true
 		s.SegmentStoreReplicas = 1
+	}
+
+	if !config.TestMode && s.MaxUnavailableControllerReplicas < 1 {
+		changed = true
+		s.MaxUnavailableControllerReplicas = 1
+	}
+
+	if !config.TestMode && s.MaxUnavailableSegmentStoreReplicas < 1 {
+		changed = true
+		s.MaxUnavailableSegmentStoreReplicas = 1
 	}
 
 	if s.Image == nil {

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -81,8 +81,16 @@ type PravegaSpec struct {
 	// +optional
 	SegmentStoreReplicas int32 `json:"segmentStoreReplicas"`
 
+	// MaxUnavailableSegmentStoreReplicas defines the
+	// MaxUnavailable SegmentStore Replicas
+	// Default is 1.
+	// +optional
 	MaxUnavailableSegmentStoreReplicas int32 `json:"maxUnavailableSegmentStoreReplicas"`
 
+	// MaxUnavailableControllerReplicas defines the
+	// MaxUnavailable Controller Replicas
+	// Default is 1.
+	// +optional
 	MaxUnavailableControllerReplicas int32 `json:"maxUnavailableControllerReplicas"`
 
 	// DebugLogging indicates whether or not debug level logging is enabled.

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -288,7 +288,7 @@ func MakeControllerService(p *api.PravegaCluster) *corev1.Service {
 }
 
 func MakeControllerPodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.PodDisruptionBudget {
-	minAvailable := intstr.FromInt(1)
+	minAvailable := intstr.FromInt(int(p.Spec.Pravega.MaxUnavailableControllerReplicas))
 	return &policyv1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -515,7 +515,7 @@ func MakeSegmentstorePodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.P
 	if p.Spec.Pravega.SegmentStoreReplicas == int32(1) {
 		maxUnavailable = intstr.FromInt(0)
 	} else {
-		maxUnavailable = intstr.FromInt(1)
+		maxUnavailable = intstr.FromInt(int(p.Spec.Pravega.MaxUnavailableSegmentStoreReplicas))
 	}
 
 	return &policyv1beta1.PodDisruptionBudget{

--- a/pkg/controller/pravegacluster/pravegacluster_controller.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller.go
@@ -304,8 +304,15 @@ func (r *ReconcilePravegaCluster) reconcileControllerPdb(p *pravegav1beta1.Prave
 	pdb := pravega.MakeControllerPodDisruptionBudget(p)
 	controllerutil.SetControllerReference(p, pdb, r.scheme)
 	err = r.client.Create(context.TODO(), pdb)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			err = r.client.Update(context.TODO(), pdb)
+			if err != nil {
+				return fmt.Errorf("failed to update pdb (%s): %v", pdb.Name, err)
+			}
+		} else {
+			return err
+		}
 	}
 	return nil
 }
@@ -314,8 +321,15 @@ func (r *ReconcilePravegaCluster) reconcileSegmentStorePdb(p *pravegav1beta1.Pra
 	pdb := pravega.MakeSegmentstorePodDisruptionBudget(p)
 	controllerutil.SetControllerReference(p, pdb, r.scheme)
 	err = r.client.Create(context.TODO(), pdb)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			err = r.client.Update(context.TODO(), pdb)
+			if err != nil {
+				return fmt.Errorf("failed to update pdb (%s): %v", pdb.Name, err)
+			}
+		} else {
+			return err
+		}
 	}
 	return nil
 }

--- a/test/e2e/resources/crd.yaml
+++ b/test/e2e/resources/crd.yaml
@@ -1121,7 +1121,7 @@ spec:
                   maxUnavailableControllerReplicas:
                     format: int32
                     type: integer
-                  maxUnavailableSgmentStoreReplicas:
+                  maxUnavailableSegmentStoreReplicas:
                     format: int32
                     type: integer
                   options:

--- a/test/e2e/resources/crd.yaml
+++ b/test/e2e/resources/crd.yaml
@@ -1119,9 +1119,13 @@ spec:
                         type: object
                     type: object
                   maxUnavailableControllerReplicas:
+                    description: MaxUnavailableControllerReplicas defines the MaxUnavailable
+                      Controller Replicas Default is 1.
                     format: int32
                     type: integer
                   maxUnavailableSegmentStoreReplicas:
+                    description: MaxUnavailableSegmentStoreReplicas defines the MaxUnavailable
+                      SegmentStore Replicas Default is 1.
                     format: int32
                     type: integer
                   options:

--- a/test/e2e/resources/crd.yaml
+++ b/test/e2e/resources/crd.yaml
@@ -1118,6 +1118,12 @@ spec:
                             type: string
                         type: object
                     type: object
+                  maxUnavailableControllerReplicas:
+                    format: int32
+                    type: integer
+                  maxUnavailableSgmentStoreReplicas:
+                    format: int32
+                    type: integer
                   options:
                     additionalProperties:
                       type: string


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
This pr helps prevent segmentstore and controller pods from evicting if number of segmentstore or controller are greater than number of nodes. By making the PDB Configurable.

### Purpose of the change
Fixes #497 

### What the code does
Added **maxUnavailableControllerReplicas** and **maxUnavailableSgmentStoreReplicas** fields which will be used to configure the controller and ss pdb respectively. 

### How to verify it
Modify the above two field and check inside the controller and ss PDB's they should have the modified values.