### PR TITLE
Issue 577: Set the correct name for controller JVM options setting in the documentation

### DIFF
--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -23,11 +23,11 @@ Here is an example,
 ...
 spec:
   pravega:
-    controllerjvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
-    segmentStoreJVMOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
+    controllerjvmOptions: ["-Xms1g", "-Xmx1g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
+    segmentStoreJVMOptions: ["-Xms4g", "-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
 ...
 ```
-We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest.
+We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest. Also we recommend setting both `-Xms` and `-Xmx` to the same value (as shown in the example above) so as to ensure that we save up the JVM growing memory.
 
 **NOTE:** For setting segementStore options **`-XX:MaxDirectMemorySize`**, **`-Xmx`** and **`pravegaservice.cache.size.max`** ,follow the guidelines provided in the [doc](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md)
 

--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -27,9 +27,9 @@ spec:
     segmentStoreJVMOptions: ["-Xms4g", "-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
 ...
 ```
-We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest. Also we recommend setting both `-Xms` and `-Xmx` to the same value (as shown in the example above) so as to ensure that we save up the JVM growing memory.
+We do not provide any JVM options as defaults within the operator code for the Controller or the Segment Store. These options can be passed into the operator through the deployment manifest. Also we recommend setting both `-Xms` and `-Xmx` to the same value (as shown in the example above) so as to ensure that we save up the JVM growing memory.
 
-**NOTE:** For setting segementStore options **`-XX:MaxDirectMemorySize`**, **`-Xmx`** and **`pravegaservice.cache.size.max`** ,follow the guidelines provided in the [doc](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md)
+**NOTE:** For setting Segment Store options **`-XX:MaxDirectMemorySize`**, **`-Xmx`** and **`pravegaservice.cache.size.max`**, follow the guidelines provided in this [document](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md).
 
 ### SegmentStore Custom Configuration
 

--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -27,7 +27,8 @@ spec:
     segmentStoreJVMOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
 ...
 ```
-We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest. 
+We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest.
+
 **NOTE:** For setting segementStore options **`-XX:MaxDirectMemorySize`**, **`-Xmx`** and **`pravegaservice.cache.size.max`** ,follow the guidelines provided in the [doc](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md)
 
 ### SegmentStore Custom Configuration

--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -23,7 +23,7 @@ Here is an example,
 ...
 spec:
   pravega:
-    controllerJvmOptions: ["-XX:MaxDirectMemorySize=1g"]
+    controllerjvmOptions: ["-XX:MaxDirectMemorySize=1g"]
     segmentStoreJVMOptions: ["-XX:MaxDirectMemorySize=1g"]
 ...
 ```

--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -23,11 +23,12 @@ Here is an example,
 ...
 spec:
   pravega:
-    controllerjvmOptions: ["-XX:MaxDirectMemorySize=1g"]
-    segmentStoreJVMOptions: ["-XX:MaxDirectMemorySize=1g"]
+    controllerjvmOptions: ["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
+    segmentStoreJVMOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"]
 ...
 ```
-We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest.
+We do not provide any JVM options as defaults within the operator code for the Controller or the Segmentstore. These options can be passed into the operator through the deployment manifest. 
+**NOTE:** For setting segementStore options **`-XX:MaxDirectMemorySize`**, **`-Xmx`** and **`pravegaservice.cache.size.max`** ,follow the guidelines provided in the [doc](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md)
 
 ### SegmentStore Custom Configuration
 

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -91,7 +91,7 @@ options:
 To summarize the way in which the segmentstore pod memory is distributed:
 
 ```
-POD_MEM_LIMIT = JVM Heap + Direct Memory + Unallocted Memory
+POD_MEM_LIMIT = JVM Heap + Direct Memory + Unallocated Memory
 Direct Memory = pravegaservice.cache.size.max + 1GB/2GB (other uses)
 ```
 **Note:** If we are upgrading pravega version to 0.9 or above using operator version 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -75,9 +75,9 @@ segmentStoreResources:
     cpu: "8000m"
 ```
 
-2. Distribute the pod's memory (POD_MEM_LIMIT) between JVM Heap and Direct Memory such that sum of JVM Heap and JVM Direct Memory is strictly lower than the POD_MEM_LIMIT memory (e.g., 0.5GB-1GB) so as to avoid pod crash during high load situations due to lack of memory resources. For instance, if POD_MEM_LIMIT=16GB then we can set 4GB for JVM Heap and 11GB for Direct Memory leaving 1GB unallocated so as to assure that the pod do not reach the maximum capacity. Conceptually POD_MEM_LIMIT (16GB) = JVM Heap (4GB) + Direct Memory (11GB) + Unallocated Memory (1GB).
+2. Distribute the pod's memory (POD_MEM_LIMIT) between JVM Heap and Direct Memory such that sum of JVM Heap and JVM Direct Memory is strictly lower than the POD_MEM_LIMIT memory (e.g., 0.5GB-1GB) so as to avoid pod crash during high load situations due to lack of memory resources. For instance, if POD_MEM_LIMIT=16GB then we can set 4GB for JVM Heap and 11GB for Direct Memory leaving 1GB unallocated so as to assure that the pod do not reach the maximum capacity. That is, POD_MEM_LIMIT (16GB) = JVM Heap (4GB) + Direct Memory (11GB) + Unallocated Memory (1GB).
 
-**NOTE:** These two options (JVM Heap and Direct Memory) can be configured through the following field of the manifest file
+**NOTE:** These two options (JVM Heap and Direct Memory) can be configured through the following field of the manifest file:
 ```
 segmentStoreJVMOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=11g"]
 ```
@@ -88,13 +88,13 @@ options:
   pravegaservice.cache.size.max: "9663676416"
 ```
 
-To summarize the way in which the segmentstore pod memory is distributed:
+To summarize the way in which the Segment Store pod memory is distributed:
 
 ```
 POD_MEM_LIMIT = JVM Heap + Direct Memory + Unallocated Memory
 Direct Memory = pravegaservice.cache.size.max + 1GB/2GB (other uses)
 ```
-For an in depth understanding of segmentStore options, refer to the [doc](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md)
+For an in depth understanding of Segment Store options, refer to this [document](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md).
 
 **Note:** If we are upgrading pravega version to 0.9 or above using operator version 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
 ```

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -75,7 +75,7 @@ segmentStoreResources:
     cpu: "8000m"
 ```
 
-2. Distribute the pod's memory (POD_MEM_LIMIT) between JVM Heap and Direct Memory such that sum of JVM Heap and JVM Direct Memory is strictly lower than the POD_MEM_LIMIT memory (e.g., 0.5GB-1GB) so as to avoid pod crash during high load situations due to lack of memory resources. For instance, if POD_MEM_LIMIT=16GB then we can set 4GB for JVM Heap and 11GB for Direct Memory leaving 1GB unallocated so as to assure that the pod do not reach the maximum capacity. Conceptually POD_MEM_LIMIT (16GB) = JVM Heap (4GB) + Direct Memory (11GB) + Unallocated Memory (1GB)
+2. Distribute the pod's memory (POD_MEM_LIMIT) between JVM Heap and Direct Memory such that sum of JVM Heap and JVM Direct Memory is strictly lower than the POD_MEM_LIMIT memory (e.g., 0.5GB-1GB) so as to avoid pod crash during high load situations due to lack of memory resources. For instance, if POD_MEM_LIMIT=16GB then we can set 4GB for JVM Heap and 11GB for Direct Memory leaving 1GB unallocated so as to assure that the pod do not reach the maximum capacity. Conceptually POD_MEM_LIMIT (16GB) = JVM Heap (4GB) + Direct Memory (11GB) + Unallocated Memory (1GB).
 
 **NOTE:** These two options (JVM Heap and Direct Memory) can be configured through the following field of the manifest file
 ```
@@ -94,6 +94,8 @@ To summarize the way in which the segmentstore pod memory is distributed:
 POD_MEM_LIMIT = JVM Heap + Direct Memory + Unallocated Memory
 Direct Memory = pravegaservice.cache.size.max + 1GB/2GB (other uses)
 ```
+For an in depth understanding of segmentStore options, refer to the [doc](https://github.com/pravega/pravega/blob/master/documentation/src/docs/admin-guide/segmentstore-memory.md)
+
 **Note:** If we are upgrading pravega version to 0.9 or above using operator version 0.5.1 or below, add the below JVM options for controller and segmentstore in addition to the current JVM options.
 ```
 segmentStoreJVMOptions: ["-XX:+UseContainerSupport","-XX:+IgnoreUnrecognizedVMOptions"]


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Set the correct name for controller JVM options setting in the documentation so as to align it with that of json string set in the [code](https://github.com/pravega/pravega-operator/blob/v0.5.5/pkg/apis/pravega/v1alpha1/pravega.go#L100)

### Purpose of the change

Fixes #577

### What the code does

Currently the name of controller JVM options setting in documentation file is listed incorrectly as `controllerJvmOptions`, while in the [code](https://github.com/pravega/pravega-operator/blob/v0.5.5/pkg/apis/pravega/v1alpha1/pravega.go#L100) the json string is set to `controllerjvmOptions`. This documentation update is to make the JVM options setting equal to the one set in the code 

### How to verify it

Make sure the value in document matches to the json string in the [code](https://github.com/pravega/pravega-operator/blob/v0.5.5/pkg/apis/pravega/v1alpha1/pravega.go#L100)
