### PR TITLE
Issue 630: Updating controller pdb policy

### DIFF
--- a/controllers/pravega_controller.go
+++ b/controllers/pravega_controller.go
@@ -403,7 +403,13 @@ func MakeControllerService(p *api.PravegaCluster) *corev1.Service {
 }
 
 func MakeControllerPodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.PodDisruptionBudget {
-	minAvailable := intstr.FromInt(int(p.Spec.Pravega.MaxUnavailableControllerReplicas))
+	var maxUnavailable intstr.IntOrString
+
+	if p.Spec.Pravega.MaxUnavailableControllerReplicas == int32(1) {
+		maxUnavailable = intstr.FromInt(0)
+	} else {
+		maxUnavailable = intstr.FromInt(int(p.Spec.Pravega.MaxUnavailableControllerReplicas))
+	}
 	return &policyv1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -414,7 +420,7 @@ func MakeControllerPodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.Pod
 			Namespace: p.Namespace,
 		},
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
-			MinAvailable: &minAvailable,
+			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: p.LabelsForController(),
 			},

--- a/controllers/pravega_controller.go
+++ b/controllers/pravega_controller.go
@@ -405,7 +405,7 @@ func MakeControllerService(p *api.PravegaCluster) *corev1.Service {
 func MakeControllerPodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.PodDisruptionBudget {
 	var maxUnavailable intstr.IntOrString
 
-	if p.Spec.Pravega.MaxUnavailableControllerReplicas == int32(1) {
+	if p.Spec.Pravega.ControllerReplicas == int32(1) {
 		maxUnavailable = intstr.FromInt(0)
 	} else {
 		maxUnavailable = intstr.FromInt(int(p.Spec.Pravega.MaxUnavailableControllerReplicas))


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Updating the controller PDB policy

### Purpose of the change

 Fixes #630

### What the code does

Currently in controller PDB, the `maxunavailableReplicas` set in values file is used for `minAvailable` . Corrected the policy. Also if the replica count is 1 setting maxunavailable replicas to `0` as in segment store

### How to verify it

Verified that able to configure PDB with these settings
