### PR TITLE
Issue 632: Upgrade of pravega cluster is failing intermittently

### DIFF
--- a/controllers/pravegacluster_controller.go
+++ b/controllers/pravegacluster_controller.go
@@ -359,6 +359,7 @@ func (r *PravegaClusterReconciler) updatePdb(currentPdb *policyv1beta1.PodDisrup
 
 	if !reflect.DeepEqual(currentPdb.Spec.MaxUnavailable, newPdb.Spec.MaxUnavailable) {
 		currentPdb.Spec.MaxUnavailable = newPdb.Spec.MaxUnavailable
+		currentPdb.Spec.MinAvailable = newPdb.Spec.MinAvailable
 		err = r.Client.Update(context.TODO(), currentPdb)
 		if err != nil {
 			return fmt.Errorf("failed to update pdb (%s): %v", currentPdb.Name, err)


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

In some cases, after updating stateful set, `updatedReplicas` field in sts is not updating correctly. Due to this, the check 
```
if sts.Status.UpdatedReplicas == sts.Status.Replicas &&
		sts.Status.UpdatedReplicas == sts.Status.ReadyReplicas 
```
is succeeding and make upgrade as completed. And segment store pods are not coming up with new image

### Purpose of the change

 Fixes #632

### What the code does
Added additional check to ensure that all  the pods are updated with new version

### How to verify it

Verified that upgrade is working fine
