### PR TITLE
Issue 670: Updating the segmentstore port

### DIFF
--- a/controllers/pravega_segmentstore.go
+++ b/controllers/pravega_segmentstore.go
@@ -641,6 +641,7 @@ func MakeSegmentStoreExternalServices(p *api.PravegaCluster) []*corev1.Service {
 		}
 		if p.Spec.Pravega.SegmentStoreLoadBalancerIP != "" {
 			service.Spec.Ports[0].Port = int32(serviceport) + i
+			service.Spec.Ports[1].Port = int32(adminPort) + i
 			service.Spec.LoadBalancerIP = p.Spec.Pravega.SegmentStoreLoadBalancerIP
 		}
 		services[i] = service


### PR DESCRIPTION
### Change log description

Updating the segment store service port incrementally if  `SegmentStoreLoadBalancerIP` is set

### Purpose of the change

 Fixes #670

### What the code does
If we are using same segment store service IP with different ports, in case of admin port as well port number needs to be incremented. If it is not incremented will give port conflict

### How to verify it
Verify segment store pods are coming up fine
