### PR TITLE
Issue 529: Add support  to configure the service and sts suffix generated by Pravega Operator

### DIFF
--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1045,6 +1045,9 @@ spec:
                       will automatically assign the default service account in the
                       namespace default
                     type: string
+                  controllerSvceNameSuffix:
+                    description: This is used as suffix for controller service name
+                    type: string
                   controllerSvcAnnotations:
                     additionalProperties:
                       type: string
@@ -1805,11 +1808,17 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  segmentStoreStsNameSuffix:
+                    description: This is used as suffix for segmentstore sts name
+                    type: string
+                  segmentStoreHeadlessSvcNameSuffix:
+                    description: This is used as suffix for segmentstore headless service name
+                    type: string
                   rollbacktimeout:
                     description: This is used to schedule the timeout value for rollback.
                     format: int32
                     minimum: 0
-                    type: integer  
+                    type: integer
                   segmentStoreResources:
                     description: SegmentStoreResources specifies the request and limit
                       of resources that segmentStore can have. SegmentStoreResources

--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1045,7 +1045,7 @@ spec:
                       will automatically assign the default service account in the
                       namespace default
                     type: string
-                  controllerSvceNameSuffix:
+                  controllerSvcNameSuffix:
                     description: This is used as suffix for controller service name
                     type: string
                   controllerSvcAnnotations:

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -136,6 +136,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `controller.service.annotations` | Annotations to add to the controller service, if external access is enabled | `{}` |
 | `controller.labels` | Labels to add to the controller pods | `{}` |
 | `controller.jvmOptions` | JVM Options for controller | `["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]` |
+| `controller.svcNameSuffix` | suffix for controller service name | `pravega-controller` |
 | `segmentStore.replicas` | Number of segmentStore replicas | `1` |
 | `segmentStore.maxUnavailableReplicas` | Maximum number of unavailable replicas possible for segmentstore pdb | |
 | `segmentStore.secret` | Secret configuration for the segmentStore | `{}` |
@@ -151,6 +152,8 @@ The following table lists the configurable parameters of the pravega chart and t
 | `segmentStore.service.loadBalancerIP` | It is used to provide a LoadBalancerIP for the segmentStore service | |
 | `segmentStore.service.externalTrafficPolicy` | It is used to provide ExternalTrafficPolicy for the segmentStore service |  |
 | `segmentStore.jvmOptions` | JVM Options for segmentStore | `[]` |
+| `segmentStore.stsNameSuffix` | suffix for segmentstore sts name | `pravega-segment-store` |
+| `segmentStore.headlessSvcNameSuffix` | suffix for segmentsdtore headless service name | `pravega-segmentstore-headless` |
 | `segmentStore.labels` | Labels to add to the segmentStore pods | `{}` |
 | `storage.longtermStorage.type` | Type of long term storage backend to be used (filesystem/ecs/hdfs) | `filesystem` |
 | `storage.longtermStorage.filesystem.pvc` | Name of the pre-created PVC, if long term storage type is filesystem | `pravega-tier2` |

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -91,6 +91,15 @@ spec:
       repository: {{ .Values.image.repository }}
       pullPolicy: {{ .Values.image.pullPolicy }}
     controllerReplicas: {{ .Values.controller.replicas }}
+    {{- if .Values.controller.svcNameSuffix }}
+    controllerSvcNameSuffix: {{ .Values.controller.svcNameSuffix }}
+    {{- end }}
+    {{- if .Values.segmentStore.stsNameSuffix }}
+    segmentStoreStsNameSuffix: {{ .Values.segmentStore.stsNameSuffix }}
+    {{- end }}
+    {{- if .Values.segmentStore.headlessSvcNameSuffix }}
+    segmentStoreHeadlessSvcNameSuffix: {{ .Values.segmentStore.headlessSvcNameSuffix }}
+    {{- end }}
     {{- if .Values.controller.maxUnavailableReplicas }}
     maxUnavailableControllerReplicas: {{ .Values.controller.maxUnavailableReplicas }}
     {{- end }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -46,6 +46,7 @@ serviceAccount:
 controller:
   replicas: 1
   maxUnavailableReplicas:
+  svcNameSuffix:
   resources:
     requests:
       cpu: 500m
@@ -90,6 +91,8 @@ segmentStore:
     externalTrafficPolicy:
   jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]
   labels: {}
