### PR TITLE
Issue 532: Remove the end to end test that is not supported

### DIFF
--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,13 +57,14 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		"testCreateRecreateCluster":              testCreateRecreateCluster,
-		"testScaleCluster":                       testScaleCluster,
-		"testUpgradeCluster":                     testUpgradeCluster,
-		"testWebhook":                            testWebhook,
-		"testCMUpgradeCluster":                   testCMUpgradeCluster,
-		"testExternalCreateRecreateCluster":      testExternalCreateRecreateCluster,
-		"testCreatePravegaClusterWithTls":        testCreatePravegaClusterWithTls,
+		"testCreateRecreateCluster":         testCreateRecreateCluster,
+		"testScaleCluster":                  testScaleCluster,
+		"testUpgradeCluster":                testUpgradeCluster,
+		"testWebhook":                       testWebhook,
+		"testCMUpgradeCluster":              testCMUpgradeCluster,
+		"testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
+		// commenting out this test as pravega installation with TLS alone is not supported
+		//"testCreatePravegaClusterWithTls":        testCreatePravegaClusterWithTls,
 		"testDeletePods":                         testDeletePods,
 		"testRollbackPravegaCluster":             testRollbackPravegaCluster,
 		"testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Remove the invalid test that is not supported

### Purpose of the change

Fixes #532

### What the code does

Comment  out the invalid test.

### How to verify it

All end to end tests should pass
