### PR TITLE
Adding validation checks for Bookkeeper Deployments

### DIFF
--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -383,6 +383,21 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		s.Options = map[string]string{}
 	}
 
+	if s.Options["bookkeeper.ensemble.size"] == "" {
+		changed = true
+		s.Options["bookkeeper.ensemble.size"] = "3"
+	}
+
+	if s.Options["bookkeeper.write.quorum.size"] == "" {
+		changed = true
+		s.Options["bookkeeper.write.quorum.size"] = "3"
+	}
+
+	if s.Options["bookkeeper.ack.quorum.size"] == "" {
+		changed = true
+		s.Options["bookkeeper.ack.quorum.size"] = "3"
+	}
+
 	if s.ControllerJvmOptions == nil {
 		changed = true
 		s.ControllerJvmOptions = []string{}

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -1349,22 +1349,22 @@ func (p *PravegaCluster) ValidateBookkeperSettings() error {
 
 	if ensembleSizeInt < writeQuorumSizeInt {
 		if ensembleSize == "" {
-			return fmt.Errorf("The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the default value of option bookkeeper.ensemble.size which is 3")
+			return fmt.Errorf("The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the value of option bookkeeper.ensemble.size (default is 3)")
 		}
 		if writeQuorumSize == "" {
-			return fmt.Errorf("The value provided for the option bookkeeper.ensemble.size should be greater than or equal to the default value of bookkeeper.write.quorum.size which is 3")
+			return fmt.Errorf("The value provided for the option bookkeeper.ensemble.size should be greater than or equal to the value of option bookkeeper.write.quorum.size (default is 3)")
 		}
 		return fmt.Errorf("The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the value of option bookkeeper.ensemble.size")
 	}
 
 	if writeQuorumSizeInt < ackQuorumSizeInt {
 		if writeQuorumSize == "" {
-			return fmt.Errorf("The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the default value of option bookkeeper.write.quorum.size which is 3")
+			return fmt.Errorf("The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the value of option bookkeeper.write.quorum.size (default is 3)")
 		}
 		if ackQuorumSize == "" {
-			return fmt.Errorf("The value provided for the option bookkeeper.write.quorum.size should be greater than or equal to the default value of bookkeeper.ack.quorum.size which is 3")
+			return fmt.Errorf("The value provided for the option bookkeeper.write.quorum.size should be greater than or equal to the value of option bookkeeper.ack.quorum.size (default is 3)")
 		}
-		return fmt.Errorf("The value provided for the option bookkeeper.ack.quorum.size should less than or equal to the value of option bookkeeper.write.quorum.size")
+		return fmt.Errorf("The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the value of option bookkeeper.write.quorum.size")
 	}
 
 	return nil

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
@@ -964,7 +964,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			})
 
 			It("should return error", func() {
-				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ensemble.size should be greater than or equal to the default value of bookkeeper.write.quorum.size which is 3")).Should(Equal(true))
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ensemble.size should be greater than or equal to the value of option bookkeeper.write.quorum.size (default is 3)")).Should(Equal(true))
 			})
 		})
 
@@ -981,11 +981,11 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			})
 
 			It("should return error", func() {
-				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the default value of option bookkeeper.ensemble.size which is 3")).Should(Equal(true))
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the value of option bookkeeper.ensemble.size (default is 3)")).Should(Equal(true))
 			})
 		})
 
-		Context("Validating wether minimum racks count is set to true false or \"\"", func() {
+		Context("Validating whether minimum racks count is set to true false or \"\"", func() {
 			var (
 				err error
 			)
@@ -1031,7 +1031,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			})
 
 			It("should return error", func() {
-				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ack.quorum.size should less than or equal to the value of option bookkeeper.write.quorum.size")).Should(Equal(true))
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the value of option bookkeeper.write.quorum.size")).Should(Equal(true))
 			})
 		})
 
@@ -1048,7 +1048,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			})
 
 			It("should return error", func() {
-				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.write.quorum.size should be greater than or equal to the default value of bookkeeper.ack.quorum.size which is 3")).Should(Equal(true))
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.write.quorum.size should be greater than or equal to the value of option bookkeeper.ack.quorum.size (default is 3)")).Should(Equal(true))
 			})
 		})
 
@@ -1065,7 +1065,7 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			})
 
 			It("should return error", func() {
-				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the default value of option bookkeeper.write.quorum.size which is 3")).Should(Equal(true))
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the value of option bookkeeper.write.quorum.size (default is 3)")).Should(Equal(true))
 			})
 		})
 	})

--- a/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types_test.go
@@ -857,4 +857,216 @@ var _ = Describe("PravegaCluster Types Spec", func() {
 			})
 		})
 	})
