### PR TITLE
Issue 601: Upgrading Pravega minor version is failing with test mode enabled

### DIFF
--- a/pkg/apis/pravega/v1beta1/pravega.go
+++ b/pkg/apis/pravega/v1beta1/pravega.go
@@ -350,7 +350,7 @@ func (s *PravegaSpec) withDefaults() (changed bool) {
 		s.ControllerReplicas = 1
 	}
 
-	if !config.TestMode && s.RollbackTimeout < 1 {
+	if s.RollbackTimeout < 1 {
 		changed = true
 		s.RollbackTimeout = 10
 	}


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

when test mode is enabled, rollback timeout is not set to any default value. Due to that upgrade is not getting any time to complete and is failing

### Purpose of the change

Fixes #601

### What the code does

Set the Rollback timeout to `10 min` even if test mode is enabled
### How to verify it

Verified that  upgrade is working fine with test mode is enabled.