+  stsNameSuffix:
+  headlessSvcNameSuffix:
 
 storage:
 

--- a/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1797,7 +1797,7 @@ spec:
                     description: This is used to schedule the timeout value for rollback.
                     format: int32
                     minimum: 0
-                    type: integer  
+                    type: integer
                   segmentStoreResources:
                     description: SegmentStoreResources specifies the request and limit
                       of resources that segmentStore can have. SegmentStoreResources

--- a/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/deploy/crds/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1033,6 +1033,9 @@ spec:
                       will automatically assign the default service account in the
                       namespace default
                     type: string
+                  controllerSvcNameSuffix:
+                    description: This is used as suffix for controller service name
+                    type: string
                   controllerSvcAnnotations:
                     additionalProperties:
                       type: string
@@ -1793,6 +1796,12 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  segmentStoreStsNameSuffix:
+                    description: This is used as suffix for segmentstore sts name
+                    type: string
+                  segmentStoreHeadlessSvcNameSuffix:
+                    description: This is used as suffix for segmentstore headless service name
+                    type: string
                   rollbacktimeout:
                     description: This is used to schedule the timeout value for rollback.
                     format: int32

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -14,3 +14,4 @@ This document explains how to configure Pravega
 * [Enable Authentication](auth.md)
 * [Enable external access](external-access.md)
 * [Enable admission webhook](webhook.md)
+* [Configuring Service and Sts Names](service-sts-name-configuration.md)

--- a/doc/service-sts-name-configuration.md
+++ b/doc/service-sts-name-configuration.md
@@ -1,6 +1,6 @@
 # Configuring SegmentStore Headless Service Name
 
-By default segmentstore headless service name is configured as  [PRAVEGA_CLUSTER_NAME] followed by string `-pravega-segmentstore-headless`.
+By default segmentstore headless service name is configured as  `[PRAVEGA_CLUSTER_NAME]-pravega-segmentstore-headless`.
 
 ```
 pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TCP    2d16h
@@ -9,19 +9,19 @@ pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TC
 But we can configure the headless service name as follows:
 
 ```
-helm install pravega pravega/pravega --set segmentStore.headlessSvcNameSuffix="segstore-svc"
+helm install pravega pravega/pravega --set segmentStore.headlessSvcNameSuffix="segmentstore-svc"
 ```
 
 After installation services can be listed using `kubectl get svc` command.
 
 ```
-pravega-segstore-svc    ClusterIP    None    <none>    12345/TCP    2d16h
+pravega-segmentstore-svc    ClusterIP    None    <none>    12345/TCP    2d16h
 
 ```
 
 # Configuring Segmentsore Statefulset Name
 
-By default segmentstore statefulset name  is configured as  [PRAVEGA_CLUSTER_NAME] followed by string `-pravega-segment-store`.
+By default segmentstore statefulset name  is configured as  `[PRAVEGA_CLUSTER_NAME]-pravega-segment-store`.
 
 ```
 pravega-pravega-segment-store    1/1     2d17h
@@ -30,19 +30,19 @@ pravega-pravega-segment-store    1/1     2d17h
 But we can configure the segmentstore statefulset name  as follows:
 
 ```
-helm install pravega pravega/pravega --set segmentStore.stsNameSuffix="segstore-sts"
+helm install pravega pravega/pravega --set segmentStore.stsNameSuffix="segmentstore-sts"
 ```
 
 After installation sts can be listed using `kubectl get sts` command.
 
 ```
-pravega-segstore-sts        1/1     2d17h
+pravega-segmentstore-sts        1/1     2d17h
 
 ```
 
 # Configuring Controller Service Name
 
