### PR TITLE
Format  within pravega helm chart

### DIFF
--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -132,40 +132,95 @@ storage:
     className:
 
 options:
-  bookkeeper.ensemble.size: "3"
-  bookkeeper.write.quorum.size: "3"
-  bookkeeper.ack.quorum.size: "3"
-  bookkeeper.write.timeout.milliseconds: "60000"
-  bookkeeper.write.outstanding.bytes.max: "33554432"
-  pravegaservice.cache.size.max: "1073741824"
-  pravegaservice.cache.time.seconds.max: "600"
-  pravegaservice.service.listener.port: "12345"
-  hdfs.block.size: "67108864"
-  writer.flush.threshold.bytes: "67108864"
-  writer.flush.size.bytes.max: "67108864"
-  pravegaservice.container.count: "8"
-  controller.container.count: "8"
-  controller.retention.bucket.count: "4"
-  controller.service.asyncTaskPool.size: "20"
-  controller.retention.thread.count: "4"
-  log.level: "INFO"
+  bookkeeper:
+    ensemble:
+      size: "3"
+    ack:
+      quorum:
+        size: "3"
+    write:
+      quorum:
+        size: "3"
+      timeout:
+        milliseconds: "60000"
+      outstanding:
+        bytes:
+          max: "33554432"
+  pravegaservice:
+    container:
+      count: "8"
+    cache:
+      size:
+        max: "1073741824"
+      time:
+        seconds:
+          max: "600"
+    service:
+      listener:
+        port: "12345"
+  hdfs:
+    block:
+      size: "67108864"
+  writer:
+    flush:
+      threshold:
+        bytes: "67108864"
+      size:
+        bytes:
+          max: "67108864"  
+  controller:
+    container:
+      count: "8"
+    retention:
+      thread:
+        count: "4"
+      bucket:
+        count: "4"
+    service:
+      asyncTaskPool:
+        size: "20"
+    ## The following parameters are only useful if you are going to deploy metrics in this cluster.
+    # metrics:
+    #   dynamicCache:
+    #     size: "100000"
+    #   statistics:
+    #     enable: "true"
+    #   statsD:
+    #     reporter:
+    #       enable: "false"
+    #     connect:
+    #       host: "telegraph.default"
+    #       port: "8125"
+    #   influxDB:
+    #     reporter:
+    #       enable: "true"
+    #     connect:
+    #       uri: "http://INFLUXDB-IP:8086"
+    #   output:
+    #     frequency:
+    #       seconds: "10"
+  log:
+    level: "INFO"
   ## The following parameters are only useful if you are going to deploy metrics in this cluster.
-  # metrics.dynamicCache.size: "100000"
-  # metrics.statistics.enable: "true"
-  # metrics.statsD.reporter.enable: "false"
-  # metrics.statsD.connect.host: "telegraph.default"
-  # metrics.statsD.connect.port: "8125"
-  # metrics.influxDB.reporter.enable: "true"
-  # metrics.output.frequency.seconds: "10"
-  # metrics.influxDB.connect.uri: "http://INFLUXDB-IP:8086"
-  # controller.metrics.dynamicCache.size: "100000"
-  # controller.metrics.statistics.enable: "true"
-  # controller.metrics.statsD.reporter.enable: "false"
-  # controller.metrics.statsD.connect.host: "telegraph.default"
-  # controller.metrics.statsD.connect.port: "8125"
-  # controller.metrics.influxDB.reporter.enable: "true"
-  # controller.metrics.output.frequency.seconds: "10"
-  # controller.metrics.influxDB.connect.uri: "http://INFLUXDB-IP:8086"
+  # metrics:
+  #   dynamicCache:
+  #     size: "100000"
+  #   statistics:
+  #     enable: "true"
+  #   statsD:
+  #     reporter:
+  #       enable: "false"
+  #     connect:
+  #       host: "telegraph.default"
+  #       port: "8125"
+  #   influxDB:
+  #     reporter:
+  #       enable: "true"
+  #     connect:
+  #       uri: "http://INFLUXDB-IP:8086"
+  #   output:
+  #     frequency:
+  #       seconds: "10"
   # hostPathVolumeMounts: "foo=/tmp/foo,bar=/tmp/bar"
   emptyDirVolumeMounts: "heap-dump=/tmp/dumpfile/heap,logs=/opt/pravega/logs"
   # configMapVolumeMounts: "prvg-logback:logback.xml=/opt/pravega/conf/logback.xml"


### PR DESCRIPTION
### Change log description

Format `options` configs within Pravega helm chart, close #554 

### Purpose of the change

Reducing confusing behavior if using helm to override the `options` variables 

### What the code does

Format `options` section

### How to verify it

```bash
helm template pravega ./charts/pravega --version=0.9.0  -f ./charts/pravega/values.yaml \
     --set segmentStore.replicas=16 \
     --set options.controller.container.count=128 \
     --set options.pravegaservice.container.count=128 \
     --set options.pravegaservice.cache.size.max=4294967296 \
     --set options.pravegaservice.cache.time.seconds.max=600 \
     --set segmentStore.resources.requests.cpu=4000m \
     --set segmentStore.resources.requests.memory=4Gi \
     --set segmentStore.resources.limits.cpu=6000m \
     --set segmentStore.resources.limits.memory=8Gi \
     --set segmentStore.jvmOptions='{-Xms1g,-Xmx2g,-XX:MaxDirectMemorySize=6g,-XX:+ExitOnOutOfMemoryError,-XX:+CrashOnOutOfMemoryError,-XX:+HeapDumpOnOutOfMemoryError,-XX:HeapDumpPath=/tmp/dumpfile/heap,-XX:+UseContainerSupport}' \
     --timeout 15m --wait
```

Output:
```yaml
  options:
      bookkeeper:
        ack:
          quorum:
            size: "3"
        ensemble:
          size: "3"
        write:
          outstanding:
            bytes:
              max: "33554432"
          quorum:
            size: "3"
          timeout:
            milliseconds: "60000"
      controller:
        container:
          count: 128
        retention:
          bucket:
            count: "4"
          thread:
            count: "4"
        service:
          asyncTaskPool:
            size: "20"
      emptyDirVolumeMounts: heap-dump=/tmp/dumpfile/heap,logs=/opt/pravega/logs
      hdfs:
        block:
          size: "67108864"
      log:
        level: INFO
      pravegaservice:
        cache:
          size:
            max: 4294967296
          time:
            seconds:
              max: 600
        container:
          count: 128
        service:
          listener:
            port: "12345"
      writer:
        flush:
          size:
            bytes:
              max: "67108864"
          threshold:
            bytes: "67108864"
```