### PR TITLE
Issue 634: Segment store pods are not restarted for labels updation

### DIFF
--- a/controllers/pravegacluster_controller.go
+++ b/controllers/pravegacluster_controller.go
@@ -704,8 +704,10 @@ func (r *PravegaClusterReconciler) restartStsPod(p *pravegav1beta1.PravegaCluste
 	if err != nil {
 		return err
 	}
+	labels := p.LabelsForPravegaCluster()
+	labels["component"] = "pravega-segmentstore"
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: currentSts.Spec.Template.Labels,
+		MatchLabels: labels,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to convert label selector: %v", err)


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

While doing restart of sts, labels are not passed correctly to list pods. Corrected the labels
### Purpose of the change

Fixes #634

### What the code does
Corrected the labels, so that the  pods are listed and restarted correctly
### How to verify it
Verified that after changing segment store pod labels,  pods are restarted