-By default controller service name is configured as  [PRAVEGA_CLUSTER_NAME] followed by string `-pravega-controller`.
+By default controller service name is configured as  `[PRAVEGA_CLUSTER_NAME]-pravega-controller`.
 
 ```
 pravega-pravega-controller    ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP        2d16h

--- a/doc/service-sts-name-configuration.md
+++ b/doc/service-sts-name-configuration.md
@@ -1,6 +1,6 @@
 # Configuring SegmentStore Headless Service Name
 
-By default segmentstore headless service name is configured as [pravegaclustername] followed by string `-pravega-segmentstore-headless`.
+By default segmentstore headless service name is configured as `<pravegaclustername>` followed by string `-pravega-segmentstore-headless`.
 
 ```
 pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TCP    2d16h
@@ -21,7 +21,7 @@ pravega-segstore-svc    ClusterIP    None    <none>    12345/TCP    2d16h
 
 # Configuring Segmentsore Statefulset Name
 
-By default segmentstore statefulset name  is configured as [pravegaclustername] followed by string `-pravega-segment-store`.
+By default segmentstore statefulset name  is configured as `<pravegaclustername>` followed by string `-pravega-segment-store`.
 
 ```
 pravega-pravega-segment-store    1/1     2d17h
@@ -42,7 +42,7 @@ pravega-segstore-sts        1/1     2d17h
 
 # Configuring Controller Service Name
 
-By default controller service name is configured as [pravegaclustername] followed by string `-pravega-controller`.
+By default controller service name is configured as `<pravegaclustername>` followed by string `-pravega-controller`.
 
 ```
 pravega-pravega-controller    ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP        2d16h

--- a/doc/service-sts-name-configuration.md
+++ b/doc/service-sts-name-configuration.md
@@ -1,6 +1,6 @@
 # Configuring SegmentStore Headless Service Name
 
-By default segmentstore headless service name is configured as `<pravegaclustername>` followed by string `-pravega-segmentstore-headless`.
+By default segmentstore headless service name is configured as  [PRAVEGA_CLUSTER_NAME] followed by string `-pravega-segmentstore-headless`.
 
 ```
 pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TCP    2d16h
@@ -9,7 +9,7 @@ pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TC
 But we can configure the headless service name as follows:
 
 ```
-helm install pravega praveg/pravega --set segmentStore.headlessSvcNameSuffix="segstore-svc"
+helm install pravega pravega/pravega --set segmentStore.headlessSvcNameSuffix="segstore-svc"
 ```
 
 After installation services can be listed using `kubectl get svc` command.
@@ -21,7 +21,7 @@ pravega-segstore-svc    ClusterIP    None    <none>    12345/TCP    2d16h
 
 # Configuring Segmentsore Statefulset Name
 
-By default segmentstore statefulset name  is configured as `<pravegaclustername>` followed by string `-pravega-segment-store`.
+By default segmentstore statefulset name  is configured as  [PRAVEGA_CLUSTER_NAME] followed by string `-pravega-segment-store`.
 
 ```
 pravega-pravega-segment-store    1/1     2d17h
@@ -30,7 +30,7 @@ pravega-pravega-segment-store    1/1     2d17h
 But we can configure the segmentstore statefulset name  as follows:
 
 ```
-helm install pravega praveg/pravega --set segmentStore.stsNameSuffix="segstore-sts"
+helm install pravega pravega/pravega --set segmentStore.stsNameSuffix="segstore-sts"
 ```
 
 After installation sts can be listed using `kubectl get sts` command.
@@ -42,7 +42,7 @@ pravega-segstore-sts        1/1     2d17h
 
 # Configuring Controller Service Name
 
-By default controller service name is configured as `<pravegaclustername>` followed by string `-pravega-controller`.
+By default controller service name is configured as  [PRAVEGA_CLUSTER_NAME] followed by string `-pravega-controller`.
 
 ```
 pravega-pravega-controller    ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP        2d16h
@@ -52,7 +52,7 @@ pravega-pravega-controller    ClusterIP   10.100.200.173   <none>        10080/T
 But we can configure the controller service name as follows:
 
 ```
-helm install pravega praveg/pravega --set controller.svcNameSuffix="controllersvc"
+helm install pravega pravega/pravega --set controller.svcNameSuffix="controllersvc"
 ```
 
 After installation, services can be listed using `kubectl get svc` command.

--- a/doc/service-sts-name-configuration.md
+++ b/doc/service-sts-name-configuration.md
@@ -8,12 +8,17 @@ pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TC
 ```
 But we can configure the headless service name as follows:
 
