### PR TITLE
Issue 537: Making JVM Options configurable

### DIFF
--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -136,7 +136,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `controller.service.annotations` | Annotations to add to the controller service, if external access is enabled | `{}` |
 | `controller.labels` | Labels to add to the controller pods | `{}` |
 | `controller.annotations` | Annotations to add to the controller pods | `{}` |
-| `controller.jvmOptions` | JVM Options for controller | `["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]` |
+| `controller.jvmOptions` | JVM Options for controller | `["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]` |
 | `controller.svcNameSuffix` | suffix for controller service name | `pravega-controller` |
 | `segmentStore.replicas` | Number of segmentStore replicas | `1` |
 | `segmentStore.maxUnavailableReplicas` | Maximum number of unavailable replicas possible for segmentStore pdb | |
@@ -152,7 +152,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `segmentStore.service.annotations` | Annotations to add to the segmentStore service, if external access is enabled | `{}` |
 | `segmentStore.service.loadBalancerIP` | It is used to provide a LoadBalancerIP for the segmentStore service | |
 | `segmentStore.service.externalTrafficPolicy` | It is used to provide ExternalTrafficPolicy for the segmentStore service |  |
-| `segmentStore.jvmOptions` | JVM Options for segmentStore | `[]` |
+| `segmentStore.jvmOptions` | JVM Options for segmentStore | `["-Xms1g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]` |
 | `segmentStore.stsNameSuffix` | suffix for segmentStore sts name | `pravega-segment-store` |
 | `segmentStore.headlessSvcNameSuffix` | suffix for segmentStore headless service name | `pravega-segmentstore-headless` |
 | `segmentStore.labels` | Labels to add to the segmentStore pods | `{}` |

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -136,7 +136,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `controller.service.annotations` | Annotations to add to the controller service, if external access is enabled | `{}` |
 | `controller.labels` | Labels to add to the controller pods | `{}` |
 | `controller.annotations` | Annotations to add to the controller pods | `{}` |
-| `controller.jvmOptions` | JVM Options for controller | `["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]` |
+| `controller.jvmOptions` | JVM Options for controller | `["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]` |
 | `controller.svcNameSuffix` | suffix for controller service name | `pravega-controller` |
 | `segmentStore.replicas` | Number of segmentStore replicas | `1` |
 | `segmentStore.maxUnavailableReplicas` | Maximum number of unavailable replicas possible for segmentStore pdb | |
@@ -152,7 +152,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `segmentStore.service.annotations` | Annotations to add to the segmentStore service, if external access is enabled | `{}` |
 | `segmentStore.service.loadBalancerIP` | It is used to provide a LoadBalancerIP for the segmentStore service | |
 | `segmentStore.service.externalTrafficPolicy` | It is used to provide ExternalTrafficPolicy for the segmentStore service |  |
-| `segmentStore.jvmOptions` | JVM Options for segmentStore | `["-Xms1g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]` |
+| `segmentStore.jvmOptions` | JVM Options for segmentStore | `["-Xms1g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]` |
 | `segmentStore.stsNameSuffix` | suffix for segmentStore sts name | `pravega-segment-store` |
 | `segmentStore.headlessSvcNameSuffix` | suffix for segmentStore headless service name | `pravega-segmentstore-headless` |
 | `segmentStore.labels` | Labels to add to the segmentStore pods | `{}` |

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -62,7 +62,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
   labels: {}
   annotations: {}
 
@@ -90,7 +90,7 @@ segmentStore:
     annotations: {}
     loadBalancerIP:
     externalTrafficPolicy:
