### PR TITLE
Update alpine version to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 ARG DOCKER_REGISTRY
 ARG GO_VERSION=1.17
-ARG ALPINE_VERSION=3.15
+ARG ALPINE_VERSION=3.16
 
 FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}golang:${GO_VERSION}-alpine${ALPINE_VERSION} as go-builder
 
@@ -41,9 +41,10 @@ RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /src/${PROJECT_NAME} \
 # =============================================================================
 FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}alpine:${ALPINE_VERSION} AS final
 
-RUN apk add --update \
+RUN apk update && apk add --upgrade \
     sudo \
-    libcap
+    libcap \
+    busybox
 
 ARG PROJECT_NAME=pravega-operator
 


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Update alpine version to fix [CVE-2022-30065](https://security.alpinelinux.org/vuln/CVE-2022-30065) , [CVE-2022-28391](https://security.alpinelinux.org/vuln/CVE-2022-28391) and [CVE-2022-1292](https://security.alpinelinux.org/vuln/CVE-2022-1292).

### Purpose of the change

Fixes #636

### What the code does

Update alpine version to 3.16

### How to verify it

_(Steps to verify that the changes are effective)_

- Pull the latest docker image
- Spawn a container out of that image and go inside the container
- run the command apk list | grep busybox to check the installed version of busybox
- run the command apk list | grep openssl to check the installed version of openssl