+```
 helm install pravega praveg/pravega --set segmentStore.headlessSvcNameSuffix="segstore-svc"
+```
+
+After installation services can be listed using `kubectl get svc` command.
 
 ```
 pravega-segstore-svc    ClusterIP    None    <none>    12345/TCP    2d16h
 
 ```
+
 # Configuring Segmentsore Statefulset Name
 
 By default segmentstore statefulset name  is configured as <pravegaclustername> followed by string `-pravega-segment-store`.
@@ -24,7 +29,11 @@ pravega-pravega-segment-store    1/1     2d17h
 ```
 But we can configure the segmentstore statefulset name  as follows:
 
+```
 helm install pravega praveg/pravega --set segmentStore.stsNameSuffix="segstore-sts"
+```
+
+After installation sts can be listed using `kubectl get sts` command.
 
 ```
 pravega-segstore-sts        1/1     2d17h
@@ -39,9 +48,14 @@ By default controller service name is configured as <pravegaclustername> followe
 pravega-pravega-controller    ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP        2d16h
 
 ```
-But we can configure the headless service name as follows:
 
+But we can configure the controller service name as follows:
+
+```
 helm install pravega praveg/pravega --set controller.svcNameSuffix="controllersvc"
+```
+
+After installation, services can be listed using `kubectl get svc` command.
 
 ```
 pravega-controllersvc      ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP     2d16h

--- a/doc/service-sts-name-configuration.md
+++ b/doc/service-sts-name-configuration.md
@@ -1,6 +1,6 @@
 # Configuring SegmentStore Headless Service Name
 
-By default segmentstore headless service name is configured as <pravegaclustername> followed by string `-pravega-segmentstore-headless`.
+By default segmentstore headless service name is configured as [pravegaclustername] followed by string `-pravega-segmentstore-headless`.
 
 ```
 pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TCP    2d16h
@@ -21,7 +21,7 @@ pravega-segstore-svc    ClusterIP    None    <none>    12345/TCP    2d16h
 
 # Configuring Segmentsore Statefulset Name
 
-By default segmentstore statefulset name  is configured as <pravegaclustername> followed by string `-pravega-segment-store`.
+By default segmentstore statefulset name  is configured as [pravegaclustername] followed by string `-pravega-segment-store`.
 
 ```
 pravega-pravega-segment-store    1/1     2d17h
@@ -42,7 +42,7 @@ pravega-segstore-sts        1/1     2d17h
 
 # Configuring Controller Service Name
 
