### PR TITLE
Issue 643: Pravega cluster upgrade is failing intermittently

### DIFF
--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -400,7 +400,7 @@ func (r *PravegaClusterReconciler) syncSegmentStoreVersion(p *pravegav1beta1.Pra
 		return false, err
 	}
 
-	if ready {
+	if ready && *sts.Spec.Replicas != (int32)(len(pods)) {
 		labels := p.LabelsForPravegaCluster()
 		labels["component"] = "pravega-segmentstore"
 		pod, err := r.getOneOutdatedPod(sts, p.Status.TargetVersion, labels)


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

In some cases, while updating segment store pods, upgrade is failing with error `Failed to get outdated pod` . When this happens all the SS pods are already updated.
### Purpose of the change

Fixes #643

### What the code does

While upgrading segment store pods,  even if the pods are updated with new version it takes some time to reflect in the status. So upgrade reconcile loop thinks upgrade is not completed and try to get an outdated pod. Since the pods are already updated, it fails to get outdated pod and makes upgrade as failed.
Added an extra check not to update the pod if all the pods are updated to target version

### How to verify it

Performed couple of upgrades and verified they are working fine.
