### PR TITLE
Issue 657: Providing support to update controller service annotations

### DIFF
--- a/controllers/pravegacluster_controller.go
+++ b/controllers/pravegacluster_controller.go
@@ -400,7 +400,6 @@ func (r *PravegaClusterReconciler) reconcileControllerService(p *pravegav1beta1.
 		} else {
 			return err
 		}
-
 	} else {
 		currentService.ObjectMeta.Labels = service.ObjectMeta.Labels
 		currentService.ObjectMeta.Annotations = service.ObjectMeta.Annotations

--- a/controllers/pravegacluster_controller.go
+++ b/controllers/pravegacluster_controller.go
@@ -396,7 +396,6 @@ func (r *PravegaClusterReconciler) reconcileControllerService(p *pravegav1beta1.
 			if err != nil && !errors.IsAlreadyExists(err) {
 				return err
 			}
-
 		} else {
 			return err
 		}
@@ -408,7 +407,6 @@ func (r *PravegaClusterReconciler) reconcileControllerService(p *pravegav1beta1.
 		if err != nil {
 			return fmt.Errorf("failed to update  service (%s): %v", service.Name, err)
 		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
### Change log description

Added support to update the annotations and labels at run time for controller service

### Purpose of the change

Fixes #657

### What the code does
In controller reconcile service, if there is change in service like annotations, labels it will be updated

### How to verify it

Verified by adding new annotations at run time
