### PR TITLE
Issue 605: Remove dependency to k8sutil in pravegacluster_types.go

### DIFF
--- a/pkg/apis/pravega/v1beta1/pravegacluster_types.go
+++ b/pkg/apis/pravega/v1beta1/pravegacluster_types.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	k8s "github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	bkapi "github.com/pravega/bookkeeper-operator/pkg/apis/bookkeeper/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/apis/pravega/v1alpha1"
 	"github.com/pravega/pravega-operator/pkg/util"
@@ -56,6 +55,9 @@ const (
 	// DefaultPravegaVersion is the default tag used for for the Pravega
 	// Docker image
 	DefaultPravegaVersion = "0.9.0"
+
+	// OperatorNameEnvVar is env variable for operator name
+	OperatorNameEnvVar = "OPERATOR_NAME"
 )
 
 func init() {
@@ -1532,7 +1534,7 @@ func (p *PravegaCluster) WaitForClusterToTerminate(kubeClient client.Client) (er
 
 func (p *PravegaCluster) NewEvent(name string, reason string, message string, eventType string) *corev1.Event {
 	now := metav1.Now()
-	operatorName, _ := k8s.GetOperatorName()
+	operatorName, _ := OperatorName()
 	generateName := name + "-"
 	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1561,7 +1563,7 @@ func (p *PravegaCluster) NewEvent(name string, reason string, message string, ev
 
 func (p *PravegaCluster) NewApplicationEvent(name string, reason string, message string, eventType string) *corev1.Event {
 	now := metav1.Now()
-	operatorName, _ := k8s.GetOperatorName()
+	operatorName, _ := OperatorName()
 	generateName := name + "-"
 	event := corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1584,4 +1586,16 @@ func (p *PravegaCluster) NewApplicationEvent(name string, reason string, message
 		ReportingInstance:   os.Getenv("POD_NAME"),
 	}
 	return &event
+}
+
+// OperatorName returns the operator name
+func OperatorName() (string, error) {
+	operatorName, found := os.LookupEnv(OperatorNameEnvVar)
+	if !found {
+		return "", fmt.Errorf("environment variable %s is not set", OperatorNameEnvVar)
+	}
+	if len(operatorName) == 0 {
+		return "", fmt.Errorf("environment variable %s is empty", OperatorNameEnvVar)
+	}
+	return operatorName, nil
 }


### PR DESCRIPTION
Signed-off-by: Andrey Andreev <andrey_andreev@dell.com>

### Change log description

The import of k8sutil is removed in pravegacluster_types.go and k8s.GetOperatorName() is replaced by the function OperatorName().

### Purpose of the change

The package k8sutil [was removed](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.0.0/#removed-package-pkgk8sutil) from operator-sdk in version 1.0.0. This blocks using of PravegaCluster as a secondary resource in projects which use operator-sdk 1.0.0+.

### What the code does

Implements OperatorName() function that returns the value of OPERATOR_NAME env variable and/or error in case of empyt or not set variable.

### How to verify it

- pravegacluster_types.go and a corresponding package don't have dependency to k8sutil
- ZKMETA_CLEANUP_ERROR and UPGRADE_ERROR events should have the same operator name as before in ReportingController field
