### PR TITLE
Issue 357: Integrating health checks

### DIFF
--- a/doc/tls.md
+++ b/doc/tls.md
@@ -16,7 +16,9 @@ $ kubectl create secret generic controller-tls \
 $ kubectl create secret generic segmentstore-tls \
   --from-file=./segmentstore01.pem \
   --from-file=./ca-cert \
-  --from-file=./segmentstore01.key.pem
+  --from-file=./segmentstore01.key.pem \
+  --from-file=./segmentstore01.jks \
+  --from-file=./password
 ```
 
 Then specify the secret names in the `tls` block and the TLS parameters in the `options` block.
@@ -37,9 +39,14 @@ spec:
       controller.security.tls.enable: "true"
       controller.security.tls.server.certificate.location: "/etc/secret-volume/controller01.pem"
       controller.security.tls.server.privateKey.location: "/etc/secret-volume/controller01.key.pem"
+      controller.security.tls.trustStore.location: "/etc/secret-volume/ca-cert"
+      controller.security.tls.server.keyStore.location: "/etc/secret-volume/controller01.jks"
+      controller.security.tls.server.keyStore.pwd.location: "/etc/secret-volume/password"
       pravegaservice.security.tls.enable: "true"
       pravegaservice.security.tls.server.certificate.location: "/etc/secret-volume/segmentStore01.pem"
       pravegaservice.security.tls.server.privateKey.location: "/etc/secret-volume/segmentStore01.key.pem"
+      pravegaservice.security.tls.server.keyStore.location: "/etc/secret-volume/segmentStore01.jks"
+      pravegaservice.security.tls.server.keyStore.pwd.location: "/etc/secret-volume/password"
 ...
 ```
 

--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -358,6 +358,7 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		changed = true
 		s.SegmentStorePodLabels = map[string]string{}
 	}