-  jvmOptions: ["-Xms1g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xms1g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
   labels: {}
   annotations: {}
   stsNameSuffix:

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -62,7 +62,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: []
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
   labels: {}
   annotations: {}
 
@@ -90,7 +90,7 @@ segmentStore:
     annotations: {}
     loadBalancerIP:
     externalTrafficPolicy:
-  jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]
+  jvmOptions: ["-Xms1g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
   labels: {}
   annotations: {}
   stsNameSuffix:
@@ -165,5 +165,5 @@ options:
   # controller.metrics.output.frequency.seconds: "10"
   # controller.metrics.influxDB.connect.uri: "http://INFLUXDB-IP:8086"
   # hostPathVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"
-  # emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap,log=/opt/pravega/logs"
+  emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap"
   # configMapVolumeMounts: "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml"

--- a/charts/pravega/values/large.yaml
+++ b/charts/pravega/values/large.yaml
@@ -12,7 +12,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: []
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
 
 segmentStore:
   replicas: 6
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=12g"]
+  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=12g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
 
 options:
   bookkeeper.ensemble.size: "3"
@@ -51,6 +51,7 @@ options:
   controller.service.asyncTaskPool.size: "20"
   controller.retention.thread.count: "4"
   log.level: "INFO"
+  emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap"
   ## The following parameters are only useful if you are going to deploy metrics in this cluster.
   # metrics.dynamicCache.size: "100000"
   # metrics.statistics.enable: "true"

--- a/charts/pravega/values/large.yaml
+++ b/charts/pravega/values/large.yaml
@@ -12,7 +12,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 segmentStore:
   replicas: 6
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=12g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=12g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"

--- a/charts/pravega/values/medium.yaml
+++ b/charts/pravega/values/medium.yaml
@@ -12,7 +12,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: []
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
 
 segmentStore:
   replicas: 2
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=4g"]
+  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=4g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
 
 options:
   bookkeeper.ensemble.size: "3"
@@ -51,6 +51,7 @@ options:
   controller.service.asyncTaskPool.size: "20"
   controller.retention.thread.count: "4"
   log.level: "INFO"
+  emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap"
   ## The following parameters are only useful if you are going to deploy metrics in this cluster.
   # metrics.dynamicCache.size: "100000"
   # metrics.statistics.enable: "true"

--- a/charts/pravega/values/medium.yaml
+++ b/charts/pravega/values/medium.yaml
@@ -12,7 +12,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 segmentStore:
   replicas: 2
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=4g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=4g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"

--- a/charts/pravega/values/small.yaml
+++ b/charts/pravega/values/small.yaml
@@ -12,7 +12,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: []
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
 
 segmentStore:
   replicas: 1
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g"]
+  jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
 
 options:
   bookkeeper.ensemble.size: "3"
@@ -51,6 +51,7 @@ options:
   controller.service.asyncTaskPool.size: "20"
   controller.retention.thread.count: "4"
   log.level: "INFO"
+  emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap"
   ## The following parameters are only useful if you are going to deploy metrics in this cluster.
   # metrics.dynamicCache.size: "100000"
   # metrics.statistics.enable: "true"

--- a/charts/pravega/values/small.yaml
+++ b/charts/pravega/values/small.yaml
@@ -12,7 +12,7 @@ controller:
     ## used to override the service type for controller
     type:
     annotations: {}
-  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 segmentStore:
   replicas: 1
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport"]
+  jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"

--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -16,7 +16,7 @@ spec:
 ```
 ### Pravega JVM Options
 
-It is also possible to tune the JVM options for Pravega Controller and Segmentstore. Pravega JVM options are for configuring Controller&Segmenstore JVM process whereas Pravega options are for configuring Pravega software.
+It is also possible to tune the JVM options for Pravega Controller and Segmentstore. Pravega JVM options are for configuring Controller & Segmenstore JVM process whereas Pravega options are for configuring Pravega software.
 
 Here is an example,
 ```
@@ -27,38 +27,7 @@ spec:
     segmentStoreJVMOptions: ["-XX:MaxDirectMemorySize=1g"]
 ...
 ```
-There are a bunch of default options in the Pravega operator code that is good for general deployment,  It is possible to override those default values by just passing the customized options. For example, the default option `"-XX:MaxDirectMemorySize=1g"` can be override by passing `"-XX:MaxDirectMemorySize=2g"` to
-the Pravega operator. The operator will detect `MaxDirectMemorySize` and override its default value if it exists.
-
-Default Controller JVM Options
-```
-"-Xms512m",
-"-XX:+ExitOnOutOfMemoryError",
-"-XX:+CrashOnOutOfMemoryError",
-"-XX:+HeapDumpOnOutOfMemoryError",
-"-XX:HeapDumpPath=" + heapDumpDir,
-```
-if Pravega version is greater or equal 0.4, then the followings are also added to the default Controller JVM Options
-```
-"-XX:+UnlockExperimentalVMOptions",
-"-XX:+UseContainerSupport",
-"-XX:MaxRAMPercentage=50.0"
-```
-
-Default Segmenstore JVM Options
-```
-"-Xms1g",
-"-XX:+ExitOnOutOfMemoryError",
-"-XX:+CrashOnOutOfMemoryError",
-"-XX:+HeapDumpOnOutOfMemoryError",
-"-XX:HeapDumpPath=" + heapDumpDir,
-```
-if Pravega version is greater or equal to 0.4, then the followings are also added to the default Segmenstore JVM Options
-```
-"-XX:+UnlockExperimentalVMOptions",
-"-XX:+UseContainerSupport",
-"-XX:MaxRAMPercentage=50.0"
-```
+We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest.
 
 ### SegmentStore Custom Configuration
 

--- a/pkg/controller/pravega/constants.go
+++ b/pkg/controller/pravega/constants.go
@@ -21,8 +21,6 @@ const (
 	tlsMountDir              = "/etc/secret-volume"
 	caBundleVolumeName       = "ca-bundle"
 	caBundleMountDir         = "/etc/secret-volume/ca-bundle"
-	heapDumpName             = "heap-dump"
-	heapDumpDir              = "/tmp/dumpfile/heap"
 	authVolumeName           = "auth-passwd-secret"
 	authMountDir             = "/etc/auth-passwd-volume"
 	defaultTokenSigningKey   = "secret"

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -109,21 +109,6 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 			}
 			volumeMounts = append(volumeMounts, m)
 		}
-	} else {
-		// if user did not set emptyDirVolumeMounts
-		v := corev1.Volume{
-			Name: heapDumpName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		}
-		volumes = append(volumes, v)
-
-		m := corev1.VolumeMount{
-			Name:      heapDumpName,
-			MountPath: heapDumpDir,
-		}
-		volumeMounts = append(volumeMounts, m)
 	}
 	if _, ok = p.Spec.Pravega.Options["configMapVolumeMounts"]; ok {
 		configMapVolumeMounts = strings.Split(p.Spec.Pravega.Options["configMapVolumeMounts"], ",")
@@ -272,25 +257,7 @@ func MakeControllerConfigMap(p *api.PravegaCluster) *corev1.ConfigMap {
 		"-Dpravegaservice.clusterName=" + p.Name,
 	}
 
-	jvmOpts := []string{
-		"-Xms512m",
-		"-XX:+ExitOnOutOfMemoryError",
-		"-XX:+CrashOnOutOfMemoryError",
-		"-XX:+HeapDumpOnOutOfMemoryError",
-		"-XX:HeapDumpPath=" + heapDumpDir,
-		"-Dpravegaservice.clusterName=" + p.Name,
-	}
-
-	if match, _ := util.CompareVersions(p.Spec.Version, "0.4.0", ">="); match {
-		// Pravega < 0.4 uses a Java version that does not support the options below
-		jvmOpts = append(jvmOpts,
-			"-XX:+UnlockExperimentalVMOptions",
-			"-XX:+UseContainerSupport",
-			"-XX:MaxRAMPercentage=50.0",
-		)
-	}
-
-	javaOpts = append(javaOpts, util.OverrideDefaultJVMOptions(jvmOpts, p.Spec.Pravega.ControllerJvmOptions)...)
+	javaOpts = util.OverrideDefaultJVMOptions(javaOpts, p.Spec.Pravega.ControllerJvmOptions)
 
 	for name, value := range p.Spec.Pravega.Options {
 		javaOpts = append(javaOpts, fmt.Sprintf("-D%v=%v", name, value))

--- a/pkg/controller/pravega/pravega_controller_test.go
+++ b/pkg/controller/pravega/pravega_controller_test.go
@@ -12,6 +12,7 @@ package pravega_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1beta1"
@@ -128,9 +129,13 @@ var _ = Describe("Controller", func() {
 					Ω(pdb.Name).Should(Equal(p.PdbNameForController()))
 				})
 
-				It("should create a config-map", func() {
+				It("should create a config-map and set the JVM options given by user", func() {
 					cm := pravega.MakeControllerConfigMap(p)
+					javaOpts := cm.Data["JAVA_OPTS"]
 					Ω(cm.Data["log.level"]).Should(Equal("DEBUG"))
+					Ω(strings.Contains(javaOpts, "-Dpravegaservice.clusterName=default")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxDirectMemorySize=1g")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxRAMPercentage=50.0")).Should(BeTrue())
 				})
 
 				It("should create the deployment", func() {
@@ -256,9 +261,13 @@ var _ = Describe("Controller", func() {
 					Ω(pdb.Spec.Selector.MatchLabels).To(Equal(p.LabelsForController()))
 				})
 
-				It("should create a config-map", func() {
+				It("should create a config-map and set the JVM options given by user", func() {
 					cm := pravega.MakeControllerConfigMap(p)
+					javaOpts := cm.Data["JAVA_OPTS"]
 					Ω(cm.Data["ZK_URL"]).To(Equal(p.Spec.ZookeeperUri))
+					Ω(strings.Contains(javaOpts, "-Dpravegaservice.clusterName=default")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxDirectMemorySize=1g")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxRAMPercentage=50.0")).Should(BeTrue())
 				})
 
 				It("should create the deployment", func() {

--- a/pkg/controller/pravega/pravega_segmentstore_test.go
+++ b/pkg/controller/pravega/pravega_segmentstore_test.go
@@ -157,6 +157,7 @@ var _ = Describe("PravegaSegmentstore", func() {
 					Ω(strings.Contains(javaOpts, "-XX:MaxDirectMemorySize=1g")).Should(BeTrue())
 					Ω(strings.Contains(javaOpts, "-XX:MaxRAMPercentage=50.0")).Should(BeTrue())
 					Ω(strings.Contains(javaOpts, "-Dpravegaservice.service.listener.port=12345")).Should(BeTrue())
+					Ω(err).Should(BeNil())
 				})
 
 				It("should create a config-map with empty tier2", func() {
@@ -168,16 +169,16 @@ var _ = Describe("PravegaSegmentstore", func() {
 
 				It("should create a stateful set", func() {
 					sts := pravega.MakeSegmentStoreStatefulSet(p)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
-					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
-					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
-					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
-					mounthostpath4 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
-					Ω(mounthostpath4).Should(Equal("/tmp/dumpfile/heap"))
-					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
-					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath0).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
+					Ω(mounthostpath1).Should(Equal("/opt/pravega/logs"))
+					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath2).Should(Equal("/tmp/dumpfile/heap"))
 					mounthostpath3 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath
 					Ω(mounthostpath3).Should(Equal("/opt/pravega/logs"))
+					mounthostpath4 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
+					Ω(mounthostpath4).Should(Equal("/opt/pravega/conf/logback.xml"))
 					Ω(err).Should(BeNil())
 				})
 
@@ -291,9 +292,13 @@ var _ = Describe("PravegaSegmentstore", func() {
 					Ω(err).Should(BeNil())
 				})
 
-				It("should create a config-map", func() {
+				It("should create a config-map and set the JVM options given by user", func() {
 					cm := pravega.MakeSegmentstoreConfigMap(p)
-					Ω(strings.Contains(cm.Data["JAVA_OPTS"], "-Dpravegaservice.service.listener.port=443")).Should(BeTrue())
+					javaOpts := cm.Data["JAVA_OPTS"]
+					Ω(strings.Contains(javaOpts, "-Dpravegaservice.clusterName=default")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxDirectMemorySize=1g")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxRAMPercentage=50.0")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-Dpravegaservice.service.listener.port=443")).Should(BeTrue())
 					Ω(err).Should(BeNil())
 				})
 
@@ -395,22 +400,27 @@ var _ = Describe("PravegaSegmentstore", func() {
 					Ω(err).Should(BeNil())
 				})
 
-				It("should create a config-map", func() {
-					_ = pravega.MakeSegmentstoreConfigMap(p)
+				It("should create a config-map and set the JVM options given by user", func() {
+					cm := pravega.MakeSegmentstoreConfigMap(p)
+					javaOpts := cm.Data["JAVA_OPTS"]
+					Ω(strings.Contains(javaOpts, "-Dpravegaservice.clusterName=default")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxDirectMemorySize=1g")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-XX:MaxRAMPercentage=50.0")).Should(BeTrue())
+					Ω(strings.Contains(javaOpts, "-Dpravegaservice.service.listener.port=12345")).Should(BeTrue())
 					Ω(err).Should(BeNil())
 				})
 				It("should create a stateful set", func() {
 					sts := pravega.MakeSegmentStoreStatefulSet(p)
-					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
-					Ω(mounthostpath0).Should(Equal("/opt/pravega/conf/logback.xml"))
-					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
-					Ω(mounthostpath1).Should(Equal("/tmp/dumpfile/heap"))
-					mounthostpath4 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
-					Ω(mounthostpath4).Should(Equal("/tmp/dumpfile/heap"))
-					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
-					Ω(mounthostpath2).Should(Equal("/opt/pravega/logs"))
+					mounthostpath0 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+					Ω(mounthostpath0).Should(Equal("/tmp/dumpfile/heap"))
+					mounthostpath1 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath
+					Ω(mounthostpath1).Should(Equal("/opt/pravega/logs"))
+					mounthostpath2 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath
+					Ω(mounthostpath2).Should(Equal("/tmp/dumpfile/heap"))
 					mounthostpath3 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[3].MountPath
 					Ω(mounthostpath3).Should(Equal("/opt/pravega/logs"))
+					mounthostpath4 := sts.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath
+					Ω(mounthostpath4).Should(Equal("/opt/pravega/conf/logback.xml"))
 					Ω(err).Should(BeNil())
 				})
 				It("should set external access service type to LoadBalancer", func() {

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -112,6 +112,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 				Ω(err).Should(BeNil())
 			})
 		})
+
 		Context("deleteOldSegmentStoreIfExist ", func() {
 			var (
 				client       client.Client
@@ -165,6 +166,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 				Ω(err1).Should(BeNil())
 			})
 		})
+
 		Context("syncControllerSize", func() {
 			var (
 				client       client.Client
@@ -199,6 +201,7 @@ var _ = Describe("PravegaCluster Controller", func() {
 				Ω(strings.ContainsAny(err1.Error(), "failed to get deployment")).Should(Equal(true))
 			})
 		})
+
 		Context("Without spec", func() {
 			var (
 				client       client.Client
@@ -538,11 +541,10 @@ var _ = Describe("PravegaCluster Controller", func() {
 				})
 
 				It("should set secret volume", func() {
-					Ω(foundController.Spec.Template.Spec.Volumes[0].Name).Should(Equal("heap-dump"))
-					Ω(foundController.Spec.Template.Spec.Volumes[1].Name).Should(Equal("tls-secret"))
-					Ω(foundController.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName).Should(Equal("controller-secret"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).Should(Equal("tls-secret"))
-					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).Should(Equal("/etc/secret-volume"))
+					Ω(foundController.Spec.Template.Spec.Volumes[0].Name).Should(Equal("tls-secret"))
+					Ω(foundController.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).Should(Equal("controller-secret"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).Should(Equal("tls-secret"))
+					Ω(foundController.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).Should(Equal("/etc/secret-volume"))
 				})
 
 				It("shoud overide pravega controller jvm options", func() {
@@ -593,11 +595,10 @@ var _ = Describe("PravegaCluster Controller", func() {
 				})
 
 				It("should set secret volume", func() {
-					Ω(foundSS.Spec.Template.Spec.Volumes[0].Name).Should(Equal("heap-dump"))
-					Ω(foundSS.Spec.Template.Spec.Volumes[1].Name).Should(Equal("tls-secret"))
-					Ω(foundSS.Spec.Template.Spec.Volumes[1].VolumeSource.Secret.SecretName).Should(Equal("segmentstore-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name).Should(Equal("tls-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath).Should(Equal("/etc/secret-volume"))
+					Ω(foundSS.Spec.Template.Spec.Volumes[0].Name).Should(Equal("tls-secret"))
+					Ω(foundSS.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).Should(Equal("segmentstore-secret"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).Should(Equal("tls-secret"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).Should(Equal("/etc/secret-volume"))
 				})
 
 				It("should overide pravega segmentstore jvm options", func() {

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -890,25 +890,21 @@ func CheckStsExists(t *testing.T, f *framework.Framework, ctx *framework.TestCtx
 	return nil
 }
 
-func CheckConfigMapUpdated(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, pravega *api.PravegaCluster, cmName string, key string, value string) error {
+func CheckConfigMapUpdated(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, pravega *api.PravegaCluster, cmName string, key string, values []string) error {
 	cm := &corev1.ConfigMap{}
 	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: pravega.Namespace, Name: cmName}, cm)
 	if err != nil {
 		return fmt.Errorf("failed to obtain configmap: %v", err)
 	}
-	fmt.Println("Printing configmap")
-	fmt.Printf("%+v", cm)
 	if cm != nil {
 		optvalue := cm.Data[key]
-		fmt.Println("Printing option value")
-		fmt.Println(optvalue)
-		if strings.Contains(optvalue, value) {
-			t.Logf("configmap is updated %s", cm.Name)
-			return nil
+		for _, value := range values {
+			if !strings.Contains(optvalue, value) {
+				return fmt.Errorf("config map is not updated")
+			}
 		}
 	}
-
-	return fmt.Errorf("config map is not updated")
+	return nil
 }
 
 func RestartTier2(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -896,6 +896,8 @@ func CheckConfigMapUpdated(t *testing.T, f *framework.Framework, ctx *framework.
 	if err != nil {
 		return fmt.Errorf("failed to obtain configmap: %v", err)
 	}
+	fmt.Println("Printing configmap")
+	fmt.Printf("%+v", cm)
 	if cm != nil {
 		optvalue := cm.Data[key]
 		fmt.Println("Printing option value")

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -903,6 +903,8 @@ func CheckConfigMapUpdated(t *testing.T, f *framework.Framework, ctx *framework.
 				return fmt.Errorf("config map is not updated")
 			}
 		}
+	} else {
+		return fmt.Errorf("config map is empty")
 	}
 	return nil
 }

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -898,6 +898,8 @@ func CheckConfigMapUpdated(t *testing.T, f *framework.Framework, ctx *framework.
 	}
 	if cm != nil {
 		optvalue := cm.Data[key]
+		fmt.Println("Printing option value")
+		fmt.Println(optvalue)
 		if strings.Contains(optvalue, value) {
 			t.Logf("configmap is updated %s", cm.Name)
 			return nil

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -92,6 +92,9 @@ func testCMUpgradeCluster(t *testing.T) {
 	pravega, err = pravega_e2eutil.GetPravegaCluster(t, f, ctx, pravega)
 	g.Expect(err).NotTo(HaveOccurred())
 
+	// Sleeping for 1 min before read/write data
+	time.Sleep(60 * time.Second)
+
 	// Check configmap is  Updated
 	fmt.Println("Checking updated configmap")
 	ss_val = "pravegaservice.service.listener.port=443"
@@ -106,9 +109,6 @@ func testCMUpgradeCluster(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", bk_val)
 	g.Expect(err).NotTo(HaveOccurred())
-
-	// Sleeping for 1 min before read/write data
-	time.Sleep(60 * time.Second)
 
 	err = pravega_e2eutil.WriteAndReadData(t, f, ctx, pravega)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -11,7 +11,6 @@
 package e2e
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -44,7 +43,6 @@ func testCMUpgradeCluster(t *testing.T) {
 
 	cluster.WithDefaults()
 	jvmOpts := []string{"-XX:MaxDirectMemorySize=1g", "-XX:MaxRAMPercentage=50.0"}
-	jvmOptions := strings.Join(jvmOpts, " ")
 	cluster.Spec.Pravega.Options["pravegaservice.containerCount"] = "3"
 	cluster.Spec.Pravega.ControllerJvmOptions = jvmOpts
 	cluster.Spec.Pravega.SegmentStoreJVMOptions = jvmOpts
@@ -64,17 +62,14 @@ func testCMUpgradeCluster(t *testing.T) {
 	// Check configmap has correct values
 	c_cm := pravega.ConfigMapNameForController()
 	ss_cm := pravega.ConfigMapNameForSegmentstore()
-	ss_val := "pravegaservice.service.listener.port=12345"
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, c_cm, "JAVA_OPTS", jvmOptions)
+	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, c_cm, "JAVA_OPTS", jvmOpts)
 	g.Expect(err).NotTo(HaveOccurred())
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", jvmOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", ss_val)
+	jvmOpts = append(jvmOpts, "pravegaservice.service.listener.port=12345")
+	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", jvmOpts)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	//updating pravega options
 	jvmOpts = []string{"-XX:MaxDirectMemorySize=4g", "-XX:MaxRAMPercentage=60.0", "-XX:+UseContainerSupport"}
-	jvmOptions = strings.Join(jvmOpts, " ")
 	pravega.Spec.Pravega.ControllerJvmOptions = jvmOpts
 	pravega.Spec.Pravega.SegmentStoreJVMOptions = jvmOpts
 	pravega.Spec.Pravega.Options["bookkeeper.bkAckQuorumSize"] = "2"
@@ -96,18 +91,11 @@ func testCMUpgradeCluster(t *testing.T) {
 	time.Sleep(60 * time.Second)
 
 	// Check configmap is  Updated
-	fmt.Println("Checking updated configmap")
-	ss_val = "pravegaservice.service.listener.port=443"
-	bk_val := "bookkeeper.bkAckQuorumSize=2"
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, c_cm, "JAVA_OPTS", jvmOptions)
+	jvmOpts = append(jvmOpts, "bookkeeper.bkAckQuorumSize=2")
+	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, c_cm, "JAVA_OPTS", jvmOpts)
 	g.Expect(err).NotTo(HaveOccurred())
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, c_cm, "JAVA_OPTS", bk_val)
-	g.Expect(err).NotTo(HaveOccurred())
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", jvmOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", ss_val)
-	g.Expect(err).NotTo(HaveOccurred())
-	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", bk_val)
+	jvmOpts = append(jvmOpts, "pravegaservice.service.listener.port=443")
+	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", jvmOpts)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	err = pravega_e2eutil.WriteAndReadData(t, f, ctx, pravega)

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -75,8 +75,8 @@ func testCMUpgradeCluster(t *testing.T) {
 	//updating pravega options
 	jvmOpts = []string{"-XX:MaxDirectMemorySize=4g", "-XX:MaxRAMPercentage=60.0", "-XX:+UseContainerSupport"}
 	jvmOptions = strings.Join(jvmOpts, " ")
-	cluster.Spec.Pravega.ControllerJvmOptions = jvmOpts
-	cluster.Spec.Pravega.SegmentStoreJVMOptions = jvmOpts
+	pravega.Spec.Pravega.ControllerJvmOptions = jvmOpts
+	pravega.Spec.Pravega.SegmentStoreJVMOptions = jvmOpts
 	pravega.Spec.Pravega.Options["bookkeeper.bkAckQuorumSize"] = "2"
 	pravega.Spec.Pravega.Options["pravegaservice.service.listener.port"] = "443"
 

--- a/test/e2e/cmchanges_test.go
+++ b/test/e2e/cmchanges_test.go
@@ -11,6 +11,7 @@
 package e2e
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -92,12 +93,18 @@ func testCMUpgradeCluster(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Check configmap is  Updated
+	fmt.Println("Checking updated configmap")
 	ss_val = "pravegaservice.service.listener.port=443"
+	bk_val := "bookkeeper.bkAckQuorumSize=2"
 	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, c_cm, "JAVA_OPTS", jvmOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, c_cm, "JAVA_OPTS", bk_val)
 	g.Expect(err).NotTo(HaveOccurred())
 	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", jvmOptions)
 	g.Expect(err).NotTo(HaveOccurred())
 	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", ss_val)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = pravega_e2eutil.CheckConfigMapUpdated(t, f, ctx, pravega, ss_cm, "JAVA_OPTS", bk_val)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Sleeping for 1 min before read/write data

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,17 +57,17 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		"testCreateRecreateCluster":         testCreateRecreateCluster,
-		"testScaleCluster":                  testScaleCluster,
-		"testUpgradeCluster":                testUpgradeCluster,
-		"testWebhook":                       testWebhook,
-		"testCMUpgradeCluster":              testCMUpgradeCluster,
-		"testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
+		// "testCreateRecreateCluster":         testCreateRecreateCluster,
+		// "testScaleCluster":                  testScaleCluster,
+		// "testUpgradeCluster":                testUpgradeCluster,
+		// "testWebhook":                       testWebhook,
+		"testCMUpgradeCluster": testCMUpgradeCluster,
+		// "testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
 		// commenting out this test as pravega installation with TLS alone is not supported
 		//"testCreatePravegaClusterWithTls":        testCreatePravegaClusterWithTls,
-		"testDeletePods":                         testDeletePods,
-		"testRollbackPravegaCluster":             testRollbackPravegaCluster,
-		"testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
+		// "testDeletePods":                         testDeletePods,
+		// "testRollbackPravegaCluster":             testRollbackPravegaCluster,
+		// "testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,17 +57,17 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		// "testCreateRecreateCluster":         testCreateRecreateCluster,
-		// "testScaleCluster":                  testScaleCluster,
-		// "testUpgradeCluster":                testUpgradeCluster,
-		// "testWebhook":                       testWebhook,
-		"testCMUpgradeCluster": testCMUpgradeCluster,
-		// "testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
+		"testCreateRecreateCluster":         testCreateRecreateCluster,
+		"testScaleCluster":                  testScaleCluster,
+		"testUpgradeCluster":                testUpgradeCluster,
+		"testWebhook":                       testWebhook,
+		"testCMUpgradeCluster":              testCMUpgradeCluster,
+		"testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
 		// commenting out this test as pravega installation with TLS alone is not supported
 		//"testCreatePravegaClusterWithTls":        testCreatePravegaClusterWithTls,
-		// "testDeletePods":                         testDeletePods,
-		// "testRollbackPravegaCluster":             testRollbackPravegaCluster,
-		// "testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
+		"testDeletePods":                         testDeletePods,
+		"testRollbackPravegaCluster":             testRollbackPravegaCluster,
+		"testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
 	}
 
 	for name, f := range testFuncs {


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Removes the hardcoded JVM options from the operator code, so that users can easily set their desired configuration through the charts, and also modify them if required.

### Purpose of the change
Fixes #537, #460 

### What the code does
Removes the hardcoded JVM options from the operator code.

### How to verify it
The segmentstore and controller should be configured with the JVM options that are provided within the values.yaml by the user. Also these values can be easily modified even after the pravega cluster has been deployed by editing the pravega cluster spec.
