### PR TITLE
Issue 518: Add suport of configurable extra volume mounts

### DIFF
--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -158,3 +158,5 @@ options:
   # controller.metrics.influxDB.reporter.enable: "true"
   # controller.metrics.output.frequency.seconds: "10"
   # controller.metrics.influxDB.connect.uri: "http://INFLUXDB-IP:8086"
+  # hostPathVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"
+  # emptyDirVolumeMounts: "baz=/tmp/baz,quux=/tmp/quux"

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -102,6 +102,55 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 	}
 
 	environment = configureTier2Secrets(environment, p.Spec.Pravega)
+
+	var hostPathVolumeMounts []string
+	var emptyDirVolumeMounts []string
+	var ok bool
+
+	if _, ok = p.Spec.Pravega.Options["hostPathVolumeMounts"]; ok {
+		hostPathVolumeMounts = strings.Split(p.Spec.Pravega.Options["hostPathVolumeMounts"], ",")
+	}
+	if _, ok = p.Spec.Pravega.Options["emptyDirVolumeMounts"]; ok {
+		emptyDirVolumeMounts = strings.Split(p.Spec.Pravega.Options["emptyDirVolumeMounts"], ",")
+	}
+
+	var volumes []corev1.Volume
+	if len(hostPathVolumeMounts) > 1 {
+		for _, vm := range hostPathVolumeMounts {
+			s := strings.Split(vm, "=")
+			v := corev1.Volume{
+				Name: s[0],
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: s[1],
+					},
+				},
+			}
+			volumes = append(volumes, v)
+		}
+	}
+	if len(emptyDirVolumeMounts) > 1 {
+		for _, vm := range emptyDirVolumeMounts {
+			s := strings.Split(vm, "=")
+			v := corev1.Volume{
+				Name: s[0],
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			}
+			volumes = append(volumes, v)
+		}
+	} else {
+		// if user did not set emptyDirVolumeMounts
+		v := corev1.Volume{
+			Name: heapDumpName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}
+		volumes = append(volumes, v)
+	}
+
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
@@ -119,7 +168,7 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 				},
 				EnvFrom:      environment,
 				Env:          util.DownwardAPIEnv(),
-				VolumeMounts: MakeSegmentStoreVolumeMount(p),
+				VolumeMounts: MakeSegmentStoreVolumeMount(p, hostPathVolumeMounts, emptyDirVolumeMounts),
 				Resources:    *p.Spec.Pravega.SegmentStoreResources,
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -155,14 +204,7 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 			},
 		},
 		Affinity: p.Spec.Pravega.SegmentStorePodAffinity,
-		Volumes: []corev1.Volume{
-			{
-				Name: heapDumpName,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			},
-		},
+		Volumes:  volumes,
 	}
 
 	if p.Spec.Pravega.SegmentStoreServiceAccountName != "" {
@@ -186,20 +228,43 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 	return podSpec
 }
 
-func MakeSegmentStoreVolumeMount(p *api.PravegaCluster) []corev1.VolumeMount {
-	volumeMount := []corev1.VolumeMount{
-		{
+func MakeSegmentStoreVolumeMount(p *api.PravegaCluster, hostPathVolumeMounts []string, emptyDirVolumeMounts []string) []corev1.VolumeMount {
+	var volumeMounts []corev1.VolumeMount
+
+	if len(hostPathVolumeMounts) > 1 {
+		for _, vm := range hostPathVolumeMounts {
+			s := strings.Split(vm, "=")
+			v := corev1.VolumeMount{
+				Name:      s[0],
+				MountPath: s[1],
+			}
+			volumeMounts = append(volumeMounts, v)
+		}
+	}
+	if len(emptyDirVolumeMounts) > 1 {
+		for _, vm := range emptyDirVolumeMounts {
+			s := strings.Split(vm, "=")
+			v := corev1.VolumeMount{
+				Name:      s[0],
+				MountPath: s[1],
+			}
+			volumeMounts = append(volumeMounts, v)
+		}
+	} else {
+		// if user did not set emptyDirVolumeMounts
+		v := corev1.VolumeMount{
 			Name:      heapDumpName,
 			MountPath: heapDumpDir,
-		},
+		}
+		volumeMounts = append(volumeMounts, v)
 	}
 	if util.IsVersionBelow07(p.Spec.Version) {
-		volumeMount = append(volumeMount, corev1.VolumeMount{
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      cacheVolumeName,
 			MountPath: cacheVolumeMountPoint,
 		})
 	}
-	return volumeMount
+	return volumeMounts
 }
 
 func MakeSegmentstoreConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {


### PR DESCRIPTION
### Change log description

- introduces the `hostPathVolumeMounts` and `emptyDirVolumeMounts` options as multiple key-value pairs, separated by commas and each consisting of a `<name>`=`<path>` tuple.
- parses the `hostPathVolumeMounts` and `emptyDirVolumeMounts` values.
- adds the extracted values to the `volumes` list and containers' `volumeMounts` list.

### Purpose of the change

Implements #518 

Pravega operator should allow to specify "extra" volumes to be mounted into pravega pods, including pravega segment store pods and pravega controller pods. Such volumes may be used to share data between the hosts and containers.

### What the code does

The code implements the new bookie options: `hostPathVolumeMounts` and `emptyDirVolumeMounts`.
To use "extra" volumes in the bookie pods, in the Bookkeeper options, specify:

- `hostPathVolumeMounts` to add `hostPath` volumes
- `emptyDirVolumeMounts` to add `emptyDir` volumes

The options consist of multiple key-value pairs, separated by commas and each consisting of a `<name>`=`<path>` tuple:

`<name>` is a volume name, the file or directory.
`<path>` is where the volume is mounted in the container.
For example, `emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs"`

### How to verify it

1. Add the `emptyDirVolumeMounts` option to Pravega options parameter, e.g., `emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs"`.
2. When the pravega cluster is deployed and ready, make sure that the the `volumes` list and containers' `volumeMounts` list has contained the emptyDir volumes and mounts specified in the `emptyDirVolumeMounts`.

The function has worked as expected on the deployed pravega cluster in our environment. 
