### PR TITLE
Issue 564: Removing supported versions configmap

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,5 @@
+# Moved
+
+The pravega operator and pravega helm charts originally developed as part of this repository have been moved [here](https://github.com/pravega/charts/tree/master/charts).
+
+A copy of the charts will remain here till the migration is complete. We will however no longer accept pull requests for any modification to these charts. All subsequent issues and pull requests will be tracked in the [pravega/charts](https://github.com/pravega/charts) repository by following the guidelines mentioned [here](https://github.com/pravega/charts/wiki/Contributing).

--- a/deploy/version_map.yaml
+++ b/deploy/version_map.yaml
@@ -1,3 +1,4 @@
+# this file is deprecated and will be removed in future releases
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -10,7 +10,7 @@
 
 > Note: If you are running on Google Kubernetes Engine (GKE), please [check this first](development.md#installation-on-google-kubernetes-engine).
 
-In case you dont have a cert-manager, Install the cert-manager v0.15.0+ from the following link:-
+In case you don't have cert-manager v0.15.0+, install it from the following link :-
 
 https://cert-manager.io/docs/installation/kubernetes/
 
@@ -21,10 +21,6 @@ $ kubectl create -f deploy/certificate.yaml
 Install the webhook
 ```
 $ kubectl create -f deploy/webhook.yaml  
-```
-Install the version map for pravega-operator which contains the list of supported versions and supported upgrade paths for the pravega cluster
-```
-$ kubectl create -f  deploy/version_map.yaml
 ```
 Register the Pravega cluster custom resource definition (CRD).
 ```
@@ -99,7 +95,7 @@ where:
 - `[ZOOKEEPER_SVC]` is the name of client service of your Zookeeper deployment.
 - `[BOOKKEEPER_SVC]` is the name of the headless service of your Bookkeeper deployment.
 
-Check out other sample CR files in the [`example`](../example) directory.
+Check out other sample CR files in the [example](../example) directory.
 
 Deploy the Pravega cluster.
 

--- a/doc/operator-upgrade.md
+++ b/doc/operator-upgrade.md
@@ -13,21 +13,12 @@ Starting Operator version `0.4.3` we also support major version upgrades for Pra
 
 ## Upgrading till 0.4.5 or from 0.5.0 to above
 
-### Trigger the upgrade via helm
-
 Pravega operator can be upgraded to a version **[VERSION]** using the following command
 
 ```
 $ helm upgrade [PRAVEGA_OPERATOR_RELEASE_NAME] pravega/pravega-operator --version=[VERSION]
 ```
 
-### Trigger the upgrade manually
-
-The pravega operator with deployment name **[DEPLOYMENT_NAME]** can be upgraded manually by modifying the image tag using kubectl edit, patch or apply
-
-```
-$ kubectl edit [DEPLOYMENT_NAME]
-```
 The upgrade is handled as a [rolling update](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/) by Kubernetes and results in a new operator pod being created and the old one being terminated.
 
 ## Upgrading from 0.4.x to 0.5.0

--- a/doc/operator-upgrade.md
+++ b/doc/operator-upgrade.md
@@ -96,7 +96,7 @@ See: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/cus
 2. Cert-Manager v0.15.0+ or some other certificate management solution must be deployed for managing webhook service certificates. The upgrade trigger script assumes that the user has [cert-manager](https://cert-manager.io/docs/installation/kubernetes/) installed but any other cert management solution can also be used and script would need to be modified accordingly.
 To install cert-manager check [this](https://cert-manager.io/docs/installation/kubernetes/).
 
-3. [Bookkeeper Operator](https://github.com/pravega/bookkeeper-operator/tree/master/charts/bookkeeper-operator) version `0.1.3` or below must be deployed in the same namespace as Pravega Operator, prior to triggering the upgrade. You can upgrade to higher bookkeeper-operator versions later, if required. Also, Bookkeeper operator version map should contain the bookkeeper versions of the installed bookkeeper.
+3. [Bookkeeper Operator](https://github.com/pravega/bookkeeper-operator/tree/master/charts/bookkeeper-operator) version `0.1.3` or below must be deployed in the same namespace as Pravega Operator, prior to triggering the upgrade. You can upgrade to higher bookkeeper-operator versions later, if required.
 
 4. Install an Issuer and a Certificate (either self-signed or CA signed) in the same namespace as the Pravega Operator (refer to [this](https://github.com/pravega/pravega-operator/blob/master/deploy/certificate.yaml) manifest to create a self-signed certificate in the default namespace).
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -5,8 +5,6 @@
 * [Certificate Error: Internal error occurred: failed calling webhook](#certificate-error-internal-error-occurred-failed-calling-webhook)
 * [Segment store in CrashLoopBackOff](#segment-store-in-crashloopbackoff)
 * [Controller pod not in ready state](#controller-pod-not-in-ready-state)
-* [Unsupported Pravega cluster version](#unsupported-pravega-cluster-version)
-* [Unsupported upgrade from version](#unsupported-upgrade-from-version)
 * [NFS volume mount failure: wrong fs type](#nfs-volume-mount-failure-wrong-fs-type)
 * [Recover Statefulset when node fails](#recover-statefulset-when-node-fails)
 * [External-IP details truncated in older Kubectl Client Versions](#external-ip-details-truncated-in-older-kubectl-client-versions)
@@ -61,46 +59,6 @@ While installing pravega, if the controller pod goes in `0/1` state as below, it
 pravega-pravega-controller-68d68796f4-m5w7m             0/1     Running            0          15m
 ```
 To resolve this issue, we have to ensure that zookeeper, bookkeeper and longterm storage are recreated before doing the pravega installation.
-
-## Unsupported Pravega cluster version
-
-While installing pravega, if we get the below error
-```
-Error: admission webhook "pravegawebhook.pravega.io" denied the request: unsupported Pravega cluster version 0.10.0-2703.c9b7be114
-```
-We need to make sure the supported versions are present in config map by the following command
-
-`kubectl describe cm supported-versions-map`
-
-If the entries are not there in configmap, we have to add these options in the configmap by enabling test mode as follows while installing operator
-
-```
-helm install pravega-operator charts/pravega-operator --set testmode.enabled=true --set testmode.version="0.10.0"
-```
-
-Alternatively, we can edit the configmap and add entry as `0.10.0:0.10.0` in the configmap and restart the pravega-operator pod
-## Unsupported upgrade from version
-
-While upgrading pravega, if we get the error similar to below
-
-```
-Error from server (unsupported upgrade from version 0.8.0-2640.e4c436ba9 to 0.9.0-2752.2652549b3): error when applying patch
-```
-We need to make sure that supported versions are present in configmap as `0.8.0:0.9.0`. If the entries are missing, we have to add these options in the configmap by enabling test mode as follows while installing Operator
-
-If the version from which we are triggering upgrade is present in configmap, use the below command.
-
-```
-helm install pravega-operator charts/pravega-operator --set testmode.enabled=true --set testmode.version="0.9.0"
-```
-
-If the version from which we are triggering upgrade and the version to which upgrade is performed are not present in configmap use the below command
-
-```
-helm install pravega-operator charts/pravega-operator --set testmode.enabled=true --set testmode.fromVersion="0.8.0" --set testmode.version="0.9.0"
-```
-
-Alternatively, we can edit the configmap and add entry as `0.8.0:0.8.0,0.9.0` in the configmap and restart the pravega-operator pod
 
 ## NFS volume mount failure: wrong fs type
 

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -28,7 +28,7 @@ bar-pravega   0.4.0     7                 7               11m
 
 ## Valid Upgrade Paths
 
-To understand the valid upgrade paths for a pravega cluster, refer to the [version map](https://github.com/pravega/pravega-operator/blob/master/deploy/version_map.yaml). The key indicates the base version of the cluster, and the value against each key indicates the list of valid versions this base version can be upgraded to.
+Upgrade of pravega cluster to any version will be allowed as long as the user does not try to downgrade the cluster version.
 
 ## Trigger an upgrade
 

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -972,7 +972,7 @@ func (p *PravegaCluster) ValidatePravegaVersion() error {
 	if match, _ := util.CompareVersions(normRequestVersion, normFoundVersion, "<"); match {
 		return fmt.Errorf("downgrading the cluster from version %s to %s is not supported", p.Status.CurrentVersion, requestVersion)
 	}
-	log.Printf("validateBookkeeperVersion:: normFoundVersion %s", normFoundVersion)
+	log.Printf("ValidatePravegaVersion:: normFoundVersion %s", normFoundVersion)
 
 	log.Print("ValidatePravegaVersion:: No error found...returning...")
 	return nil

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -11,7 +11,6 @@
 package v1beta1
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -898,13 +897,13 @@ func (p *PravegaCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (p *PravegaCluster) ValidateCreate() error {
 	log.Printf("validate create %s", p.Name)
-	return p.ValidatePravegaVersion("")
+	return p.ValidatePravegaVersion()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (p *PravegaCluster) ValidateUpdate(old runtime.Object) error {
 	log.Printf("validate update %s", p.Name)
-	err := p.ValidatePravegaVersion("")
+	err := p.ValidatePravegaVersion()
 	if err != nil {
 		return err
 	}
@@ -922,42 +921,7 @@ func (p *PravegaCluster) ValidateDelete() error {
 	return nil
 }
 
-func getSupportedVersions(filename string) (map[string]string, error) {
-	var supportedVersions = map[string]string{}
-	filepath := filename
-	if filename == "" {
-		filepath = "/tmp/config/keys"
-	}
-
-	file, err := os.Open(filepath)
-
-	if err != nil {
-		log.Fatalf("failed opening file: %v", err)
-		return supportedVersions, nil
-	}
-
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
-	var txtlines []string
-
-	for scanner.Scan() {
-		txtlines = append(txtlines, scanner.Text())
-	}
-	defer file.Close()
-
-	for _, eachline := range txtlines {
-		entry := strings.Split(eachline, ":")
-		supportedVersions[entry[0]] = entry[1]
-	}
-	return supportedVersions, nil
-}
-
-func (p *PravegaCluster) ValidatePravegaVersion(filename string) error {
-	supportedVersions, err := getSupportedVersions(filename)
-	if err != nil {
-		return fmt.Errorf("Error retrieving suported versions %v", err)
-	}
-
+func (p *PravegaCluster) ValidatePravegaVersion() error {
 	if p.Spec.Version == "" {
 		p.Spec.Version = DefaultPravegaVersion
 	}
@@ -989,10 +953,6 @@ func (p *PravegaCluster) ValidatePravegaVersion(filename string) error {
 		return fmt.Errorf("request version is not in valid format: %v", err)
 	}
 
-	if _, ok := supportedVersions[normRequestVersion]; !ok {
-		return fmt.Errorf("unsupported Pravega cluster version %s", requestVersion)
-	}
-
 	if p.Status.CurrentVersion == "" {
 		// we're deploying for the very first time
 		return nil
@@ -1009,16 +969,11 @@ func (p *PravegaCluster) ValidatePravegaVersion(filename string) error {
 		return fmt.Errorf("found version is not in valid format, something bad happens: %v", err)
 	}
 
-	log.Printf("ValidatePravegaVersion:: normFoundVersion %s", normFoundVersion)
-	upgradeString, ok := supportedVersions[normFoundVersion]
-	if !ok {
-		// It should never happen
-		return fmt.Errorf("failed to find current cluster version in the supported versions")
+	if match, _ := util.CompareVersions(normRequestVersion, normFoundVersion, "<"); match {
+		return fmt.Errorf("downgrading the cluster from version %s to %s is not supported", p.Status.CurrentVersion, requestVersion)
 	}
-	upgradeList := strings.Split(upgradeString, ",")
-	if !util.ContainsVersion(upgradeList, normRequestVersion) {
-		return fmt.Errorf("unsupported upgrade from version %s to %s", p.Status.CurrentVersion, requestVersion)
-	}
+	log.Printf("validateBookkeeperVersion:: normFoundVersion %s", normFoundVersion)
+
 	log.Print("ValidatePravegaVersion:: No error found...returning...")
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Removes the supported versions configmap from the pravege operator.

### Purpose of the change
Fixes #564 

### What the code does
Removes the version validation from the validating webhook at the time of installation or upgrades of the pravega cluster. However the webhook will continue to check the format of the image being provided and will not allow any downgrade, unless while trying to rollback the cluster in case of a failed upgrade.

### How to verify it
The pravega operator should allow installation of any pravega version given in the correct format (i.e. *MAJOR*.*MINOR*.*PATCH*-*XXXX*), and should also allow upgrades to any other pravega version. Downgrades are however not allowed.

The following scenarios have been tested
- Upgrading the pravega operator from version 0.5.4 (which contains the version map) to the latest one (not containing the version map)
- Tested installation and upgrade to any pravega version is allowed
- Tested that the pravega operator does not allow using images which do not follow semantic versioning, and also does not allow the user from downgrading the pravega version
