### PR TITLE
Issue 525: Add suport of configurable extra configmap volume mounts

### DIFF
--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -163,4 +163,5 @@ options:
   # controller.metrics.output.frequency.seconds: "10"
   # controller.metrics.influxDB.connect.uri: "http://INFLUXDB-IP:8086"
   # hostPathVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"
-  # emptyDirVolumeMounts: "baz=/tmp/baz,quux=/tmp/quux"
+  # emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs"
+  # configMapVolumeMounts: "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml"

--- a/pkg/controller/pravega/pravega_controller_test.go
+++ b/pkg/controller/pravega/pravega_controller_test.go
@@ -91,7 +91,9 @@ var _ = Describe("Controller", func() {
 						ControllerJvmOptions:   []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						SegmentStoreJVMOptions: []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						Options: map[string]string{
-							"dummy-key": "dummy-value",
+							"dummy-key":             "dummy-value",
+							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
+							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						CacheVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
 							VolumeName: "abc",
@@ -133,6 +135,16 @@ var _ = Describe("Controller", func() {
 				It("should create the deployment", func() {
 					deploy := pravega.MakeControllerDeployment(p)
 					Ω(*deploy.Spec.Replicas).Should(Equal(int32(2)))
+				})
+
+				It("should have configMap/emptyDir VolumeMounts set to the values given by user", func() {
+					deploy := pravega.MakeControllerPodTemplate(p)
+					mounthostpath0 := deploy.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
+					mounthostpath1 := deploy.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath2 := deploy.Spec.Containers[0].VolumeMounts[1].MountPath
+					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
 				})
 
 				It("should create the service", func() {
@@ -211,7 +223,9 @@ var _ = Describe("Controller", func() {
 						ControllerJvmOptions:   []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						SegmentStoreJVMOptions: []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						Options: map[string]string{
-							"dummy-key": "dummy-value",
+							"dummy-key":             "dummy-value",
+							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
+							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						CacheVolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
 							VolumeName: "abc",
@@ -247,6 +261,16 @@ var _ = Describe("Controller", func() {
 				It("should create the deployment", func() {
 					deploy := pravega.MakeControllerDeployment(p)
 					Ω(deploy.Name).To(Equal(p.DeploymentNameForController()))
+				})
+
+				It("should have configMap/emptyDir VolumeMounts set to the values given by user", func() {
+					deploy := pravega.MakeControllerPodTemplate(p)
+					mounthostpath0 := deploy.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
+					mounthostpath1 := deploy.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath2 := deploy.Spec.Containers[0].VolumeMounts[1].MountPath
+					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
 				})
 
 				It("should create the service", func() {

--- a/pkg/controller/pravega/pravega_segmentstore_test.go
+++ b/pkg/controller/pravega/pravega_segmentstore_test.go
@@ -231,8 +231,8 @@ var _ = Describe("PravegaSegmentstore", func() {
 						Options: map[string]string{
 							"dummy-key":                            "dummy-value",
 							"pravegaservice.service.listener.port": "443",
-							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
-							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
+							"configMapVolumeMounts":                "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
+							"emptyDirVolumeMounts":                 "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						LongTermStorage: &v1beta1.LongTermStorageSpec{
 							FileSystem: &v1beta1.FileSystemSpec{

--- a/pkg/controller/pravega/pravega_segmentstore_test.go
+++ b/pkg/controller/pravega/pravega_segmentstore_test.go
@@ -96,7 +96,9 @@ var _ = Describe("PravegaSegmentstore", func() {
 						ControllerJvmOptions:   []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						SegmentStoreJVMOptions: []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						Options: map[string]string{
-							"dummy-key": "dummy-value",
+							"dummy-key":             "dummy-value",
+							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
+							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						LongTermStorage: &v1beta1.LongTermStorageSpec{
 							Ecs: &v1beta1.ECSSpec{
@@ -158,7 +160,13 @@ var _ = Describe("PravegaSegmentstore", func() {
 					Ω(err).Should(BeNil())
 				})
 				It("should create a stateful set", func() {
-					_ = pravega.MakeSegmentStoreStatefulSet(p)
+					sts := pravega.MakeSegmentStoreStatefulSet(p)
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
+					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
+					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
 					Ω(err).Should(BeNil())
 				})
 				It("should set external access service type to LoadBalancer", func() {
@@ -223,6 +231,8 @@ var _ = Describe("PravegaSegmentstore", func() {
 						Options: map[string]string{
 							"dummy-key":                            "dummy-value",
 							"pravegaservice.service.listener.port": "443",
+							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
+							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						LongTermStorage: &v1beta1.LongTermStorageSpec{
 							FileSystem: &v1beta1.FileSystemSpec{
@@ -274,7 +284,13 @@ var _ = Describe("PravegaSegmentstore", func() {
 				})
 
 				It("should create a stateful set", func() {
-					_ = pravega.MakeSegmentStoreStatefulSet(p)
+					sts := pravega.MakeSegmentStoreStatefulSet(p)
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
+					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
+					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
 					Ω(err).Should(BeNil())
 				})
 
@@ -330,7 +346,9 @@ var _ = Describe("PravegaSegmentstore", func() {
 						ControllerJvmOptions:   []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						SegmentStoreJVMOptions: []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"},
 						Options: map[string]string{
-							"dummy-key": "dummy-value",
+							"dummy-key":             "dummy-value",
+							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
+							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						LongTermStorage: &v1beta1.LongTermStorageSpec{
 							Hdfs: &v1beta1.HDFSSpec{
@@ -378,7 +396,13 @@ var _ = Describe("PravegaSegmentstore", func() {
 					Ω(err).Should(BeNil())
 				})
 				It("should create a stateful set", func() {
-					_ = pravega.MakeSegmentStoreStatefulSet(p)
+					sts := pravega.MakeSegmentStoreStatefulSet(p)
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
+					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
+					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
 					Ω(err).Should(BeNil())
 				})
 				It("should set external access service type to LoadBalancer", func() {

--- a/pkg/controller/pravega/pravega_segmentstore_test.go
+++ b/pkg/controller/pravega/pravega_segmentstore_test.go
@@ -99,6 +99,7 @@ var _ = Describe("PravegaSegmentstore", func() {
 							"dummy-key":             "dummy-value",
 							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
 							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
+							"hostPathVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						LongTermStorage: &v1beta1.LongTermStorageSpec{
 							Ecs: &v1beta1.ECSSpec{
@@ -161,12 +162,16 @@ var _ = Describe("PravegaSegmentstore", func() {
 				})
 				It("should create a stateful set", func() {
 					sts := pravega.MakeSegmentStoreStatefulSet(p)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
 					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
 					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
 					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath4 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath4).Should(Equal("/tmp/dumpfile/heap"))
 					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
 					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
+					mounthostpath3 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath
+					Ω(mounthostpath3).Should(Equal("/opt/pravega/logs"))
 					Ω(err).Should(BeNil())
 				})
 				It("should set external access service type to LoadBalancer", func() {
@@ -231,8 +236,6 @@ var _ = Describe("PravegaSegmentstore", func() {
 						Options: map[string]string{
 							"dummy-key":                            "dummy-value",
 							"pravegaservice.service.listener.port": "443",
-							"configMapVolumeMounts":                "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
-							"emptyDirVolumeMounts":                 "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						LongTermStorage: &v1beta1.LongTermStorageSpec{
 							FileSystem: &v1beta1.FileSystemSpec{
@@ -285,12 +288,8 @@ var _ = Describe("PravegaSegmentstore", func() {
 
 				It("should create a stateful set", func() {
 					sts := pravega.MakeSegmentStoreStatefulSet(p)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
-					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
-					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
-					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
-					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
-					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath0).Should(Equal("/tmp/dumpfile/heap"))
 					Ω(err).Should(BeNil())
 				})
 
@@ -349,6 +348,7 @@ var _ = Describe("PravegaSegmentstore", func() {
 							"dummy-key":             "dummy-value",
 							"configMapVolumeMounts": "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml",
 							"emptyDirVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
+							"hostPathVolumeMounts":  "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs",
 						},
 						LongTermStorage: &v1beta1.LongTermStorageSpec{
 							Hdfs: &v1beta1.HDFSSpec{
@@ -397,12 +397,16 @@ var _ = Describe("PravegaSegmentstore", func() {
 				})
 				It("should create a stateful set", func() {
 					sts := pravega.MakeSegmentStoreStatefulSet(p)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
 					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
 					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
 					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath4 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath4).Should(Equal("/tmp/dumpfile/heap"))
 					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
 					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
+					mounthostpath3 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath
+					Ω(mounthostpath3).Should(Equal("/opt/pravega/logs"))
 					Ω(err).Should(BeNil())
 				})
 				It("should set external access service type to LoadBalancer", func() {


### PR DESCRIPTION
### Change log description

- introduces the `configMapVolumeMounts` option as multiple key-value pairs, separated by commas and each consisting of a `<configMapName>`:`<configKey>`=`<configFilePath>` tuple.
- parses the `configMapVolumeMounts` values.
- adds the extracted values to the `volumes` list and containers' `volumeMounts` list.

### Purpose of the change

Implements #525 

Pravega operator should allow to specify "extra" configmap volumes to be mounted into pravega pods, including pravega segment store pods and pravega controller pods. Such config volumes may be used to import external configs for pravega use.

### What the code does

The code implements the new pravega option `configMapVolumeMounts`.
To use "extra" volumes in the pravega pods, in the Pravega options, specify:

- `configMapVolumeMounts` to add `configMap` volumes

The option consist of multiple key-value pairs, separated by commas and each consisting of a `<configMapName>`:`<configKey>`=`<configFilePath>` tuple:

`<configMapName>` is the name of the configmap to be mounted.
`<configKey>` is the key (file name) of the configmap data.
`<configFilePath>` is the path of the config file inside the container to be overriden..
For example, `configMapVolumeMounts: "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml"`

### How to verify it

1. Add the `configMapVolumeMounts` option to Pravega options parameter, e.g., `configMapVolumeMounts: "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml"`.
2. When the pravega cluster is deployed and ready, make sure that the the `volumes` list and containers' `volumeMounts` list has contained the configMapVolumeMounts volumes and mounts specified in the `configMapVolumeMounts`. In addition, make sure that the config file inside the pravega pods has been overriden by the data in the config map.

The function has worked as expected on the deployed pravega cluster in our environment. We've already successfully both the positive and negative test cases. In the negative case, I've also verified successfully the scenario that the pravega is install successfully as originally expected without all the customized pod labels and extra volume mounts parameters.