### PR TITLE
Issue 649: Upgrading k8s version (#650)

### DIFF
--- a/controllers/pravega_controller.go
+++ b/controllers/pravega_controller.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pravega/pravega-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -404,7 +404,7 @@ func MakeControllerService(p *api.PravegaCluster) *corev1.Service {
 	}
 }
 
-func MakeControllerPodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.PodDisruptionBudget {
+func MakeControllerPodDisruptionBudget(p *api.PravegaCluster) *policyv1.PodDisruptionBudget {
 	var maxUnavailable intstr.IntOrString
 
 	if p.Spec.Pravega.ControllerReplicas == int32(1) {
@@ -412,16 +412,16 @@ func MakeControllerPodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.Pod
 	} else {
 		maxUnavailable = intstr.FromInt(int(p.Spec.Pravega.MaxUnavailableControllerReplicas))
 	}
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
-			APIVersion: "policy/v1beta1",
+			APIVersion: "policy/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.PdbNameForController(),
 			Namespace: p.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: p.LabelsForController(),

--- a/controllers/pravega_segmentstore.go
+++ b/controllers/pravega_segmentstore.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pravega/pravega-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -631,7 +631,7 @@ func MakeSegmentStoreExternalServices(p *api.PravegaCluster) []*corev1.Service {
 	return services
 }
 
-func MakeSegmentstorePodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.PodDisruptionBudget {
+func MakeSegmentstorePodDisruptionBudget(p *api.PravegaCluster) *policyv1.PodDisruptionBudget {
 	var maxUnavailable intstr.IntOrString
 
 	if p.Spec.Pravega.SegmentStoreReplicas == int32(1) {
@@ -640,16 +640,16 @@ func MakeSegmentstorePodDisruptionBudget(p *api.PravegaCluster) *policyv1beta1.P
 		maxUnavailable = intstr.FromInt(int(p.Spec.Pravega.MaxUnavailableSegmentStoreReplicas))
 	}
 
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
-			APIVersion: "policy/v1beta1",
+			APIVersion: "policy/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.PdbNameForSegmentstore(),
 			Namespace: p.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: p.LabelsForSegmentStore(),

--- a/controllers/pravegacluster_controller.go
+++ b/controllers/pravegacluster_controller.go
@@ -26,7 +26,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -330,7 +330,7 @@ func (r *PravegaClusterReconciler) reconcileControllerPdb(p *pravegav1beta1.Prav
 		return err
 	}
 
-	currentPdb := &policyv1beta1.PodDisruptionBudget{}
+	currentPdb := &policyv1.PodDisruptionBudget{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: pdb.Name, Namespace: p.Namespace}, currentPdb)
 	if err != nil {
 		return err
@@ -347,7 +347,7 @@ func (r *PravegaClusterReconciler) reconcileSegmentStorePdb(p *pravegav1beta1.Pr
 		return err
 	}
 
-	currentPdb := &policyv1beta1.PodDisruptionBudget{}
+	currentPdb := &policyv1.PodDisruptionBudget{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: pdb.Name, Namespace: p.Namespace}, currentPdb)
 	if err != nil {
 		return err
@@ -355,7 +355,7 @@ func (r *PravegaClusterReconciler) reconcileSegmentStorePdb(p *pravegav1beta1.Pr
 	return r.updatePdb(currentPdb, pdb)
 }
 
-func (r *PravegaClusterReconciler) updatePdb(currentPdb *policyv1beta1.PodDisruptionBudget, newPdb *policyv1beta1.PodDisruptionBudget) (err error) {
+func (r *PravegaClusterReconciler) updatePdb(currentPdb *policyv1.PodDisruptionBudget, newPdb *policyv1.PodDisruptionBudget) (err error) {
 
 	if !reflect.DeepEqual(currentPdb.Spec.MaxUnavailable, newPdb.Spec.MaxUnavailable) {
 		currentPdb.Spec.MaxUnavailable = newPdb.Spec.MaxUnavailable

--- a/controllers/pravegacluster_controller_test.go
+++ b/controllers/pravegacluster_controller_test.go
@@ -17,7 +17,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -359,19 +359,19 @@ var _ = Describe("PravegaCluster Controller", func() {
 					BeforeEach(func() {
 						res, err = r.Reconcile(ctx, req)
 						p.WithDefaults()
-						currentpdb := &policyv1beta1.PodDisruptionBudget{}
+						currentpdb := &policyv1.PodDisruptionBudget{}
 						r.Client.Get(context.TODO(), types.NamespacedName{Name: p.PdbNameForSegmentstore(), Namespace: p.Namespace}, currentpdb)
 						maxUnavailable := intstr.FromInt(3)
-						newpdb := &policyv1beta1.PodDisruptionBudget{
+						newpdb := &policyv1.PodDisruptionBudget{
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "PodDisruptionBudget",
-								APIVersion: "policy/v1beta1",
+								APIVersion: "policy/v1",
 							},
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "test-name",
 								Namespace: p.Namespace,
 							},
-							Spec: policyv1beta1.PodDisruptionBudgetSpec{
+							Spec: policyv1.PodDisruptionBudgetSpec{
 								MaxUnavailable: &maxUnavailable,
 								Selector: &metav1.LabelSelector{
 									MatchLabels: p.LabelsForController(),


### PR DESCRIPTION
### Change log description

Updated pod disruption budget to v1
### Purpose of the change

 Fixes #649

### What the code does

Updated pod disruption budget to support k8 1.25

### How to verify it
All e2e tests should pass