+
 	if s.ControllerSvcNameSuffix == "" {
 		changed = true
 		s.ControllerSvcNameSuffix = "pravega-controller"

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -207,7 +207,7 @@ func (s *ClusterSpec) withDefaults(p *PravegaCluster) (changed bool) {
 		s.Pravega.SegmentStorePodAffinity = util.PodAntiAffinity("pravega-segmentstore", p.GetName())
 	}
 
-	if util.IsVersionBelow07(s.Version) && s.Pravega.CacheVolumeClaimTemplate == nil {
+	if util.IsVersionBelow(s.Version, "0.7.0") && s.Pravega.CacheVolumeClaimTemplate == nil {
 		changed = true
 		s.Pravega.CacheVolumeClaimTemplate = &corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -454,7 +454,7 @@ func (dst *PravegaCluster) updatePravegaOwnerReferences() error {
 }
 
 func (dst *PravegaCluster) updateSSSReferences(ownerRefs []metav1.OwnerReference) error {
-	if util.IsVersionBelow07(dst.Spec.Version) {
+	if util.IsVersionBelow(dst.Spec.Version, "0.7.0") {
 		numPvcs := int(dst.Spec.Pravega.SegmentStoreReplicas)
 		for i := 0; i < numPvcs; i++ {
 			pvcName := "cache-" + dst.StatefulSetNameForSegmentstoreBelow07() + "-" + strconv.Itoa(i)
@@ -1196,7 +1196,7 @@ func (p *PravegaCluster) validateConfigMap() error {
 
 //to return name of segmentstore based on the version
 func (p *PravegaCluster) StatefulSetNameForSegmentstore() string {
-	if util.IsVersionBelow07(p.Spec.Version) {
+	if util.IsVersionBelow(p.Spec.Version, "0.7.0") {
 		return p.StatefulSetNameForSegmentstoreBelow07()
 	}
 	return p.StatefulSetNameForSegmentstoreAbove07()
@@ -1278,7 +1278,7 @@ func (p *PravegaCluster) ServiceNameForController() string {
 }
 
 func (p *PravegaCluster) ServiceNameForSegmentStore(index int32) string {
-	if util.IsVersionBelow07(p.Spec.Version) {
+	if util.IsVersionBelow(p.Spec.Version, "0.7.0") {
 		return p.ServiceNameForSegmentStoreBelow07(index)
 	}
 	return p.ServiceNameForSegmentStoreAbove07(index)

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -133,7 +133,7 @@ type ClusterSpec struct {
 	// The version must follow the [semver]( http://semver.org) format, for example "3.2.13".
 	// Only Pravega released versions are supported: https://github.com/pravega/pravega/releases
 	//
-	// If version is not set, default is "0.4.0".
+	// If version is not set, default value will be set.
 	// +optional
 	Version string `json:"version"`
 

--- a/pkg/controller/pravega/pravega_controller.go
+++ b/pkg/controller/pravega/pravega_controller.go
@@ -170,7 +170,7 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: util.ControllerReadinessCheck(10080, p.Spec.Authentication.IsEnabled()),
+							Command: util.ControllerReadinessCheck(p.Spec.Version, 10080, p.Spec.Authentication.IsEnabled()),
 						},
 					},
 					// Controller pods start fast. We give it up to 20 seconds to become ready.
@@ -181,7 +181,7 @@ func makeControllerPodSpec(p *api.PravegaCluster) *corev1.PodSpec {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: util.HealthcheckCommand(9090),
+							Command: util.HealthcheckCommand(p.Spec.Version, 9090, 10080),
 						},
 					},
 					// We start the liveness probe from the maximum time the pod can take

--- a/pkg/controller/pravega/pravega_segmentstore.go
+++ b/pkg/controller/pravega/pravega_segmentstore.go
@@ -55,7 +55,7 @@ func MakeSegmentStoreStatefulSet(p *api.PravegaCluster) *appsv1.StatefulSet {
 			},
 		},
 	}
-	if util.IsVersionBelow07(p.Spec.Version) {
+	if util.IsVersionBelow(p.Spec.Version, "0.7.0") {
 		statefulSet.Spec.VolumeClaimTemplates = makeCacheVolumeClaimTemplate(p)
 	}
 	return statefulSet
@@ -179,7 +179,7 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 			volumeMounts = append(volumeMounts, m)
 		}
 	}
-	if util.IsVersionBelow07(p.Spec.Version) {
+	if util.IsVersionBelow(p.Spec.Version, "0.7.0") {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      cacheVolumeName,
 			MountPath: cacheVolumeMountPoint,
@@ -209,7 +209,7 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: util.HealthcheckCommand(int32(containerport)),
+							Command: util.SegmentStoreReadinessCheck(p.Spec.Version, int32(containerport), 6061),
 						},
 					},
 					// Segment Stores can take a few minutes to become ready when the cluster
@@ -222,7 +222,7 @@ func makeSegmentstorePodSpec(p *api.PravegaCluster) corev1.PodSpec {
 				LivenessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
 						Exec: &corev1.ExecAction{
-							Command: util.HealthcheckCommand(int32(containerport)),
+							Command: util.HealthcheckCommand(p.Spec.Version, int32(containerport), 6061),
 						},
 					},
 					// In the readiness probe we allow the pod to take up to 5 minutes

--- a/pkg/controller/pravegacluster/pravegacluster_controller.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller.go
@@ -527,7 +527,7 @@ func (r *ReconcilePravegaCluster) deployCluster(p *pravegav1beta1.PravegaCluster
 			return err
 		}
 
-		if !util.IsVersionBelow07(p.Spec.Version) {
+		if !util.IsVersionBelow(p.Spec.Version, "0.7.0") {
 			newsts := &appsv1.StatefulSet{}
 			name := p.StatefulSetNameForSegmentstoreAbove07()
 			err = r.client.Get(context.TODO(),
@@ -1026,7 +1026,7 @@ func (r *ReconcilePravegaCluster) isRollbackTriggered(p *pravegav1beta1.PravegaC
 
 //this function will return true only in case of upgrading from a version below 0.7 to pravega version 0.7 or later
 func (r *ReconcilePravegaCluster) IsClusterUpgradingTo07(p *pravegav1beta1.PravegaCluster) bool {
-	if !util.IsVersionBelow07(p.Spec.Version) && util.IsVersionBelow07(p.Status.CurrentVersion) {
+	if !util.IsVersionBelow(p.Spec.Version, "0.7.0") && util.IsVersionBelow(p.Status.CurrentVersion, "0.7.0") {
 		return true
 	}
 	return false

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -235,7 +235,6 @@ var _ = Describe("PravegaCluster Controller", func() {
 					Ω(foundPravega.Spec.ExternalAccess.Enabled).Should(Equal(false))
 					Ω(foundPravega.Spec.ExternalAccess.DomainName).Should(Equal(""))
 					Ω(foundPravega.Spec.Pravega).ShouldNot(BeNil())
-					fmt.Println("DEFAULTS ARE SET")
 				})
 			})
 
@@ -653,8 +652,8 @@ var _ = Describe("PravegaCluster Controller", func() {
 				It("should set secret volume", func() {
 					Ω(foundSS.Spec.Template.Spec.Volumes[0].Name).Should(Equal("tls-secret"))
 					Ω(foundSS.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).Should(Equal("segmentstore-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).Should(Equal("tls-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).Should(Equal("/etc/secret-volume"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).Should(Equal("tls-secret"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).Should(Equal("/etc/secret-volume"))
 				})
 
 				It("should overide pravega segmentstore jvm options", func() {

--- a/pkg/controller/pravegacluster/pravegacluster_controller_test.go
+++ b/pkg/controller/pravegacluster/pravegacluster_controller_test.go
@@ -653,8 +653,8 @@ var _ = Describe("PravegaCluster Controller", func() {
 				It("should set secret volume", func() {
 					Ω(foundSS.Spec.Template.Spec.Volumes[0].Name).Should(Equal("tls-secret"))
 					Ω(foundSS.Spec.Template.Spec.Volumes[0].VolumeSource.Secret.SecretName).Should(Equal("segmentstore-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).Should(Equal("tls-secret"))
-					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).Should(Equal("/etc/secret-volume"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).Should(Equal("tls-secret"))
+					Ω(foundSS.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).Should(Equal("/etc/secret-volume"))
 				})
 
 				It("should overide pravega segmentstore jvm options", func() {

--- a/pkg/controller/pravegacluster/upgrade.go
+++ b/pkg/controller/pravegacluster/upgrade.go
@@ -408,7 +408,7 @@ func (r *ReconcilePravegaCluster) syncSegmentStoreVersion(p *pravegav1beta1.Prav
 
 //this function is to check are we doing a rollback in case of a upgrade failure while upgrading from a version below 07 to a version above 07
 func (r *ReconcilePravegaCluster) IsClusterRollbackingFrom07(p *pravegav1beta1.PravegaCluster) bool {
-	if util.IsVersionBelow07(p.Spec.Version) && r.IsAbove07STSPresent(p) {
+	if util.IsVersionBelow(p.Spec.Version, "0.7.0") && r.IsAbove07STSPresent(p) {
 		return true
 	}
 	return false
@@ -452,7 +452,7 @@ func (r *ReconcilePravegaCluster) deleteExternalServices(p *pravegav1beta1.Prave
 	var name string = ""
 	for i := int32(0); i < p.Spec.Pravega.SegmentStoreReplicas; i++ {
 		service := &corev1.Service{}
-		if !util.IsVersionBelow07(p.Spec.Version) {
+		if !util.IsVersionBelow(p.Spec.Version, "0.7.0") {
 			name = p.ServiceNameForSegmentStoreBelow07(i)
 		} else {
 			name = p.ServiceNameForSegmentStoreAbove07(i)

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -78,7 +78,7 @@ func HealthcheckCommand(version string, port int32, restport int32) []string {
 	if IsVersionBelow(version, compareVersion) {
 		command = fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)
 	} else {
-		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/liveness'", restport)
+		command = fmt.Sprintf("(netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d) && (curl -s -X GET 'http://localhost:%d/v1/health/liveness' || curl -s -k -X GET 'https://localhost:%d/v1/health/liveness')", port, port, restport, restport)
 	}
 	return []string{"/bin/sh", "-c", command}
 }
@@ -106,7 +106,7 @@ func ControllerReadinessCheck(version string, port int32, authflag bool) []strin
 			command = fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'|| (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system') ", port, port, port, port)
 		}
 	} else {
-		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/readiness'", port)
+		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/readiness' || curl -s -k -X GET 'https://localhost:%d/v1/health/readiness'", port, port)
 	}
 	return []string{"/bin/sh", "-c", command}
 }
@@ -116,7 +116,7 @@ func SegmentStoreReadinessCheck(version string, port int32, restport int32) []st
 	if IsVersionBelow(version, compareVersion) {
 		command = fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)
 	} else {
-		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/readiness'", restport)
+		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/readiness' || curl -s -k -X GET 'https://localhost:%d/v1/health/readiness'", restport, restport)
 	}
 	return []string{"/bin/sh", "-c", command}
 }

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -36,11 +36,11 @@ func init() {
 }
 
 //function to check if the version is below 0.7 or not
-func IsVersionBelow07(ver string) bool {
-	if ver == "" {
+func IsVersionBelow(version string, comp string) bool {
+	if version == "" {
 		return true
 	}
-	result, _ := CompareVersions(ver, "0.7.0", "<")
+	result, _ := CompareVersions(version, comp, "<")
 	if result {
 		return true
 	}
@@ -69,29 +69,52 @@ func IsOrphan(k8sObjectName string, replicas int32) bool {
 	return int32(ordinal) >= replicas
 }
 
-func HealthcheckCommand(port int32) []string {
-	return []string{"/bin/sh", "-c", fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)}
+func HealthcheckCommand(version string, port int32, restport int32) []string {
+	command := ""
+	if IsVersionBelow(version, "0.10.0") {
+		command = fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)
+	} else {
+		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/liveness' | grep true", restport)
+	}
+	return []string{"/bin/sh", "-c", command}
 }
 
-//This function check for the readiness of the controller in the following cases
-//1) Auth and TLS Enabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
-//2) Auth Enabled and TLS Disabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
-//3) Auth Disabled and TLS Enabled- in this case, we check if the controller can create scopes or not by checking if _system scope is present or not
-//4) Auth and TLS Disabled- in this case, we check if the controller can create scopes or not by checking if _system scope is present or not
-func ControllerReadinessCheck(port int32, authflag bool) []string {
-	// This is to check the readiness of controller in case auth is Enabled
-	// here we are using login credential as testtls:testtls which should
-	// not be used as auth credential and we depend on controller giving us
-	// 401 error which means controller is properly configured with auth
-	// it checks both cases when tls is enabled as well as tls disabled
-	// with auth enabled
-	if authflag == true {
-		return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 || (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) ||  (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) || (curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 )", port, port, port, port)}
+func ControllerReadinessCheck(version string, port int32, authflag bool) []string {
+	command := ""
+	if IsVersionBelow(version, "0.10.0") {
+		//This function check for the readiness of the controller in the following cases
+		//1) Auth and TLS Enabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
+		//2) Auth Enabled and TLS Disabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
+		//3) Auth Disabled and TLS Enabled- in this case, we check if the controller can create scopes or not by checking if _system scope is present or not
+		//4) Auth and TLS Disabled- in this case, we check if the controller can create scopes or not by checking if _system scope is present or not
+		if authflag == true {
+			// This is to check the readiness of controller in case auth is Enabled
+			// here we are using login credential as testtls:testtls which should
+			// not be used as auth credential and we depend on controller giving us
+			// 401 error which means controller is properly configured with auth
+			// it checks both cases when tls is enabled as well as tls disabled
+			// with auth enabled
+			command = fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 || (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) ||  (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -v -k -u testtls:testtls -s -X GET 'https://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 ) || (curl -v -k -u testtls:testtls -s -X GET 'http://localhost:%d/v1/scopes/' 2>&1 -H 'accept: application/json' | grep 401 )", port, port, port, port)
+		} else {
+			// This is to check the readiness in case auth is not enabled
+			// and it covers both the cases with tls enabled and tls disabled
+			// along with auth disabled
+			command = fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'|| (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system') ", port, port, port, port)
+		}
+	} else {
+		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/readiness' | grep true", port)
 	}
-	// This is to check the readiness in case auth is not enabled
-	// and it covers both the cases with tls enabled and tls disabled
-	// along with auth disabled
-	return []string{"/bin/sh", "-c", fmt.Sprintf("echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=true' &&  curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system'|| (echo $JAVA_OPTS | grep 'controller.auth.tlsEnabled=false' && curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (echo $JAVA_OPTS | grep 'controller.security.tls.enable=true' && echo $JAVA_OPTS | grep -v 'controller.auth.tlsEnabled' && curl -s -X GET 'https://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system' ) || (curl -s -X GET 'http://localhost:%d/v1/scopes/' -H 'accept: application/json' | grep '_system') ", port, port, port, port)}
+	return []string{"/bin/sh", "-c", command}
+}
+
+func SegmentStoreReadinessCheck(version string, port int32, restport int32) []string {
+	command := ""
+	if IsVersionBelow(version, "0.10.0") {
+		command = fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)
+	} else {
+		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/readiness' | grep true", restport)
+	}
+	return []string{"/bin/sh", "-c", command}
 }
 
 // Min returns the smaller of x or y.
@@ -156,7 +179,9 @@ func ContainsVersion(list []string, version string) bool {
 }
 
 func NormalizeVersion(version string) (string, error) {
+	fmt.Println(version)
 	matches := versionRegexp.FindStringSubmatch(version)
+	fmt.Println(matches)
 	if matches == nil || len(matches) <= 1 {
 		return "", fmt.Errorf("failed to parse version %s", version)
 	}

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	compareVersion          string = "0.10.0"
+	healthcheckVersion      string = "0.10.0"
 	MajorMinorVersionRegexp string = `^v?(?P<Version>[0-9]+\.[0-9]+\.[0-9]+)`
 )
 
@@ -75,17 +75,17 @@ func IsOrphan(k8sObjectName string, replicas int32) bool {
 
 func HealthcheckCommand(version string, port int32, restport int32) []string {
 	command := ""
-	if IsVersionBelow(version, compareVersion) {
+	if IsVersionBelow(version, healthcheckVersion) {
 		command = fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)
 	} else {
-		command = fmt.Sprintf("(netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d) && (curl -s -X GET 'http://localhost:%d/v1/health/liveness' || curl -s -k -X GET 'https://localhost:%d/v1/health/liveness')", port, port, restport, restport)
+		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/liveness' || curl -s -k -X GET 'https://localhost:%d/v1/health/liveness'", restport, restport)
 	}
 	return []string{"/bin/sh", "-c", command}
 }
 
 func ControllerReadinessCheck(version string, port int32, authflag bool) []string {
 	command := ""
-	if IsVersionBelow(version, compareVersion) {
+	if IsVersionBelow(version, healthcheckVersion) {
 		//This function check for the readiness of the controller in the following cases
 		//1) Auth and TLS Enabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
 		//2) Auth Enabled and TLS Disabled- in this case, we check if the controller is properly enabled with authentication or not and we do a get on controller and with dummy credentials(testtls:testtls) and the controller returns 401 error in this case if it's correctly configured
@@ -113,7 +113,7 @@ func ControllerReadinessCheck(version string, port int32, authflag bool) []strin
 
 func SegmentStoreReadinessCheck(version string, port int32, restport int32) []string {
 	command := ""
-	if IsVersionBelow(version, compareVersion) {
+	if IsVersionBelow(version, healthcheckVersion) {
 		command = fmt.Sprintf("netstat -ltn 2> /dev/null | grep %d || ss -ltn 2> /dev/null | grep %d", port, port)
 	} else {
 		command = fmt.Sprintf("curl -s -X GET 'http://localhost:%d/v1/health/readiness' || curl -s -k -X GET 'https://localhost:%d/v1/health/readiness'", restport, restport)

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -10,7 +10,6 @@
 package util
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -175,7 +174,6 @@ var _ = Describe("pravegacluster", func() {
 	// })
 	//
 	// Context("ControllerReadinessCheck()", func() {
-	// 	fmt.Println("here")
 	// 	out := ControllerReadinessCheck("0.9.0", 1234, true)
 	// 	It("Should not be Empty", func() {
 	// 		Ω(len(out)).ShouldNot(Equal(0))

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -10,6 +10,7 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -26,13 +27,13 @@ func TestPravegacluster(t *testing.T) {
 
 var _ = Describe("pravegacluster", func() {
 
-	Context("IsVersionBelow07", func() {
+	Context("IsVersionBelow", func() {
 		var result1, result2, result3, result4 bool
 		BeforeEach(func() {
-			result1 = IsVersionBelow07("0.7.1")
-			result2 = IsVersionBelow07("0.6.0")
-			result3 = IsVersionBelow07("666")
-			result4 = IsVersionBelow07("")
+			result1 = IsVersionBelow("0.7.1", "0.7.0")
+			result2 = IsVersionBelow("0.6.0", "0.7.0")
+			result3 = IsVersionBelow("666", "0.7.0")
+			result4 = IsVersionBelow("", "0.7.0")
 		})
 		It("should return false for result1", func() {
 			Ω(result1).To(Equal(false))
@@ -47,13 +48,13 @@ var _ = Describe("pravegacluster", func() {
 			Ω(result4).To(Equal(true))
 		})
 	})
+
 	Context("ContainsVersion fn", func() {
 		var result1, result2 bool
 		BeforeEach(func() {
 			input := []string{"0.4.0", "0.5.0", "a.b.c"}
 			result1 = ContainsVersion(input, "0.4.0")
 			result2 = ContainsVersion(input, "0.7.0")
-
 		})
 		It("should return true for result", func() {
 			Ω(result1).To(Equal(true))
@@ -66,7 +67,6 @@ var _ = Describe("pravegacluster", func() {
 	Context("IsOrphan", func() {
 		var result1, result2, result3, result4 bool
 		BeforeEach(func() {
-
 			result1 = IsOrphan("segment-store-4", 3)
 			result2 = IsOrphan("segment-store-2", 3)
 			result3 = IsOrphan("segmentstore", 1)
@@ -85,6 +85,7 @@ var _ = Describe("pravegacluster", func() {
 			Ω(result4).To(Equal(false))
 		})
 	})
+
 	Context("OverrideDefaultJVMOptions", func() {
 		var result, result1 []string
 		BeforeEach(func() {
@@ -104,19 +105,16 @@ var _ = Describe("pravegacluster", func() {
 				"-yy:mem",
 				"",
 			}
-
 			result = OverrideDefaultJVMOptions(jvmOpts, customOpts)
 			result1 = OverrideDefaultJVMOptions(jvmOpts, result1)
-
 		})
 		It("should contain string", func() {
 			Ω(len(result)).ShouldNot(Equal(0))
 			Ω(result[0]).To(Equal("-Xms1024m"))
 			Ω(result1[0]).To(Equal("-Xms512m"))
-
 		})
-
 	})
+
 	Context("RemoveString", func() {
 		var opts []string
 		BeforeEach(func() {
@@ -125,7 +123,6 @@ var _ = Describe("pravegacluster", func() {
 				"test1",
 			}
 			opts = RemoveString(opts, "abc-test")
-
 		})
 		It("should return false for result", func() {
 			Ω(opts[0]).To(Equal("test1"))
@@ -141,8 +138,8 @@ var _ = Describe("pravegacluster", func() {
 			}
 			result = ContainsString(opts, "abc-test")
 			result1 = ContainsString(opts, "abc-test1")
-
 		})
+
 		It("should return true", func() {
 			Ω(result).To(Equal(true))
 		})
@@ -151,50 +148,66 @@ var _ = Describe("pravegacluster", func() {
 			Ω(result1).To(Equal(false))
 		})
 	})
-	Context("PodAntiAffinity", func() {
 
+	Context("PodAntiAffinity", func() {
 		affinity := PodAntiAffinity("segstore", "pravega")
 		It("should not be nil", func() {
 			Ω(affinity).ShouldNot(BeNil())
 		})
-
 	})
 
 	Context("DownwardAPIEnv()", func() {
-
 		env := DownwardAPIEnv()
 		It("should not be nil", func() {
 			Ω(env).ShouldNot(BeNil())
 		})
-
 	})
-	Context("HealthcheckCommand()", func() {
 
-		out := HealthcheckCommand(1234)
-		It("should not be nil", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
-		})
+	// Context("HealthcheckCommand()", func() {
+	// 	out := HealthcheckCommand("0.9.0", 1234, 6061)
+	// 	It("should not be nil", func() {
+	// 		Ω(len(out)).ShouldNot(Equal(0))
+	// 	})
+	// 	out = HealthcheckCommand("0.10.0", 1234, 6061)
+	// 	It("should not be nil", func() {
+	// 		Ω(len(out)).ShouldNot(Equal(0))
+	// 	})
+	// })
+	//
+	// Context("ControllerReadinessCheck()", func() {
+	// 	fmt.Println("here")
+	// 	out := ControllerReadinessCheck("0.9.0", 1234, true)
+	// 	It("Should not be Empty", func() {
+	// 		Ω(len(out)).ShouldNot(Equal(0))
+	// 	})
+	// 	out = ControllerReadinessCheck("0.9.0", 1234, false)
+	// 	It("Should not be Empty", func() {
+	// 		Ω(len(out)).ShouldNot(Equal(0))
+	// 	})
+	// 	out = ControllerReadinessCheck("0.10.0", 1234, true)
+	// 	It("Should not be Empty", func() {
+	// 		Ω(len(out)).ShouldNot(Equal(0))
+	// 	})
+	// })
+	//
+	// Context("SegmentStoreReadinessCheck()", func() {
+	// 	out := SegmentStoreReadinessCheck("0.9.0", 1234, 6061)
+	// 	It("Should not be Empty", func() {
+	// 		Ω(len(out)).ShouldNot(Equal(0))
+	// 	})
+	// 	out = SegmentStoreReadinessCheck("0.10.0", 1234, 6061)
+	// 	It("Should not be Empty", func() {
+	// 		Ω(len(out)).ShouldNot(Equal(0))
+	// 	})
+	// })
 
-	})
-	Context("ControllerReadinessCheck()", func() {
-		out := ControllerReadinessCheck(1234, true)
-		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
-		})
-		out = ControllerReadinessCheck(1234, false)
-		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
-		})
-	})
 	Context("Min()", func() {
-
 		It("Min should be 10", func() {
 			Ω(Min(10, 20)).Should(Equal(int32(10)))
 		})
 		It("Min should be 20", func() {
 			Ω(Min(30, 20)).Should(Equal(int32(20)))
 		})
-
 	})
 
 	Context("podReady", func() {
@@ -222,6 +235,7 @@ var _ = Describe("pravegacluster", func() {
 
 		})
 	})
+
 	Context("podFaulty", func() {
 		var result, result1 bool
 		BeforeEach(func() {
@@ -259,6 +273,7 @@ var _ = Describe("pravegacluster", func() {
 
 		})
 	})
+
 	Context("CompareConfigMap", func() {
 		var output1, output2 bool
 		BeforeEach(func() {

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -167,39 +167,48 @@ var _ = Describe("pravegacluster", func() {
 	})
 
 	Context("HealthcheckCommand()", func() {
-		out := HealthcheckCommand("0.9.0", 1234, 6061)
-		It("should not be nil", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
+		var r1, r2 []string
+		BeforeEach(func() {
+			r1 = HealthcheckCommand("0.9.0", 1234, 6061)
+			r2 = HealthcheckCommand("0.10.0", 1234, 6061)
 		})
-		out = HealthcheckCommand("0.10.0", 1234, 6061)
 		It("should not be nil", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
+			Ω(len(r1)).ShouldNot(Equal(0))
+		})
+		It("should not be nil", func() {
+			Ω(len(r2)).ShouldNot(Equal(0))
 		})
 	})
 
 	Context("ControllerReadinessCheck()", func() {
-		out := ControllerReadinessCheck("0.9.0", 1234, true)
-		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
+		var r1, r2, r3 []string
+		BeforeEach(func() {
+			r1 = ControllerReadinessCheck("0.9.0", 1234, true)
+			r2 = ControllerReadinessCheck("0.9.0", 1234, false)
+			r3 = ControllerReadinessCheck("0.10.0", 1234, true)
 		})
-		out = ControllerReadinessCheck("0.9.0", 1234, false)
 		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
+			Ω(len(r1)).ShouldNot(Equal(0))
 		})
-		out = ControllerReadinessCheck("0.10.0", 1234, true)
 		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
+			Ω(len(r2)).ShouldNot(Equal(0))
+		})
+		It("Should not be Empty", func() {
+			Ω(len(r3)).ShouldNot(Equal(0))
 		})
 	})
 
 	Context("SegmentStoreReadinessCheck()", func() {
-		out := SegmentStoreReadinessCheck("0.9.0", 1234, 6061)
-		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
+		var r1, r2 []string
+		BeforeEach(func() {
+			r1 = SegmentStoreReadinessCheck("0.9.0", 1234, 6061)
+			r2 = SegmentStoreReadinessCheck("0.10.0", 1234, 6061)
 		})
-		out = SegmentStoreReadinessCheck("0.10.0", 1234, 6061)
 		It("Should not be Empty", func() {
-			Ω(len(out)).ShouldNot(Equal(0))
+			Ω(len(r1)).ShouldNot(Equal(0))
+		})
+		It("Should not be Empty", func() {
+			Ω(len(r2)).ShouldNot(Equal(0))
 		})
 	})
 

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -27,12 +27,13 @@ func TestPravegacluster(t *testing.T) {
 var _ = Describe("pravegacluster", func() {
 
 	Context("IsVersionBelow", func() {
-		var result1, result2, result3, result4 bool
+		var result1, result2, result3, result4, result5 bool
 		BeforeEach(func() {
 			result1 = IsVersionBelow("0.7.1", "0.7.0")
 			result2 = IsVersionBelow("0.6.0", "0.7.0")
 			result3 = IsVersionBelow("666", "0.7.0")
 			result4 = IsVersionBelow("", "0.7.0")
+			result5 = IsVersionBelow("0.6.5", "")
 		})
 		It("should return false for result1", func() {
 			Ω(result1).To(Equal(false))
@@ -45,6 +46,9 @@ var _ = Describe("pravegacluster", func() {
 		})
 		It("should return true for result4", func() {
 			Ω(result4).To(Equal(true))
+		})
+		It("should return false for result5", func() {
+			Ω(result5).To(Equal(false))
 		})
 	})
 

--- a/pkg/util/pravegacluster_test.go
+++ b/pkg/util/pravegacluster_test.go
@@ -166,42 +166,42 @@ var _ = Describe("pravegacluster", func() {
 		})
 	})
 
-	// Context("HealthcheckCommand()", func() {
-	// 	out := HealthcheckCommand("0.9.0", 1234, 6061)
-	// 	It("should not be nil", func() {
-	// 		Ω(len(out)).ShouldNot(Equal(0))
-	// 	})
-	// 	out = HealthcheckCommand("0.10.0", 1234, 6061)
-	// 	It("should not be nil", func() {
-	// 		Ω(len(out)).ShouldNot(Equal(0))
-	// 	})
-	// })
-	//
-	// Context("ControllerReadinessCheck()", func() {
-	// 	out := ControllerReadinessCheck("0.9.0", 1234, true)
-	// 	It("Should not be Empty", func() {
-	// 		Ω(len(out)).ShouldNot(Equal(0))
-	// 	})
-	// 	out = ControllerReadinessCheck("0.9.0", 1234, false)
-	// 	It("Should not be Empty", func() {
-	// 		Ω(len(out)).ShouldNot(Equal(0))
-	// 	})
-	// 	out = ControllerReadinessCheck("0.10.0", 1234, true)
-	// 	It("Should not be Empty", func() {
-	// 		Ω(len(out)).ShouldNot(Equal(0))
-	// 	})
-	// })
-	//
-	// Context("SegmentStoreReadinessCheck()", func() {
-	// 	out := SegmentStoreReadinessCheck("0.9.0", 1234, 6061)
-	// 	It("Should not be Empty", func() {
-	// 		Ω(len(out)).ShouldNot(Equal(0))
-	// 	})
-	// 	out = SegmentStoreReadinessCheck("0.10.0", 1234, 6061)
-	// 	It("Should not be Empty", func() {
-	// 		Ω(len(out)).ShouldNot(Equal(0))
-	// 	})
-	// })
+	Context("HealthcheckCommand()", func() {
+		out := HealthcheckCommand("0.9.0", 1234, 6061)
+		It("should not be nil", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+		out = HealthcheckCommand("0.10.0", 1234, 6061)
+		It("should not be nil", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+	})
+
+	Context("ControllerReadinessCheck()", func() {
+		out := ControllerReadinessCheck("0.9.0", 1234, true)
+		It("Should not be Empty", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+		out = ControllerReadinessCheck("0.9.0", 1234, false)
+		It("Should not be Empty", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+		out = ControllerReadinessCheck("0.10.0", 1234, true)
+		It("Should not be Empty", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+	})
+
+	Context("SegmentStoreReadinessCheck()", func() {
+		out := SegmentStoreReadinessCheck("0.9.0", 1234, 6061)
+		It("Should not be Empty", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+		out = SegmentStoreReadinessCheck("0.10.0", 1234, 6061)
+		It("Should not be Empty", func() {
+			Ω(len(out)).ShouldNot(Equal(0))
+		})
+	})
 
 	Context("Min()", func() {
 		It("Min should be 10", func() {

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,17 +57,17 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		"testScaleCluster":                  testScaleCluster,
-		"testCreateRecreateCluster":         testCreateRecreateCluster,
-		"testUpgradeCluster":                testUpgradeCluster,
-		"testWebhook":                       testWebhook,
-		"testCMUpgradeCluster":              testCMUpgradeCluster,
-		"testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
+		// "testScaleCluster":                  testScaleCluster,
+		// "testCreateRecreateCluster":         testCreateRecreateCluster,
+		// "testUpgradeCluster":                testUpgradeCluster,
+		// "testWebhook":                       testWebhook,
+		// "testCMUpgradeCluster":              testCMUpgradeCluster,
+		// "testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
 		// commenting out this test as pravega installation with TLS alone is not supported
 		// "testCreatePravegaClusterWithTls":    testCreatePravegaClusterWithTls,
-		"testDeletePods":             testDeletePods,
-		"testRollbackPravegaCluster": testRollbackPravegaCluster,
-		// "testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
+		// "testDeletePods":             testDeletePods,
+		// "testRollbackPravegaCluster": testRollbackPravegaCluster,
+		"testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,17 +57,17 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		"testCreateRecreateCluster":         testCreateRecreateCluster,
-		"testScaleCluster":                  testScaleCluster,
-		"testUpgradeCluster":                testUpgradeCluster,
-		"testWebhook":                       testWebhook,
-		"testCMUpgradeCluster":              testCMUpgradeCluster,
-		"testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
+		// "testCreateRecreateCluster":         testCreateRecreateCluster,
+		// "testScaleCluster":                  testScaleCluster,
+		// "testUpgradeCluster":                testUpgradeCluster,
+		// "testWebhook":                       testWebhook,
+		// "testCMUpgradeCluster":              testCMUpgradeCluster,
+		// "testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
 		// commenting out this test as pravega installation with TLS alone is not supported
 		//"testCreatePravegaClusterWithTls":        testCreatePravegaClusterWithTls,
-		"testDeletePods":                         testDeletePods,
-		"testRollbackPravegaCluster":             testRollbackPravegaCluster,
-		"testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
+		// "testDeletePods":                         testDeletePods,
+		"testRollbackPravegaCluster": testRollbackPravegaCluster,
+		// "testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
 	}
 
 	for name, f := range testFuncs {

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,15 +57,15 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		// "testCreateRecreateCluster":         testCreateRecreateCluster,
-		// "testScaleCluster":                  testScaleCluster,
-		// "testUpgradeCluster":                testUpgradeCluster,
-		// "testWebhook":                       testWebhook,
-		// "testCMUpgradeCluster":              testCMUpgradeCluster,
-		// "testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
+		"testScaleCluster":                  testScaleCluster,
+		"testCreateRecreateCluster":         testCreateRecreateCluster,
+		"testUpgradeCluster":                testUpgradeCluster,
+		"testWebhook":                       testWebhook,
+		"testCMUpgradeCluster":              testCMUpgradeCluster,
+		"testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
 		// commenting out this test as pravega installation with TLS alone is not supported
-		//"testCreatePravegaClusterWithTls":        testCreatePravegaClusterWithTls,
-		// "testDeletePods":                         testDeletePods,
+		// "testCreatePravegaClusterWithTls":    testCreatePravegaClusterWithTls,
+		"testDeletePods":             testDeletePods,
 		"testRollbackPravegaCluster": testRollbackPravegaCluster,
 		// "testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
 	}

--- a/test/e2e/pravegacluster_test.go
+++ b/test/e2e/pravegacluster_test.go
@@ -57,16 +57,16 @@ func testPravegaCluster(t *testing.T) {
 	}
 
 	testFuncs := map[string]func(t *testing.T){
-		// "testScaleCluster":                  testScaleCluster,
-		// "testCreateRecreateCluster":         testCreateRecreateCluster,
-		// "testUpgradeCluster":                testUpgradeCluster,
-		// "testWebhook":                       testWebhook,
-		// "testCMUpgradeCluster":              testCMUpgradeCluster,
-		// "testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
+		"testScaleCluster":                  testScaleCluster,
+		"testCreateRecreateCluster":         testCreateRecreateCluster,
+		"testUpgradeCluster":                testUpgradeCluster,
+		"testWebhook":                       testWebhook,
+		"testCMUpgradeCluster":              testCMUpgradeCluster,
+		"testExternalCreateRecreateCluster": testExternalCreateRecreateCluster,
 		// commenting out this test as pravega installation with TLS alone is not supported
 		// "testCreatePravegaClusterWithTls":    testCreatePravegaClusterWithTls,
-		// "testDeletePods":             testDeletePods,
-		// "testRollbackPravegaCluster": testRollbackPravegaCluster,
+		"testDeletePods":                         testDeletePods,
+		"testRollbackPravegaCluster":             testRollbackPravegaCluster,
 		"testCreatePravegaClusterWithAuthAndTls": testCreatePravegaClusterWithAuthAndTls,
 	}
 


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Integrates the apis exposed by the new healthcheck framework which is compatible with pravega version >= 0.10.0, while not breaking backward compatibility.

### Purpose of the change
Fixes #357 

### What the code does
Uses the latest healthcheck apis for monitoring the health of the controller and segmentstore pods when any pravega version starting 0.10.0 is deployed. Also, uses the earlier liveness and readiness probes for the controller and segmentstore pods when pravega version lower than 0.10.0 has been deployed. 

### How to verify it
When pravega version is lesser than 0.10.0, the following healthchecks are invoked

**for SegmentStore**
```
 livenessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        -  netstat -ltn 2> /dev/null | grep 12345 || ss -ltn 2> /dev/null | grep 12345
     
   readinessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        -  netstat -ltn 2> /dev/null | grep 12345 || ss -ltn 2> /dev/null | grep 12345
```

**for Controller**
```
 livenessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - netstat -ltn 2> /dev/null | grep 9090 || ss -ltn 2> /dev/null | grep 9090
       
   readinessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - 'echo $JAVA_OPTS | grep ''controller.auth.tlsEnabled=true'' &&  curl -s
          -X GET ''https://localhost:10080/v1/scopes/'' -H ''accept: application/json''
          | grep ''_system''|| (echo $JAVA_OPTS | grep ''controller.auth.tlsEnabled=false''
          && curl -s -X GET ''http://localhost:10080/v1/scopes/'' -H ''accept: application/json''
          | grep ''_system'' ) || (echo $JAVA_OPTS | grep ''controller.security.tls.enable=true''
          && echo $JAVA_OPTS | grep -v ''controller.auth.tlsEnabled'' && curl -s -X
          GET ''https://localhost:10080/v1/scopes/'' -H ''accept: application/json''
          | grep ''_system'' ) || (curl -s -X GET ''http://localhost:10080/v1/scopes/''
          -H ''accept: application/json'' | grep ''_system'') '
```
However, when deployed pravega version is equal to 0.10.0, the latest healthcheck apis are invoked.

**for SegmentStore**
```
  livenessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - curl -s -X GET 'http://localhost:6061/v1/health/liveness'
     
  readinessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - curl -s -X GET 'http://localhost:6061/v1/health/readiness'
```

**for Controller**
```
  livenessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - curl -s -X GET 'http://localhost:10080/v1/health/liveness'
      
  readinessProbe:
      exec:
        command:
        - /bin/sh
        - -c
        - curl -s -X GET 'http://localhost:10080/v1/health/readiness'
```
Following scenarios have been tested (with Auth and TLS disabled, with only Auth enabled, and with both Auth and TLS enabled)
- deploy pravega operator 0.5.3, pravega 0.10.0; upgrade pravega operator to latest
- deploy latest pravega operator, pravega 0.9.0; upgrade pravega to 0.10.0