### PR TITLE
Issue 628: Fix for disable finalizer flag is not functioning correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,10 +32,10 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	controllerconfig "github.com/pravega/bookkeeper-operator/pkg/controller/config"
-	"github.com/pravega/bookkeeper-operator/pkg/util"
 	v1beta1 "github.com/pravega/pravega-operator/api/v1beta1"
 	"github.com/pravega/pravega-operator/controllers"
+	controllerconfig "github.com/pravega/pravega-operator/pkg/controller/config"
+	"github.com/pravega/pravega-operator/pkg/util"
 	"github.com/pravega/pravega-operator/pkg/version"
 	"github.com/sirupsen/logrus"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
@@ -57,7 +57,7 @@ var (
 func init() {
 	flag.BoolVar(&versionFlag, "version", false, "Show version and quit")
 	flag.BoolVar(&controllerconfig.TestMode, "test", false, "Enable test mode. Do not use this flag in production")
-	flag.BoolVar(&controllerconfig.DisableFinalizer, "disableFinalizer", false, "Disable finalizers for bookkeeperclusters. Use this flag with awareness of the consequences")
+	flag.BoolVar(&controllerconfig.DisableFinalizer, "disableFinalizer", false, "Disable finalizers for pravegaclusters. Use this flag with awareness of the consequences")
 	flag.BoolVar(&webhookFlag, "webhook", true, "Enable webhook, the default is enabled.")
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1beta1.AddToScheme(scheme))


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

imports in `main.go` file was wrongly referring bookkeeper imports

### Purpose of the change

Fixes #628

### What the code does

Corrected the imports

### How to verify it

Verified pravega operator installation by enabling disablefinalizer flag and finalizer is not getting added
