### PR TITLE
Issue 566: Including operator base version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ SHELL=/bin/bash -o pipefail
 
 PROJECT_NAME=pravega-operator
 REPO=testpravegaop/$(PROJECT_NAME)
-VERSION=$(shell git describe --always --tags --dirty | sed "s/\(.*\)-g`git rev-parse --short HEAD`/\1/")
+BASE_VERSION=0.5.5
+ID=$(shell git rev-list HEAD --count)
 GIT_SHA=$(shell git rev-parse --short HEAD)
+VERSION=$(BASE_VERSION)-$(ID)-$(GIT_SHA)
 TEST_IMAGE=$(REPO)-testimages:$(VERSION)
 GOOS=linux
 GOARCH=amd64


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Hardcodes the base version of the operator in the Makefile, which needs to be updated after every pravega operator release, to serve as the base version.

### Purpose of the change
Fixes #566 

### What the code does
Hardcodes the pravega operator base version in the Makefile to compute the version for pravega operator images that are build using `make build-image` command.
The final version for the pravega operator is computed in the following format inside the Makefile
```
{base_version}-{number_of_commits}-{commit_id}
```

### How to verify it
Running the command `make build-image` should build the pravega operator image with version in the desired format
