### PR TITLE
Issue 544: Add ability to launch Controller's container in privileged mode

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -14,5 +14,5 @@ package config
 // the following changes:
 // - Disables Pravega Controller minimum number of replicas
 // - Disables Segment Store minimum number of replicas
-// - Enables privileged mode for Segment Store containers
+// - Enables privileged mode for Segment Store / Controller containers
 var TestMode bool

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	api "github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
+	"github.com/pravega/pravega-operator/pkg/controller/config"
 	"github.com/pravega/pravega-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -204,6 +205,9 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 					InitialDelaySeconds: 60,
 					PeriodSeconds:       15,
 					FailureThreshold:    4,
+				},
+				SecurityContext: &corev1.SecurityContext{
+					Privileged: &config.TestMode,
 				},
 			},
 		},


### PR DESCRIPTION
### Change log description

Enables "Privileged" mode for Pravega Controller container in case of test mode.

### Purpose of the change

Fixes https://github.com/pravega/pravega-operator/issues/544

### What the code does

Adds ability to launch Pravega Controller container with privileged mode.

### How to verify it
1. Deploy Pravega Operator with testmode enabled.
```
helm install pravega ... --set testmode.enabled=true
```
2. Deploy Pravega cluster.
3. Check that Pravega Controller is running with privileged mode.
```
kubectl get pod <pravega controller pod name> -o yaml | grep privileged
```