### PR TITLE
Issue-505: Added changes for Avoiding 2 Restarts when Both Version and cm changes are done at the same time 

### DIFF
--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -393,6 +393,28 @@ var _ = Describe("PravegaCluster Controller", func() {
 					})
 				})
 
+				Context("checking checkVersionUpgradeTriggered function", func() {
+					var (
+						ans1, ans2 bool
+					)
+					BeforeEach(func() {
+						client = fake.NewFakeClient(p)
+						r = &ReconcilePravegaCluster{client: client, scheme: s}
+						res, err = r.Reconcile(req)
+
+						ans1 = r.checkVersionUpgradeTriggered(p)
+						p.Spec.Version = "0.8.0"
+						ans2 = r.checkVersionUpgradeTriggered(p)
+					})
+					It("ans1 should be false", func() {
+						Ω(ans1).To(Equal(false))
+					})
+					It("ans2 should be true", func() {
+						Ω(ans2).To(Equal(true))
+					})
+
+				})
+
 				Context("reconcileFinalizers", func() {
 					BeforeEach(func() {
 						p.WithDefaults()


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Added changes for Avoiding 2 Restarts when Both Version and cm changes are done at the same time. This makes the upgrade process fast and we don't get error messages due to race condition.

### Purpose of the change
Fixes #505 

### What the code does

Code checks for any change in the version of the bk cluster when there are changes in cm and if there is change in the version
then we skip restart of pods and only upgrade the cm

### How to verify it
Install pravega cluster then upgrade the cluster along with changing some field in the option we should only see one restart of all pravega(controller and ss) pods and the upgrade should complete.