-By default controller service name is configured as <pravegaclustername> followed by string `-pravega-controller`.
+By default controller service name is configured as [pravegaclustername] followed by string `-pravega-controller`.
 
 ```
 pravega-pravega-controller    ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP        2d16h

--- a/doc/service-sts-name-configuration.md
+++ b/doc/service-sts-name-configuration.md
@@ -1,0 +1,49 @@
+# Configuring SegmentStore Headless Service Name
+
+By default segmentstore headless service name is configured as <pravegaclustername> followed by string `-pravega-segmentstore-headless`.
+
+```
+pravega-pravega-segmentstore-headless    ClusterIP    None    <none>    12345/TCP    2d16h
+
+```
+But we can configure the headless service name as follows:
+
+helm install pravega praveg/pravega --set segmentStore.headlessSvcNameSuffix="segstore-svc"
+
+```
+pravega-segstore-svc    ClusterIP    None    <none>    12345/TCP    2d16h
+
+```
+# Configuring Segmentsore Statefulset Name
+
+By default segmentstore statefulset name  is configured as <pravegaclustername> followed by string `-pravega-segment-store`.
+
+```
+pravega-pravega-segment-store    1/1     2d17h
+
+```
+But we can configure the segmentstore statefulset name  as follows:
+
+helm install pravega praveg/pravega --set segmentStore.stsNameSuffix="segstore-sts"
+
+```
+pravega-segstore-sts        1/1     2d17h
+
+```
+
+# Configuring Controller Service Name
+
+By default controller service name is configured as <pravegaclustername> followed by string `-pravega-controller`.
+
+```
+pravega-pravega-controller    ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP        2d16h
+
+```
+But we can configure the headless service name as follows:
+
+helm install pravega praveg/pravega --set controller.svcNameSuffix="controllersvc"
+
+```
+pravega-controllersvc      ClusterIP   10.100.200.173   <none>        10080/TCP,9090/TCP     2d16h
+
+```

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -203,6 +203,15 @@ type PravegaSpec struct {
 
 	//This is used to schedule the timeout value for rollback
 	RollbackTimeout int32 `json:"rollbacktimeout,omitempty"`
+
+	//This is used as suffix for controller service name
+	ControllerSvcNameSuffix string `json:"controllerSvcNameSuffix,omitempty"`
+
+	//This is used as suffix for segmentstore sts name
+	SegmentStoreStsNameSuffix string `json:"segmentStoreStsNameSuffix,omitempty"`
+
+	//This is used as suffix for segmentstore headless service name
+	SegmentStoreHeadlessSvcNameSuffix string `json:"segmentStoreHeadlessSvcNameSuffix,omitempty"`
 }
 
 func (s *PravegaSpec) withDefaults() (changed bool) {
@@ -317,6 +326,19 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 	if s.SegmentStorePodLabels == nil {
 		changed = true
 		s.SegmentStorePodLabels = map[string]string{}
+	}
+	if s.ControllerSvcNameSuffix == "" {
+		changed = true
+		s.ControllerSvcNameSuffix = "pravega-controller"
+	}
+
+	if s.SegmentStoreHeadlessSvcNameSuffix == "" {
+		changed = true
+		s.SegmentStoreHeadlessSvcNameSuffix = "pravega-segmentstore-headless"
+	}
+	if s.SegmentStoreStsNameSuffix == "" {
+		changed = true
+		s.SegmentStoreStsNameSuffix = "pravega-segment-store"
 	}
 
 	return changed

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -201,16 +201,16 @@ type PravegaSpec struct {
 	// The scheduling constraints on Segementstore pods.
 	SegmentStorePodAffinity *corev1.Affinity `json:"segmentStorePodAffinity,omitempty"`
 
-	//This is used to schedule the timeout value for rollback
+	// This is used to schedule the timeout value for rollback
 	RollbackTimeout int32 `json:"rollbacktimeout,omitempty"`
 
-	//This is used as suffix for controller service name
+	// This is used as suffix for controller service name
 	ControllerSvcNameSuffix string `json:"controllerSvcNameSuffix,omitempty"`
 
-	//This is used as suffix for segmentstore sts name
+	// This is used as suffix for segmentstore sts name
 	SegmentStoreStsNameSuffix string `json:"segmentStoreStsNameSuffix,omitempty"`
 
-	//This is used as suffix for segmentstore headless service name
+	// This is used as suffix for segmentstore headless service name
 	SegmentStoreHeadlessSvcNameSuffix string `json:"segmentStoreHeadlessSvcNameSuffix,omitempty"`
 }
 

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -291,10 +291,10 @@ type AuthenticationParameters struct {
 	// optional - used only by PasswordAuthHandler for authentication
 	PasswordAuthSecret string `json:"passwordAuthSecret,omitempty"`
 
-	//name of secret containg TokenSigningKey
+	// name of secret containg TokenSigningKey
 	ControllerTokenSecret string `json:"controllerTokenSecret,omitempty"`
 
-	//name of secret containg TokenSigningKey and AuthToken
+	// name of secret containg TokenSigningKey and AuthToken
 	SegmentStoreTokenSecret string `json:"segmentStoreTokenSecret,omitempty"`
 }
 

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -1249,7 +1249,7 @@ func (p *PravegaCluster) StatefulSetNameForSegmentstore() string {
 
 //if version is above or equals to 0.7 this name will be assigned
 func (p *PravegaCluster) StatefulSetNameForSegmentstoreAbove07() string {
-	return fmt.Sprintf("%s-pravega-segment-store", p.Name)
+	return fmt.Sprintf("%s-%s", p.Name, p.Spec.Pravega.SegmentStoreStsNameSuffix)
 }
 
 //if version is below 0.7 this name will be assigned
@@ -1299,7 +1299,7 @@ func (p *PravegaCluster) ConfigMapNameForController() string {
 }
 
 func (p *PravegaCluster) ServiceNameForController() string {
-	return fmt.Sprintf("%s-pravega-controller", p.Name)
+	return fmt.Sprintf("%s-%s", p.Name, p.Spec.Pravega.ControllerSvcNameSuffix)
 }
 
 func (p *PravegaCluster) ServiceNameForSegmentStore(index int32) string {
@@ -1314,11 +1314,11 @@ func (p *PravegaCluster) ServiceNameForSegmentStoreBelow07(index int32) string {
 }
 
 func (p *PravegaCluster) ServiceNameForSegmentStoreAbove07(index int32) string {
-	return fmt.Sprintf("%s-pravega-segment-store-%d", p.Name, index)
+	return fmt.Sprintf("%s-%s-%d", p.Name, p.Spec.Pravega.SegmentStoreStsNameSuffix, index)
 }
 
 func (p *PravegaCluster) HeadlessServiceNameForSegmentStore() string {
-	return fmt.Sprintf("%s-pravega-segmentstore-headless", p.Name)
+	return fmt.Sprintf("%s-%s", p.Name, p.Spec.Pravega.SegmentStoreHeadlessSvcNameSuffix)
 }
 
 func (p *PravegaCluster) HeadlessServiceNameForBookie() string {

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
@@ -347,6 +347,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			Ω(name).ShouldNot(BeNil())
 		})
 
+		p.WithDefaults()
 		name = p.StatefulSetNameForSegmentstoreAbove07()
 		It("Should return segmentstore sts name", func() {
 			Ω(name).ShouldNot(BeNil())
@@ -357,6 +358,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			Ω(name).ShouldNot(BeNil())
 		})
 
+		p.WithDefaults()
 		name = p.PravegaControllerServiceURL()
 		It("Should return controller service url", func() {
 			Ω(name).ShouldNot(BeNil())

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -21,6 +21,7 @@ import (
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
 	"github.com/pravega/pravega-operator/pkg/util"
 	zkapi "github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -867,6 +868,23 @@ func CheckExternalAccesss(t *testing.T, f *framework.Framework, ctx *framework.T
 		return fmt.Errorf("External Access is not enabled")
 	}
 	t.Logf("pravega cluster External Acess Validated: %s", pravega.Name)
+	return nil
+}
+
+func CheckServiceExists(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, pravega *api.PravegaCluster, svcName string) error {
+	svc := &corev1.Service{}
+	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: pravega.Namespace, Name: svcName}, svc)
+	if err != nil {
+		return fmt.Errorf("service doesnt exist: %v", err)
+	}
+	return nil
+}
+func CheckStsExists(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, pravega *api.PravegaCluster, stsName string) error {
+	sts := &appsv1.StatefulSet{}
+	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: pravega.Namespace, Name: stsName}, sts)
+	if err != nil {
+		return fmt.Errorf("sts doesnt exist: %v", err)
+	}
 	return nil
 }
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -11,6 +11,7 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -40,7 +41,23 @@ func testCreateRecreateCluster(t *testing.T) {
 	defaultCluster := pravega_e2eutil.NewDefaultCluster(namespace)
 	defaultCluster.WithDefaults()
 
+	defaultCluster.Spec.Pravega.ControllerSvcNameSuffix = "testcontroller"
+	defaultCluster.Spec.Pravega.SegmentStoreHeadlessSvcNameSuffix = "testsegstore"
+	defaultCluster.Spec.Pravega.SegmentStoreStsNameSuffix = "segsts"
+
 	pravega, err := pravega_e2eutil.CreatePravegaCluster(t, f, ctx, defaultCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	svcName := fmt.Sprintf("%s-testcontroller", pravega.Name)
+	err = pravega_e2eutil.CheckServiceExists(t, f, ctx, pravega, svcName)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	svcName = fmt.Sprintf("%s-testsegstore", pravega.Name)
+	err = pravega_e2eutil.CheckServiceExists(t, f, ctx, pravega, svcName)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	stsName := fmt.Sprintf("%s-segsts", pravega.Name)
+	err = pravega_e2eutil.CheckStsExists(t, f, ctx, pravega, stsName)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// A default Pravega cluster should have 2 pods: 1 controller, 1 segment store
@@ -68,6 +85,18 @@ func testCreateRecreateCluster(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	err = pravega_e2eutil.WaitForPravegaClusterToBecomeReady(t, f, ctx, pravega, podSize)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	svcName = fmt.Sprintf("%s-pravega-controller", pravega.Name)
+	err = pravega_e2eutil.CheckServiceExists(t, f, ctx, pravega, svcName)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	svcName = fmt.Sprintf("%s-pravega-segmentstore-headless", pravega.Name)
+	err = pravega_e2eutil.CheckServiceExists(t, f, ctx, pravega, svcName)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	stsName = fmt.Sprintf("%s-pravega-segment-store", pravega.Name)
+	err = pravega_e2eutil.CheckStsExists(t, f, ctx, pravega, stsName)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	err = pravega_e2eutil.WriteAndReadData(t, f, ctx, pravega)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -48,6 +48,11 @@ func testCreateRecreateCluster(t *testing.T) {
 	pravega, err := pravega_e2eutil.CreatePravegaCluster(t, f, ctx, defaultCluster)
 	g.Expect(err).NotTo(HaveOccurred())
 
+	// A default Pravega cluster should have 2 pods: 1 controller, 1 segment store
+	podSize := 2
+	err = pravega_e2eutil.WaitForPravegaClusterToBecomeReady(t, f, ctx, pravega, podSize)
+	g.Expect(err).NotTo(HaveOccurred())
+
 	svcName := fmt.Sprintf("%s-testcontroller", pravega.Name)
 	err = pravega_e2eutil.CheckServiceExists(t, f, ctx, pravega, svcName)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -58,11 +63,6 @@ func testCreateRecreateCluster(t *testing.T) {
 
 	stsName := fmt.Sprintf("%s-segsts", pravega.Name)
 	err = pravega_e2eutil.CheckStsExists(t, f, ctx, pravega, stsName)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	// A default Pravega cluster should have 2 pods: 1 controller, 1 segment store
-	podSize := 2
-	err = pravega_e2eutil.WaitForPravegaClusterToBecomeReady(t, f, ctx, pravega, podSize)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	err = pravega_e2eutil.WriteAndReadData(t, f, ctx, pravega)

--- a/test/e2e/resources/crd.yaml
+++ b/test/e2e/resources/crd.yaml
@@ -1035,6 +1035,9 @@ spec:
                       will automatically assign the default service account in the
                       namespace default
                     type: string
+                  controllerSvcNameSuffix:
+                    description: This is used as suffix for controller service name
+                    type: string
                   controllerSvcAnnotations:
                     additionalProperties:
                       type: string
@@ -1795,6 +1798,12 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  segmentStoreStsNameSuffix:
+                    description: This is used as suffix for segmentstore sts name
+                    type: string
+                  segmentStoreHeadlessSvcNameSuffix:
+                    description: This is used as suffix for segmentstore headless service name
+                    type: string
                   rollbacktimeout:
                     description: This is used to schedule the timeout value for rollback.
                     format: int32


### PR DESCRIPTION
### Change log description

Currently, in operator controller service name is hardcoded as `pravega cluster name`  followed by string `-pravega-controller`. Similarly, headless service name is  `pravega cluster name`  followed by string `-pravega-segment-store-headless` . So in case of providing  cluster names with more length installation is failing with error `service name should not be more than 63 characters`

### Purpose of the change

Fixes #529
### What the code does
Provide an option to configure service name suffix and sts name suffix.

### How to verify it

Verified the following scenarios
1. Installed Pravegacluster by configuring different suffix names for controller and segment store headless service and sts name. Service names are shown as clustername followed by configured suffix
2.  Installed pravegacluster without configuring suffix for service name and sts. Cluster is coming up with default suffix for service name and sts name
3. Verified upgrading the operator, service name and sts name is not changing and not creating new service or sts.
