### PR TITLE
Issue 643: Pravega cluster upgrade is failing intermittently

### DIFF
--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -415,7 +415,7 @@ func (r *PravegaClusterReconciler) syncSegmentStoreVersion(p *pravegav1beta1.Pra
 		log.Infof("upgrading pod: %s", pod.Name)
 
 		err = r.Client.Delete(context.TODO(), pod)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return false, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
Pravega cluster upgrade is failing in certain cases. In failed scenarios, while deleting the pod, we are getting error pod not found. Due to that error upgrade status is set to failure and due to that subsequent upgrade of pods is not happening

### Purpose of the change

 Fixes #643

### What the code does

Made changes to not return error in the case of pod deletion fails with pod not found error. This ensures that remaining pods can be upgraded successfully. 

### How to verify it

Verified upgrade of pravega cluster multiple times and is successful
