### PR TITLE
Issue 593: Convert markdown to support Docusaurus and combined docs repo

### DIFF
--- a/doc/auth-handlers.md
+++ b/doc/auth-handlers.md
@@ -1,4 +1,4 @@
-## AuthImplementations
+# Auth Handler Implementations
 
 If we need to enable auth handlers in Pravega controller, modify the Pravega manifest and ensure that following fields are present in the yaml file.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,4 +1,4 @@
-## Configuration
+# Configuration
 
 This document explains how to configure Pravega
 

--- a/doc/external-access.md
+++ b/doc/external-access.md
@@ -1,4 +1,4 @@
-# Enable external access
+# Enable External Access
 
 By default, a Pravega cluster uses `ClusterIP` services which are only accessible from within Kubernetes. However, when creating the Pravega cluster resource, you can opt to enable external access.
 

--- a/doc/init-containers.md
+++ b/doc/init-containers.md
@@ -1,4 +1,4 @@
-## Init Containers
+# Init Containers
 
 Users can mention the details in init containers to perform certain operations before the main container starts. This is supported in controller as well as segmentstore.
 

--- a/doc/longtermstorage.md
+++ b/doc/longtermstorage.md
@@ -1,4 +1,4 @@
-## LongTermStorage
+# Long Term Storage
 
 The following LongTermStorage storage providers are supported:
 

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -1,4 +1,4 @@
-## Manual installation
+# Manual Installation
 
 * [Install the Operator manually](#install-the-operator-manually)
 * [Set up LongTermStorage](#set-up-longtermstorage)

--- a/doc/manual-installation.md
+++ b/doc/manual-installation.md
@@ -95,7 +95,7 @@ where:
 - `[ZOOKEEPER_SVC]` is the name of client service of your Zookeeper deployment.
 - `[BOOKKEEPER_SVC]` is the name of the headless service of your Bookkeeper deployment.
 
-Check out other sample CR files in the [example](../example) directory.
+Check out other sample CR files in the [example](https://github.com/pravega/pravega-operator/tree/master/example) directory.
 
 Deploy the Pravega cluster.
 

--- a/doc/pravega-options.md
+++ b/doc/pravega-options.md
@@ -1,4 +1,4 @@
-## Pravega options
+# Pravega Options
 
 Pravega has many configuration options for setting up metrics, tuning, etc. The available options can be found [here](https://github.com/pravega/pravega/blob/master/config/config.properties) and are expressed through the pravega/options part of the resource specification.
 

--- a/doc/rbac.md
+++ b/doc/rbac.md
@@ -1,4 +1,4 @@
-## Setting up RBAC for Pravega operator
+# Setting up RBAC for Pravega operator
 
 ### Use non-default service accounts
 

--- a/doc/release_process.md
+++ b/doc/release_process.md
@@ -33,7 +33,7 @@ This is a minor release with backward compatible changes and bug fixes.
     `$ git push origin <release-branch-name>`
     
 5. Create a new release candidate tag on this branch. 
-   Tag name should correspond to release-branch-name-<release-candidate-version>. 
+   Tag name should correspond to `release-branch-name-<release-candidate-version>`.
    For example: `0.3.3-rc1` for the first release candidate.
    
     `$ git tag -a <tag-name> -m "<description>"`

--- a/doc/service-sts-name-configuration.md
+++ b/doc/service-sts-name-configuration.md
@@ -1,4 +1,4 @@
-# Configuring SegmentStore Headless Service Name
+# Configuring Segment Store Headless Service Name
 
 By default segmentstore headless service name is configured as  `[PRAVEGA_CLUSTER_NAME]-pravega-segmentstore-headless`.
 

--- a/doc/sidebars.js
+++ b/doc/sidebars.js
@@ -1,0 +1,22 @@
+module.exports = {
+    mainSidebar: [
+        'manual-installation',
+        {
+            'Configuration':
+            [
+                'rbac',
+                'longtermstorage',
+                'pravega-options',
+                'tls',
+                'auth',
+                'external-access',
+                'webhook',
+                'service-sts-name-configuration',
+                'auth-handlers',
+                'init-containers',
+                'influxdb-auth'
+            ]
+        },
+        'upgrade-cluster',
+    ]
+};

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -202,7 +202,7 @@ helm install [RELEASE_NAME] pravega/pravega --version=[VERSION] --set zookeeperU
 
 ## Operator pod in container creating state
 
-while installing operator, if the operator pod goes in `ContainerCreating` state for long time, make sure certificates are installed correctly. Please refer to the [prerequisites](https://github.com/pravega/charts/tree/master/charts/pravega-operator#prerequisites).
+While installing operator, if the operator pod goes in `ContainerCreating` state for long time, make sure certificates are installed correctly. Please refer to the [prerequisites](https://github.com/pravega/charts/tree/master/charts/pravega-operator#prerequisites).
 
 ## Recover Operator when node fails
 

--- a/doc/upgrade-cluster.md
+++ b/doc/upgrade-cluster.md
@@ -1,4 +1,4 @@
-# Pravega cluster upgrade
+# Pravega Cluster Upgrade
 
 This document shows how to upgrade a Pravega cluster managed by the operator to a desired version while preserving the cluster's state and data whenever possible.
 

--- a/doc/webhook.md
+++ b/doc/webhook.md
@@ -1,4 +1,4 @@
-## Admission Webhook
+# Admission Webhook
 
 [Admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) are HTTP callbacks that receive admission requests and do something with them.
 There are  two webhooks [ValidatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) and


### PR DESCRIPTION
### Change log description

Convert to Docusaurus format.

### Purpose of the change

Fixes #593

### What the code does

Allows operator docs to be rendered along with other docs as previewed here: https://pravega.io/docs/snapshot