+
+	Context("Validate Bookie Settings", func() {
+		var (
+			p *v1beta1.PravegaCluster
+		)
+
+		BeforeEach(func() {
+			p = &v1beta1.PravegaCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			}
+			p.WithDefaults()
+		})
+
+		Context("Validating with correct values for Ensemble Size, Write Quorum size and Ack quorum size", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "3"
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = "3"
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "3"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("Should return nil", func() {
+				Ω(err).Should(BeNil())
+			})
+		})
+
+		Context("Invalid Value for Enseble size", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "3.4"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("Should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "Cannot convert ensemble size from string to integer")).Should(Equal(true))
+			})
+		})
+
+		Context("Invalid Value for Write Quorum size", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = "3##4"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("Should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "Cannot convert write quorum size from string to integer")).Should(Equal(true))
+			})
+		})
+
+		Context("Invalid Value for Ack Quorum size", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "2!342"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("Should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "Cannot convert ack quorum size from string to integer")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating with Ensemble Size < Write Quorum Size", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "3"
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = "4"
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "3"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the value of option bookkeeper.ensemble.size")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating with Ensemble size <=2 and Write quorum size is set to default", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "2"
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = ""
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "3"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ensemble.size should be greater than or equal to the default value of bookkeeper.write.quorum.size which is 3")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating with Write quorum size > 3 and Ensemble size is set to default", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = ""
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = "4"
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "3"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the default value of option bookkeeper.ensemble.size which is 3")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating wether minimum racks count is set to true false or \"\"", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.racks.minimumCount.enable"] = "True"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "bookkeeper.write.quorum.racks.minimumCount.enable can be only set to \"true\" \"false\" or \"\"")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating with Enseble Size set to 1 and minimum count enabled is set to true", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "1"
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = ""
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = ""
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.racks.minimumCount.enable"] = "true"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "bookkeeper.write.quorum.racks.minimumCount.enable should be set to false if bookkeeper.ensemble.size is 1")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating with Write quorum size < Acq quorum size", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "4"
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = "4"
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "5"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ack.quorum.size should less than or equal to the value of option bookkeeper.write.quorum.size")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating with Write quorum size <=2 and Acq quorum size is set to default", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "3"
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = "2"
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = ""
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.write.quorum.size should be greater than or equal to the default value of bookkeeper.ack.quorum.size which is 3")).Should(Equal(true))
+			})
+		})
+
+		Context("Validating with Ack quorum size > 3 and Write quorum size is set to default", func() {
+			var (
+				err error
+			)
+
+			BeforeEach(func() {
+				p.Spec.Pravega.Options["bookkeeper.ensemble.size"] = "3"
+				p.Spec.Pravega.Options["bookkeeper.write.quorum.size"] = ""
+				p.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "4"
+				err = p.ValidateBookkeperSettings()
+			})
+
+			It("should return error", func() {
+				Ω(strings.ContainsAny(err.Error(), "The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the default value of option bookkeeper.write.quorum.size which is 3")).Should(Equal(true))
+			})
+		})
+	})
 })

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -230,7 +230,7 @@ func testWebhook(t *testing.T) {
 	ensembleSizeLessThanEqualToTwoWriteQuorumSizeSetToDefault.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = ""
 	_, err = pravega_e2eutil.CreatePravegaCluster(t, f, ctx, ensembleSizeLessThanEqualToTwoWriteQuorumSizeSetToDefault)
 	g.Expect(err).To(HaveOccurred(), "Ensemble size should be greater than the default value of write quorum size")
-	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.ensemble.size should be greater than or equal to the default value of bookkeeper.write.quorum.size which is 3"))
+	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.ensemble.size should be greater than or equal to the value of option bookkeeper.write.quorum.size (default is 3)"))
 
 	ensembleSizeSetToDefaultWriteQuorumSizeGreaterThanThree := pravega_e2eutil.NewDefaultCluster(namespace)
 	ensembleSizeSetToDefaultWriteQuorumSizeGreaterThanThree.WithDefaults()
@@ -239,7 +239,7 @@ func testWebhook(t *testing.T) {
 	ensembleSizeSetToDefaultWriteQuorumSizeGreaterThanThree.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "3"
 	_, err = pravega_e2eutil.CreatePravegaCluster(t, f, ctx, ensembleSizeSetToDefaultWriteQuorumSizeGreaterThanThree)
 	g.Expect(err).To(HaveOccurred(), "The value for write quorum size should be less than default value of ensemble size")
-	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the default value of option bookkeeper.ensemble.size which is 3"))
+	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.write.quorum.size should be less than or equal to the value of option bookkeeper.ensemble.size (default is 3)"))
 
 	writeQuorumSizeLessThanAckQuorumSize := pravega_e2eutil.NewDefaultCluster(namespace)
 	writeQuorumSizeLessThanAckQuorumSize.WithDefaults()
@@ -248,7 +248,7 @@ func testWebhook(t *testing.T) {
 	writeQuorumSizeLessThanAckQuorumSize.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "3"
 	_, err = pravega_e2eutil.CreatePravegaCluster(t, f, ctx, writeQuorumSizeLessThanAckQuorumSize)
 	g.Expect(err).To(HaveOccurred(), "The value for write quorum size should be greater than or equal to ack quorum size")
-	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.ack.quorum.size should less than or equal to the value of option bookkeeper.write.quorum.size"))
+	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the value of option bookkeeper.write.quorum.size"))
 
 	writeQuorumSizeLessThanEqualToTwoAckQuorumSizeSetToDefault := pravega_e2eutil.NewDefaultCluster(namespace)
 	writeQuorumSizeLessThanEqualToTwoAckQuorumSizeSetToDefault.WithDefaults()
@@ -257,7 +257,7 @@ func testWebhook(t *testing.T) {
 	writeQuorumSizeLessThanEqualToTwoAckQuorumSizeSetToDefault.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = ""
 	_, err = pravega_e2eutil.CreatePravegaCluster(t, f, ctx, writeQuorumSizeLessThanEqualToTwoAckQuorumSizeSetToDefault)
 	g.Expect(err).To(HaveOccurred(), "Write quorum size should be greater than the default value of ack quorum size")
-	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.write.quorum.size should be greater than or equal to the default value of bookkeeper.ack.quorum.size which is 3"))
+	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.write.quorum.size should be greater than or equal to the value of option bookkeeper.ack.quorum.size (default is 3)"))
 
 	writeQuorumSizeSetToDefaultAckQuorumSizeGreaterThanThree := pravega_e2eutil.NewDefaultCluster(namespace)
 	writeQuorumSizeSetToDefaultAckQuorumSizeGreaterThanThree.WithDefaults()
@@ -266,7 +266,7 @@ func testWebhook(t *testing.T) {
 	writeQuorumSizeSetToDefaultAckQuorumSizeGreaterThanThree.Spec.Pravega.Options["bookkeeper.ack.quorum.size"] = "4"
 	_, err = pravega_e2eutil.CreatePravegaCluster(t, f, ctx, writeQuorumSizeSetToDefaultAckQuorumSizeGreaterThanThree)
 	g.Expect(err).To(HaveOccurred(), "The value for ack quorum size should be less than default value of write quorum size")
-	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the default value of option bookkeeper.write.quorum.size which is 3"))
+	g.Expect(err.Error()).To(ContainSubstring("The value provided for the option bookkeeper.ack.quorum.size should be less than or equal to the value of option bookkeeper.write.quorum.size (default is 3)"))
 
 	validBookkeeperSettings := pravega_e2eutil.NewDefaultCluster(namespace)
 	validBookkeeperSettings.WithDefaults()


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

When deploying the pravega cluster,  the options `bookkeeper.ensemble.size`  `bookkeeper.write.quorum.size`  `bookkeeper.ack.quorum.size` should be set such that the following condition is satisfied: `bookkeeper.ensemble.size >= bookkeeper.write.quorum.size >= bookkeeper.ack.quorum.size`

### Purpose of the change

Fixes #587

### What the code does

The code preforms the following checks :
- `bookkeeper.ensemble.size >=  bookkeeper.write.quorum.size  >= bookkeeper.ack.quorum.size`
- If `bookkeeper.ensemble.size == 1` then `bookkeeper.write.quorum.racks.minimumCount.enable` should be set to `false`

### How to verify it

Install a pravega cluster with different values of  `bookkeeper.ensemble.size`  `bookkeeper.write.quorum.size`  `bookkeeper.ack.quorum.size` and in case the above mentioned condition in not met , then an error is retuned by the validating webhook. 
In case the values adheres to the above condition say  `bookkeeper.ensemble.size=4`  `bookkeeper.write.quorum.size=3`  `bookkeeper.ack.quorum.size=3` then post installation of the pravega cluster if you go inside Controller/ Segment Store Pod then all these values should be available in the env variable `JAVA_OPTS` as

>  JAVA_OPTS=-Dbookkeeper.ack.quorum.size=3 -Dbookkeeper.ensemble.size=4 -Dbookkeeper.write.outstanding.bytes.max=33554432 -Dbookkeeper.write.quorum.size=3 -Dbookkeeper.write.timeout.milliseconds=60000 -Dcontroller.container.count=8 -Dcontroller.retention.bucket.count=4 -Dcontroller.retention.thread.count=4 -Dcontroller.service.asyncTaskPool.size=20 
