### PR TITLE
Issue 620: Fix for pravega upgrade failure

### DIFF
--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -400,6 +400,7 @@ func (r *PravegaClusterReconciler) syncSegmentStoreVersion(p *pravegav1beta1.Pra
 
 	if ready {
 		labels := p.LabelsForPravegaCluster()
+		labels["component"] = "pravega-segmentstore"
 		pod, err := r.getOneOutdatedPod(sts, p.Status.TargetVersion, labels)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

While doing upgrade of pravega cluster, we are finding outdated pod in segment store using the pravega cluster labels. Since the controller and segment store share the same labels, outdated pod lists controller pod as well and upgrade is not happening correctly.

### Purpose of the change

Fixes #620

### What the code does

Corrected the labels for finding outdated pod

### How to verify it
Verified that upgrade is working fine
