### PR TITLE
Issue 571: Fixing end to end tests

### DIFF
--- a/test/e2e/resources/kubernetes_master_install.sh
+++ b/test/e2e/resources/kubernetes_master_install.sh
@@ -28,8 +28,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" \
 && sudo apt-get update
 sudo apt-get update \
 && sudo apt-get install -yq \
-kubelet \
-kubeadm \
+kubelet=1.21.2-00 \
+kubeadm=1.21.2-00 \
 kubernetes-cni
 sudo apt-mark hold kubelet kubeadm kubectl
 UUID=`cat /etc/fstab | grep swap | awk '{print $1}' | tr -d "#UUID="`

--- a/test/e2e/resources/kubernetes_slave_install.sh
+++ b/test/e2e/resources/kubernetes_slave_install.sh
@@ -26,8 +26,8 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" \
   && sudo apt-get update
 sudo apt-get update \
   && sudo apt-get install -yq \
-  kubelet \
-  kubeadm \
+  kubelet=1.21.2-00 \
+  kubeadm=1.21.2-00 \
   kubernetes-cni
 sudo apt-mark hold kubelet kubeadm kubectl
 UUID=`cat /etc/fstab | grep swap | awk '{print $1}' | tr -d "#UUID="`


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Kubectl version is taken as v1.22 in github action causing end to end tests to fail

### Purpose of the change

Fixes #571

### What the code does

Update kubernetes version to 1.21

### How to verify it
End to end tests should pass