### PR TITLE
Issue 557: Many Pravega Spec parameters are still not updatable at runtime

### DIFF
--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -397,6 +397,62 @@ var _ = Describe("PravegaCluster Controller", func() {
 					})
 				})
 
+				Context("checking updateStatefulset", func() {
+					var (
+						err1 error
+						str1 string
+					)
+					BeforeEach(func() {
+
+						p.WithDefaults()
+						sts := &appsv1.StatefulSet{}
+						name := p.StatefulSetNameForSegmentstore()
+						foundPravega := &v1beta1.PravegaCluster{}
+						_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+						foundPravega.Spec.Pravega.SegmentStoreServiceAccountName = "testsa"
+						client.Update(context.TODO(), foundPravega)
+						_, _ = r.Reconcile(req)
+						err1 = r.client.Get(context.TODO(),
+							types.NamespacedName{Name: name, Namespace: p.Namespace}, sts)
+
+						str1 = fmt.Sprintf("%s", sts.Spec.Template.Spec.ServiceAccountName)
+					})
+					It("should not give error", func() {
+						Ω(err1).Should(BeNil())
+					})
+					It("service account name should get updated correctly", func() {
+						Ω(str1).To(Equal("testsa"))
+					})
+				})
+
+				Context("checking updateDeployment", func() {
+					var (
+						err1 error
+						str1 string
+					)
+					BeforeEach(func() {
+
+						p.WithDefaults()
+						deploy := &appsv1.Deployment{}
+						name := p.DeploymentNameForController()
+						foundPravega := &v1beta1.PravegaCluster{}
+						_ = client.Get(context.TODO(), req.NamespacedName, foundPravega)
+						foundPravega.Spec.Pravega.ControllerServiceAccountName = "testsa"
+						client.Update(context.TODO(), foundPravega)
+						_, _ = r.Reconcile(req)
+						err1 = r.client.Get(context.TODO(),
+							types.NamespacedName{Name: name, Namespace: p.Namespace}, deploy)
+
+						str1 = fmt.Sprintf("%s", deploy.Spec.Template.Spec.ServiceAccountName)
+					})
+					It("should not give error", func() {
+						Ω(err1).Should(BeNil())
+					})
+					It("service account name should get updated correctly", func() {
+						Ω(str1).To(Equal("testsa"))
+					})
+				})
+
 				Context("checking checkVersionUpgradeTriggered function", func() {
 					var (
 						ans1, ans2 bool

--- a/pkg/test/e2e/e2eutil/pravegacluster_util.go
+++ b/pkg/test/e2e/e2eutil/pravegacluster_util.go
@@ -909,6 +909,30 @@ func CheckConfigMapUpdated(t *testing.T, f *framework.Framework, ctx *framework.
 	return nil
 }
 
+// GetSts returns the sts
+func GetSts(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, stsName string) (*appsv1.StatefulSet, error) {
+	sts := &appsv1.StatefulSet{}
+	ns := "default"
+	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: ns, Name: stsName}, sts)
+	if err != nil {
+		return nil, fmt.Errorf("sts doesnt exist: %v", err)
+	}
+
+	return sts, nil
+}
+
+// GetDeployment returns the deployment
+func GetDeployment(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, deployName string) (*appsv1.Deployment, error) {
+	deploy := &appsv1.Deployment{}
+	ns := "default"
+	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: ns, Name: deployName}, deploy)
+	if err != nil {
+		return nil, fmt.Errorf("Deployment doesnt exist: %v", err)
+	}
+
+	return deploy, nil
+}
+
 func RestartTier2(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, namespace string) error {
 	t.Log("restarting tier2 storage")
 	tier2 := NewTier2(namespace)


### PR DESCRIPTION
### Change log description

Currently many parameters belonging to sts and deployment are not updatable at runtime. eg; Resources

### Purpose of the change

 Fixes #557

### What the code does

Made changes for updating statefulset and deployment if there are any changes to them

### How to verify it

Modified pravega cluster fields like resources and verified that sts and deployments are getting updated and pods are getting restarted.