### PR TITLE
Issue-520: Adding Changes to Allow latest operator to deploy 0.5.2 operator

### DIFF
--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -24,8 +24,12 @@ spec:
     enabled: {{ .Values.authentication.enabled }}
     {{- if .Values.authentication.enabled }}
     passwordAuthSecret: {{ .Values.authentication.passwordAuthSecret }}
+    {{- if .Values.authentication.segmentStoreTokenSecret }}
     segmentStoreTokenSecret: {{ .Values.authentication.segmentStoreTokenSecret }}
+    {{- end }}
+    {{- if .Values.authentication.controllerTokenSecret }}
     controllerTokenSecret: {{ .Values.authentication.controllerTokenSecret }}
+    {{- end }}
     {{- end }}
   version: {{ .Values.version }}
   zookeeperUri: {{ .Values.zookeeperUri }}

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -27,7 +27,6 @@ spec:
     segmentStoreTokenSecret: {{ .Values.authentication.segmentStoreTokenSecret }}
     controllerTokenSecret: {{ .Values.authentication.controllerTokenSecret }}
     {{- end }}
-
   version: {{ .Values.version }}
   zookeeperUri: {{ .Values.zookeeperUri }}
   bookkeeperUri: {{ .Values.bookkeeperUri }}
@@ -88,13 +87,17 @@ spec:
       repository: {{ .Values.image.repository }}
       pullPolicy: {{ .Values.image.pullPolicy }}
     controllerReplicas: {{ .Values.controller.replicas }}
+    {{- if .Values.controller.maxUnavailableControllerReplicas }}
     maxUnavailableControllerReplicas: {{ .Values.controller.maxUnavailableControllerReplicas }}
+    {{- end }}
     {{- if .Values.controller.resources }}
     controllerResources:
 {{ toYaml .Values.controller.resources | indent 6 }}
     {{- end }}
     segmentStoreReplicas: {{ .Values.segmentStore.replicas }}
+    {{- if .Values.segmentStore.maxUnavailableSegmentStoreReplicas }}
     maxUnavailableSegmentStoreReplicas: {{ .Values.segmentStore.maxUnavailableSegmentStoreReplicas }}
+    {{- end }}
     {{- if .Values.segmentStore.resources }}
     segmentStoreResources:
 {{ toYaml .Values.segmentStore.resources | indent 6 }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -45,7 +45,7 @@ serviceAccount:
 
 controller:
   replicas: 1
-  maxUnavailableControllerReplicas: 1
+  #maxUnavailableControllerReplicas: 1
   resources:
     requests:
       cpu: 500m
@@ -66,7 +66,7 @@ controller:
 
 segmentStore:
   replicas: 1
-  maxUnavailableSegmentStoreReplicas: 1
+  #maxUnavailableSegmentStoreReplicas: 1
   secret: {}
     # name:
     # path:

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -14,10 +14,10 @@ authentication:
   enabled: false
   ## passwordAuthSecret is ignored if authentication is disabled
   passwordAuthSecret:
-  #segmentStoreToken is ignored if authentication is disabled
-  segmentStoreTokenSecret:
-  #controllerTokenSecret is ignored if authentication is disabled
-  controllerTokenSecret:
+  ##segmentStoreToken is ignored if authentication is disabled
+  #segmentStoreTokenSecret:
+  ##controllerTokenSecret is ignored if authentication is disabled
+  #controllerTokenSecret:
 
 zookeeperUri: zookeeper-client:2181
 bookkeeperUri: bookkeeper-bookie-headless:3181


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Adding Changes to Allow the latest operator to deploy 0.5.2 operator

### Purpose of the change
Fix #520 

### What the code does
I have made maxunavailable replicas for both ss and controller optional in pravega chart . Which should now allow for deploying of 0.5.2 pravega operator and finally pravega cluster. 

### How to verify it
Try deploying 0.5.2 operator with latest charts and then try deploying pravega cluster post that we should be able to deploy both.