### PR TITLE
Issue 643: Fixing intermittent upgrade failure

### DIFF
--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -414,7 +414,7 @@ func (r *PravegaClusterReconciler) syncSegmentStoreVersion(p *pravegav1beta1.Pra
 				return false, err
 			}
 			if *sts.Spec.Replicas == (int32)(len(pods)) {
-				log.Infof("All segmentstore pods are upadted")
+				log.Infof("All segmentstore pods are updated")
 				return false, nil
 			}
 			return false, fmt.Errorf("could not obtain outdated pod")

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -414,6 +414,7 @@ func (r *PravegaClusterReconciler) syncSegmentStoreVersion(p *pravegav1beta1.Pra
 				return false, err
 			}
 			if *sts.Spec.Replicas == (int32)(len(pods)) {
+				log.Infof("All segmentstore pods are upadted")
 				return false, nil
 			}
 			return false, fmt.Errorf("could not obtain outdated pod")

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -409,6 +409,13 @@ func (r *PravegaClusterReconciler) syncSegmentStoreVersion(p *pravegav1beta1.Pra
 		}
 
 		if pod == nil {
+			pods, err := r.getStsPodsWithVersion(sts, p.Status.TargetVersion)
+			if err != nil {
+				return false, err
+			}
+			if *sts.Spec.Replicas == (int32)(len(pods)) {
+				return false, nil
+			}
 			return false, fmt.Errorf("could not obtain outdated pod")
 		}
 


### PR DESCRIPTION
### Change log description

Fixing intermittent upgrade failure of pravega.
Added some more conditions to handle error scenarios

### Purpose of the change

Fixes #643

### What the code does

while during segmentstore update, it fails to get the pod sometimes. Issue is happening because while it tries to get an outdated pod, it has already updated. So added more checks to post error only if all pods were not updated

### How to verify it
Peformed upgrade multiple time and issue is not seen
