### PR TITLE
Issue 674: Fix for segment store services are not coming up properly

### DIFF
--- a/api/v1beta1/pravegacluster_types.go
+++ b/api/v1beta1/pravegacluster_types.go
@@ -132,6 +132,9 @@ type ClusterSpec struct {
 	// +optional
 	BookkeeperUri string `json:"bookkeeperUri"`
 
+	// Reserved ports
+	ReservedPortList []int32 `json:"reservedPortList,omitempty"`
+
 	// Pravega configuration
 	// +optional
 	Pravega *PravegaSpec `json:"pravega"`

--- a/config/crd/bases/pravega.pravega.io_pravegaclusters.yaml
+++ b/config/crd/bases/pravega.pravega.io_pravegaclusters.yaml
@@ -175,14 +175,14 @@ spec:
                           containers will use emptyDir as volume
                         properties:
                           accessModes:
-                            description: 'AccessModes contains the desired access
+                            description: 'accessModes contains the desired access
                               modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
                             type: array
                           dataSource:
-                            description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            description: 'dataSource field can be used to specify
+                              either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                               * An existing PVC (PersistentVolumeClaim) If the provisioner
                               or an external controller can support the specified
                               data source, it will create a new volume based on the
@@ -207,13 +207,13 @@ spec:
                             - name
                             type: object
                           dataSourceRef:
-                            description: 'Specifies the object from which to populate
-                              the volume with data, if a non-empty volume is desired.
-                              This may be any local object from a non-empty API group
-                              (non core object) or a PersistentVolumeClaim object.
-                              When this field is specified, volume binding will only
-                              succeed if the type of the specified object matches
-                              some installed volume populator or dynamic provisioner.
+                            description: 'dataSourceRef specifies the object from
+                              which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any local object from
+                              a non-empty API group (non core object) or a PersistentVolumeClaim
+                              object. When this field is specified, volume binding
+                              will only succeed if the type of the specified object
+                              matches some installed volume populator or dynamic provisioner.
                               This field will replace the functionality of the DataSource
                               field and as such if both fields are non-empty, they
                               must have the same value. For backwards compatibility,
@@ -226,8 +226,8 @@ spec:
                               PersistentVolumeClaim objects. * While DataSource ignores
                               disallowed values (dropping them), DataSourceRef preserves
                               all values, and generates an error if a disallowed value
-                              is specified. (Alpha) Using this field requires the
-                              AnyVolumeDataSource feature gate to be enabled.'
+                              is specified. (Beta) Using this field requires the AnyVolumeDataSource
+                              feature gate to be enabled.'
                             properties:
                               apiGroup:
                                 description: APIGroup is the group for the resource
@@ -246,7 +246,7 @@ spec:
                             - name
                             type: object
                           resources:
-                            description: 'Resources represents the minimum resources
+                            description: 'resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
                               feature is enabled users are allowed to specify resource
                               requirements that are lower than previous value but
@@ -278,8 +278,8 @@ spec:
                                 type: object
                             type: object
                           selector:
-                            description: A label query over volumes to consider for
-                              binding.
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -324,8 +324,8 @@ spec:
                                 type: object
                             type: object
                           storageClassName:
-                            description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            description: 'storageClassName is the name of the StorageClass
+                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                             type: string
                           volumeMode:
                             description: volumeMode defines what type of volume is
@@ -333,7 +333,7 @@ spec:
                               when not included in claim spec.
                             type: string
                           volumeName:
-                            description: VolumeName is the binding reference to the
+                            description: volumeName is the binding reference to the
                               PersistentVolume backing this claim.
                             type: string
                         type: object
@@ -344,14 +344,14 @@ spec:
                           containers will use emptyDir as volume
                         properties:
                           accessModes:
-                            description: 'AccessModes contains the desired access
+                            description: 'accessModes contains the desired access
                               modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
                             type: array
                           dataSource:
-                            description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            description: 'dataSource field can be used to specify
+                              either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                               * An existing PVC (PersistentVolumeClaim) If the provisioner
                               or an external controller can support the specified
                               data source, it will create a new volume based on the
@@ -376,13 +376,13 @@ spec:
                             - name
                             type: object
                           dataSourceRef:
-                            description: 'Specifies the object from which to populate
-                              the volume with data, if a non-empty volume is desired.
-                              This may be any local object from a non-empty API group
-                              (non core object) or a PersistentVolumeClaim object.
-                              When this field is specified, volume binding will only
-                              succeed if the type of the specified object matches
-                              some installed volume populator or dynamic provisioner.
+                            description: 'dataSourceRef specifies the object from
+                              which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any local object from
+                              a non-empty API group (non core object) or a PersistentVolumeClaim
+                              object. When this field is specified, volume binding
+                              will only succeed if the type of the specified object
+                              matches some installed volume populator or dynamic provisioner.
                               This field will replace the functionality of the DataSource
                               field and as such if both fields are non-empty, they
                               must have the same value. For backwards compatibility,
@@ -395,8 +395,8 @@ spec:
                               PersistentVolumeClaim objects. * While DataSource ignores
                               disallowed values (dropping them), DataSourceRef preserves
                               all values, and generates an error if a disallowed value
-                              is specified. (Alpha) Using this field requires the
-                              AnyVolumeDataSource feature gate to be enabled.'
+                              is specified. (Beta) Using this field requires the AnyVolumeDataSource
+                              feature gate to be enabled.'
                             properties:
                               apiGroup:
                                 description: APIGroup is the group for the resource
@@ -415,7 +415,7 @@ spec:
                             - name
                             type: object
                           resources:
-                            description: 'Resources represents the minimum resources
+                            description: 'resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
                               feature is enabled users are allowed to specify resource
                               requirements that are lower than previous value but
@@ -447,8 +447,8 @@ spec:
                                 type: object
                             type: object
                           selector:
-                            description: A label query over volumes to consider for
-                              binding.
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -493,8 +493,8 @@ spec:
                                 type: object
                             type: object
                           storageClassName:
-                            description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            description: 'storageClassName is the name of the StorageClass
+                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                             type: string
                           volumeMode:
                             description: volumeMode defines what type of volume is
@@ -502,7 +502,7 @@ spec:
                               when not included in claim spec.
                             type: string
                           volumeName:
-                            description: VolumeName is the binding reference to the
+                            description: volumeName is the binding reference to the
                               PersistentVolume backing this claim.
                             type: string
                         type: object
@@ -513,14 +513,14 @@ spec:
                           containers will use emptyDir as volume
                         properties:
                           accessModes:
-                            description: 'AccessModes contains the desired access
+                            description: 'accessModes contains the desired access
                               modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
                             type: array
                           dataSource:
-                            description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            description: 'dataSource field can be used to specify
+                              either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                               * An existing PVC (PersistentVolumeClaim) If the provisioner
                               or an external controller can support the specified
                               data source, it will create a new volume based on the
@@ -545,13 +545,13 @@ spec:
                             - name
                             type: object
                           dataSourceRef:
-                            description: 'Specifies the object from which to populate
-                              the volume with data, if a non-empty volume is desired.
-                              This may be any local object from a non-empty API group
-                              (non core object) or a PersistentVolumeClaim object.
-                              When this field is specified, volume binding will only
-                              succeed if the type of the specified object matches
-                              some installed volume populator or dynamic provisioner.
+                            description: 'dataSourceRef specifies the object from
+                              which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any local object from
+                              a non-empty API group (non core object) or a PersistentVolumeClaim
+                              object. When this field is specified, volume binding
+                              will only succeed if the type of the specified object
+                              matches some installed volume populator or dynamic provisioner.
                               This field will replace the functionality of the DataSource
                               field and as such if both fields are non-empty, they
                               must have the same value. For backwards compatibility,
@@ -564,8 +564,8 @@ spec:
                               PersistentVolumeClaim objects. * While DataSource ignores
                               disallowed values (dropping them), DataSourceRef preserves
                               all values, and generates an error if a disallowed value
-                              is specified. (Alpha) Using this field requires the
-                              AnyVolumeDataSource feature gate to be enabled.'
+                              is specified. (Beta) Using this field requires the AnyVolumeDataSource
+                              feature gate to be enabled.'
                             properties:
                               apiGroup:
                                 description: APIGroup is the group for the resource
@@ -584,7 +584,7 @@ spec:
                             - name
                             type: object
                           resources:
-                            description: 'Resources represents the minimum resources
+                            description: 'resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
                               feature is enabled users are allowed to specify resource
                               requirements that are lower than previous value but
@@ -616,8 +616,8 @@ spec:
                                 type: object
                             type: object
                           selector:
-                            description: A label query over volumes to consider for
-                              binding.
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
@@ -662,8 +662,8 @@ spec:
                                 type: object
                             type: object
                           storageClassName:
-                            description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            description: 'storageClassName is the name of the StorageClass
+                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                             type: string
                           volumeMode:
                             description: volumeMode defines what type of volume is
@@ -671,7 +671,7 @@ spec:
                               when not included in claim spec.
                             type: string
                           volumeName:
-                            description: VolumeName is the binding reference to the
+                            description: volumeName is the binding reference to the
                               PersistentVolume backing this claim.
                             type: string
                         type: object
@@ -705,14 +705,14 @@ spec:
                       spec, stateful containers will use emptyDir as volume
                     properties:
                       accessModes:
-                        description: 'AccessModes contains the desired access modes
+                        description: 'accessModes contains the desired access modes
                           the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                         items:
                           type: string
                         type: array
                       dataSource:
-                        description: 'This field can be used to specify either: *
-                          An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                        description: 'dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                           * An existing PVC (PersistentVolumeClaim) If the provisioner
                           or an external controller can support the specified data
                           source, it will create a new volume based on the contents
@@ -737,11 +737,11 @@ spec:
                         - name
                         type: object
                       dataSourceRef:
-                        description: 'Specifies the object from which to populate
-                          the volume with data, if a non-empty volume is desired.
-                          This may be any local object from a non-empty API group
-                          (non core object) or a PersistentVolumeClaim object. When
-                          this field is specified, volume binding will only succeed
+                        description: 'dataSourceRef specifies the object from which
+                          to populate the volume with data, if a non-empty volume
+                          is desired. This may be any local object from a non-empty
+                          API group (non core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed
                           if the type of the specified object matches some installed
                           volume populator or dynamic provisioner. This field will
                           replace the functionality of the DataSource field and as
@@ -754,7 +754,7 @@ spec:
                           DataSourceRef allows any non-core object, as well as PersistentVolumeClaim
                           objects. * While DataSource ignores disallowed values (dropping
                           them), DataSourceRef preserves all values, and generates
-                          an error if a disallowed value is specified. (Alpha) Using
+                          an error if a disallowed value is specified. (Beta) Using
                           this field requires the AnyVolumeDataSource feature gate
                           to be enabled.'
                         properties:
@@ -775,7 +775,7 @@ spec:
                         - name
                         type: object
                       resources:
-                        description: 'Resources represents the minimum resources the
+                        description: 'resources represents the minimum resources the
                           volume should have. If RecoverVolumeExpansionFailure feature
                           is enabled users are allowed to specify resource requirements
                           that are lower than previous value but must still be higher
@@ -807,7 +807,8 @@ spec:
                             type: object
                         type: object
                       selector:
-                        description: A label query over volumes to consider for binding.
+                        description: selector is a label query over volumes to consider
+                          for binding.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -852,8 +853,8 @@ spec:
                             type: object
                         type: object
                       storageClassName:
-                        description: 'Name of the StorageClass required by the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        description: 'storageClassName is the name of the StorageClass
+                          required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                         type: string
                       volumeMode:
                         description: volumeMode defines what type of volume is required
@@ -861,7 +862,7 @@ spec:
                           in claim spec.
                         type: string
                       volumeName:
-                        description: VolumeName is the binding reference to the PersistentVolume
+                        description: volumeName is the binding reference to the PersistentVolume
                           backing this claim.
                         type: string
                     type: object
@@ -1041,13 +1042,13 @@ spec:
                               that is owned by someone else (the system).
                             properties:
                               claimName:
-                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                description: 'claimName is the name of a PersistentVolumeClaim
                                   in the same namespace as the pod using this volume.
                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 type: string
                               readOnly:
-                                description: Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
                                 type: boolean
                             required:
                             - claimName
@@ -1292,14 +1293,14 @@ spec:
                       spec, stateful containers will use emptyDir as volume
                     properties:
                       accessModes:
-                        description: 'AccessModes contains the desired access modes
+                        description: 'accessModes contains the desired access modes
                           the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                         items:
                           type: string
                         type: array
                       dataSource:
-                        description: 'This field can be used to specify either: *
-                          An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                        description: 'dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                           * An existing PVC (PersistentVolumeClaim) If the provisioner
                           or an external controller can support the specified data
                           source, it will create a new volume based on the contents
@@ -1324,11 +1325,11 @@ spec:
                         - name
                         type: object
                       dataSourceRef:
-                        description: 'Specifies the object from which to populate
-                          the volume with data, if a non-empty volume is desired.
-                          This may be any local object from a non-empty API group
-                          (non core object) or a PersistentVolumeClaim object. When
-                          this field is specified, volume binding will only succeed
+                        description: 'dataSourceRef specifies the object from which
+                          to populate the volume with data, if a non-empty volume
+                          is desired. This may be any local object from a non-empty
+                          API group (non core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed
                           if the type of the specified object matches some installed
                           volume populator or dynamic provisioner. This field will
                           replace the functionality of the DataSource field and as
@@ -1341,7 +1342,7 @@ spec:
                           DataSourceRef allows any non-core object, as well as PersistentVolumeClaim
                           objects. * While DataSource ignores disallowed values (dropping
                           them), DataSourceRef preserves all values, and generates
-                          an error if a disallowed value is specified. (Alpha) Using
+                          an error if a disallowed value is specified. (Beta) Using
                           this field requires the AnyVolumeDataSource feature gate
                           to be enabled.'
                         properties:
@@ -1362,7 +1363,7 @@ spec:
                         - name
                         type: object
                       resources:
-                        description: 'Resources represents the minimum resources the
+                        description: 'resources represents the minimum resources the
                           volume should have. If RecoverVolumeExpansionFailure feature
                           is enabled users are allowed to specify resource requirements
                           that are lower than previous value but must still be higher
@@ -1394,7 +1395,8 @@ spec:
                             type: object
                         type: object
                       selector:
-                        description: A label query over volumes to consider for binding.
+                        description: selector is a label query over volumes to consider
+                          for binding.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
@@ -1439,8 +1441,8 @@ spec:
                             type: object
                         type: object
                       storageClassName:
-                        description: 'Name of the StorageClass required by the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        description: 'storageClassName is the name of the StorageClass
+                          required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                         type: string
                       volumeMode:
                         description: volumeMode defines what type of volume is required
@@ -1448,7 +1450,7 @@ spec:
                           in claim spec.
                         type: string
                       volumeName:
-                        description: VolumeName is the binding reference to the PersistentVolume
+                        description: volumeName is the binding reference to the PersistentVolume
                           backing this claim.
                         type: string
                     type: object
@@ -1575,11 +1577,11 @@ spec:
                         run within a pod.
                       properties:
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
                             to a single $, which allows for escaping the $(VAR_NAME)
                             syntax: i.e. "$$(VAR_NAME)" will produce the string literal
                             "$(VAR_NAME)". Escaped references will never be expanded,
@@ -1590,7 +1592,7 @@ spec:
                           type: array
                         command:
                           description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
+                            The container image''s ENTRYPOINT is used if this is not
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
@@ -1766,7 +1768,7 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                             This field is optional to allow higher level config management
                             to default or override container images in workload controllers
                             like Deployments and StatefulSets.'
@@ -2002,8 +2004,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -2210,8 +2212,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -2575,8 +2577,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -3115,9 +3117,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -3174,7 +3174,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -3278,9 +3278,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -3335,7 +3333,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -3439,9 +3437,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -3498,7 +3494,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -3602,9 +3598,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -3659,7 +3653,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -4086,13 +4080,13 @@ spec:
                               that is owned by someone else (the system).
                             properties:
                               claimName:
-                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                description: 'claimName is the name of a PersistentVolumeClaim
                                   in the same namespace as the pod using this volume.
                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 type: string
                               readOnly:
-                                description: Will force the ReadOnly setting in VolumeMounts.
-                                  Default false.
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
                                 type: boolean
                             required:
                             - claimName
@@ -4140,122 +4134,124 @@ spec:
                         may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
-                          description: 'AWSElasticBlockStore represents an AWS Disk
+                          description: 'awsElasticBlockStore represents an AWS Disk
                             resource that is attached to a kubelet''s host machine
                             and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty).'
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Specify "true" to force and set the ReadOnly
-                                property in VolumeMounts to "true". If omitted, the
-                                default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: boolean
                             volumeID:
-                              description: 'Unique ID of the persistent disk resource
-                                in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: string
                           required:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: AzureDisk represents an Azure Data Disk mount
+                          description: azureDisk represents an Azure Data Disk mount
                             on the host and bind mount to the pod.
                           properties:
                             cachingMode:
-                              description: 'Host Caching mode: None, Read Only, Read
-                                Write.'
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
                               type: string
                             diskName:
-                              description: The Name of the data disk in the blob storage
+                              description: diskName is the Name of the data disk in
+                                the blob storage
                               type: string
                             diskURI:
-                              description: The URI the data disk in the blob storage
+                              description: diskURI is the URI of data disk in the
+                                blob storage
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is Filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             kind:
-                              description: 'Expected values Shared: multiple blob
-                                disks per storage account  Dedicated: single blob
-                                disk per storage account  Managed: azure managed data
-                                disk (only in managed availability set). defaults
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
                                 to shared'
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                           required:
                           - diskName
                           - diskURI
                           type: object
                         azureFile:
-                          description: AzureFile represents an Azure File Service
+                          description: azureFile represents an Azure File Service
                             mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
-                              description: the name of secret that contains Azure
-                                Storage Account Name and Key
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
                               type: string
                             shareName:
-                              description: Share Name
+                              description: shareName is the azure share Name
                               type: string
                           required:
                           - secretName
                           - shareName
                           type: object
                         cephfs:
-                          description: CephFS represents a Ceph FS mount on the host
+                          description: cephFS represents a Ceph FS mount on the host
                             that shares a pod's lifetime
                           properties:
                             monitors:
-                              description: 'Required: Monitors is a collection of
-                                Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             path:
-                              description: 'Optional: Used as the mounted root, rather
-                                than the full Ceph tree, default is /'
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: boolean
                             secretFile:
-                              description: 'Optional: SecretFile is the path to key
-                                ring for User, default is /etc/ceph/user.secret More
-                                info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                authentication secret for User, default is empty.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -4264,30 +4260,30 @@ spec:
                                   type: string
                               type: object
                             user:
-                              description: 'Optional: User is the rados user name,
-                                default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                           required:
                           - monitors
                           type: object
                         cinder:
-                          description: 'Cinder represents a cinder volume attached
+                          description: 'cinder represents a cinder volume attached
                             and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
+                              description: 'readOnly defaults to false (read/write).
                                 ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                 More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: boolean
                             secretRef:
-                              description: 'Optional: points to a secret object containing
-                                parameters used to connect to OpenStack.'
+                              description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -4296,37 +4292,38 @@ spec:
                                   type: string
                               type: object
                             volumeID:
-                              description: 'volume id used to identify the volume
-                                in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                           required:
                           - volumeID
                           type: object
                         configMap:
-                          description: ConfigMap represents a configMap that should
+                          description: configMap represents a configMap that should
                             populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced ConfigMap will be
-                                projected into the volume as a file whose name is
-                                the key and content is the value. If specified, the
-                                listed keys will be projected into the specified paths,
-                                and unlisted keys will not be present. If a key is
-                                specified which is not present in the ConfigMap, the
-                                volume setup will error unless it is marked optional.
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
                                 Paths must be relative and may not contain the '..'
                                 path or start with '..'.
                               items:
@@ -4334,26 +4331,26 @@ spec:
                                   volume.
                                 properties:
                                   key:
-                                    description: The key to project.
+                                    description: key is the key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -4365,28 +4362,28 @@ spec:
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its keys
-                                must be defined
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
                               type: boolean
                           type: object
                         csi:
-                          description: CSI (Container Storage Interface) represents
+                          description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
                             CSI drivers (Beta feature).
                           properties:
                             driver:
-                              description: Driver is the name of the CSI driver that
+                              description: driver is the name of the CSI driver that
                                 handles this volume. Consult with your admin for the
                                 correct name as registered in the cluster.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Ex. "ext4", "xfs",
-                                "ntfs". If not provided, the empty value is passed
-                                to the associated CSI driver which will determine
-                                the default filesystem to apply.
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
                               type: string
                             nodePublishSecretRef:
-                              description: NodePublishSecretRef is a reference to
+                              description: nodePublishSecretRef is a reference to
                                 the secret object containing sensitive information
                                 to pass to the CSI driver to complete the CSI NodePublishVolume
                                 and NodeUnpublishVolume calls. This field is optional,
@@ -4401,13 +4398,13 @@ spec:
                                   type: string
                               type: object
                             readOnly:
-                              description: Specifies a read-only configuration for
-                                the volume. Defaults to false (read/write).
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
                               type: boolean
                             volumeAttributes:
                               additionalProperties:
                                 type: string
-                              description: VolumeAttributes stores driver-specific
+                              description: volumeAttributes stores driver-specific
                                 properties that are passed to the CSI driver. Consult
                                 your driver's documentation for supported values.
                               type: object
@@ -4415,7 +4412,7 @@ spec:
                           - driver
                           type: object
                         downwardAPI:
-                          description: DownwardAPI represents downward API about the
+                          description: downwardAPI represents downward API about the
                             pod that should populate this volume
                           properties:
                             defaultMode:
@@ -4505,31 +4502,33 @@ spec:
                               type: array
                           type: object
                         emptyDir:
-                          description: 'EmptyDir represents a temporary directory
+                          description: 'emptyDir represents a temporary directory
                             that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           properties:
                             medium:
-                              description: 'What type of storage medium should back
-                                this directory. The default is "" which means to use
-                                the node''s default medium. Must be an empty string
-                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Total amount of local storage required
-                                for this EmptyDir volume. The size limit is also applicable
-                                for memory medium. The maximum usage on memory medium
-                                EmptyDir would be the minimum value between the SizeLimit
-                                specified here and the sum of memory limits of all
-                                containers in a pod. The default is nil which means
-                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
                         ephemeral:
-                          description: "Ephemeral represents a volume that is handled
+                          description: "ephemeral represents a volume that is handled
                             by a cluster storage driver. The volume's lifecycle is
                             tied to the pod that defines it - it will be created before
                             the pod starts, and deleted when the pod is removed. \n
@@ -4585,18 +4584,18 @@ spec:
                                     also valid here.
                                   properties:
                                     accessModes:
-                                      description: 'AccessModes contains the desired
+                                      description: 'accessModes contains the desired
                                         access modes the volume should have. More
                                         info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'This field can be used to specify
-                                        either: * An existing VolumeSnapshot object
-                                        (snapshot.storage.k8s.io/VolumeSnapshot) *
-                                        An existing PVC (PersistentVolumeClaim) If
-                                        the provisioner or an external controller
+                                      description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
                                         can support the specified data source, it
                                         will create a new volume based on the contents
                                         of the specified data source. If the AnyVolumeDataSource
@@ -4624,17 +4623,17 @@ spec:
                                       - name
                                       type: object
                                     dataSourceRef:
-                                      description: 'Specifies the object from which
-                                        to populate the volume with data, if a non-empty
-                                        volume is desired. This may be any local object
-                                        from a non-empty API group (non core object)
-                                        or a PersistentVolumeClaim object. When this
-                                        field is specified, volume binding will only
-                                        succeed if the type of the specified object
-                                        matches some installed volume populator or
-                                        dynamic provisioner. This field will replace
-                                        the functionality of the DataSource field
-                                        and as such if both fields are non-empty,
+                                      description: 'dataSourceRef specifies the object
+                                        from which to populate the volume with data,
+                                        if a non-empty volume is desired. This may
+                                        be any local object from a non-empty API group
+                                        (non core object) or a PersistentVolumeClaim
+                                        object. When this field is specified, volume
+                                        binding will only succeed if the type of the
+                                        specified object matches some installed volume
+                                        populator or dynamic provisioner. This field
+                                        will replace the functionality of the DataSource
+                                        field and as such if both fields are non-empty,
                                         they must have the same value. For backwards
                                         compatibility, both fields (DataSource and
                                         DataSourceRef) will be set to the same value
@@ -4647,7 +4646,7 @@ spec:
                                         objects. * While DataSource ignores disallowed
                                         values (dropping them), DataSourceRef preserves
                                         all values, and generates an error if a disallowed
-                                        value is specified. (Alpha) Using this field
+                                        value is specified. (Beta) Using this field
                                         requires the AnyVolumeDataSource feature gate
                                         to be enabled.'
                                       properties:
@@ -4671,7 +4670,7 @@ spec:
                                       - name
                                       type: object
                                     resources:
-                                      description: 'Resources represents the minimum
+                                      description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
                                         feature is enabled users are allowed to specify
                                         resource requirements that are lower than
@@ -4706,8 +4705,8 @@ spec:
                                           type: object
                                       type: object
                                     selector:
-                                      description: A label query over volumes to consider
-                                        for binding.
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -4758,8 +4757,9 @@ spec:
                                           type: object
                                       type: object
                                     storageClassName:
-                                      description: 'Name of the StorageClass required
-                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                       type: string
                                     volumeMode:
                                       description: volumeMode defines what type of
@@ -4768,7 +4768,7 @@ spec:
                                         claim spec.
                                       type: string
                                     volumeName:
-                                      description: VolumeName is the binding reference
+                                      description: volumeName is the binding reference
                                         to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
@@ -4777,32 +4777,34 @@ spec:
                               type: object
                           type: object
                         fc:
-                          description: FC represents a Fibre Channel resource that
+                          description: fc represents a Fibre Channel resource that
                             is attached to a kubelet's host machine and then exposed
                             to the pod.
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified. TODO: how do we prevent errors in the
-                                filesystem from compromising the machine'
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified. TODO: how do we prevent
+                                errors in the filesystem from compromising the machine'
                               type: string
                             lun:
-                              description: 'Optional: FC target lun number'
+                              description: 'lun is Optional: FC target lun number'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
                               type: boolean
                             targetWWNs:
-                              description: 'Optional: FC target worldwide names (WWNs)'
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
                               items:
                                 type: string
                               type: array
                             wwids:
-                              description: 'Optional: FC volume world wide identifiers
+                              description: 'wwids Optional: FC volume world wide identifiers
                                 (wwids) Either wwids or combination of targetWWNs
                                 and lun must be set, but not both simultaneously.'
                               items:
@@ -4810,35 +4812,37 @@ spec:
                               type: array
                           type: object
                         flexVolume:
-                          description: FlexVolume represents a generic volume resource
+                          description: flexVolume represents a generic volume resource
                             that is provisioned/attached using an exec based plugin.
                           properties:
                             driver:
-                              description: Driver is the name of the driver to use
+                              description: driver is the name of the driver to use
                                 for this volume.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". The default filesystem depends on FlexVolume
-                                script.
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                depends on FlexVolume script.
                               type: string
                             options:
                               additionalProperties:
                                 type: string
-                              description: 'Optional: Extra command options if any.'
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
                               type: object
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
                               type: boolean
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                secret object containing sensitive information to
-                                pass to the plugin scripts. This may be empty if no
-                                secret object is specified. If the secret object contains
-                                more than one secret, all secrets are passed to the
-                                plugin scripts.'
+                              description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -4850,49 +4854,50 @@ spec:
                           - driver
                           type: object
                         flocker:
-                          description: Flocker represents a Flocker volume attached
+                          description: flocker represents a Flocker volume attached
                             to a kubelet's host machine. This depends on the Flocker
                             control service being running
                           properties:
                             datasetName:
-                              description: Name of the dataset stored as metadata
-                                -> name on the dataset for Flocker should be considered
-                                as deprecated
+                              description: datasetName is Name of the dataset stored
+                                as metadata -> name on the dataset for Flocker should
+                                be considered as deprecated
                               type: string
                             datasetUUID:
-                              description: UUID of the dataset. This is unique identifier
-                                of a Flocker dataset
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
-                          description: 'GCEPersistentDisk represents a GCE Disk resource
+                          description: 'gcePersistentDisk represents a GCE Disk resource
                             that is attached to a kubelet''s host machine and then
                             exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               format: int32
                               type: integer
                             pdName:
-                              description: 'Unique name of the PD resource in GCE.
-                                Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
+                              description: 'readOnly here will force the ReadOnly
                                 setting in VolumeMounts. Defaults to false. More info:
                                 https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: boolean
@@ -4900,42 +4905,43 @@ spec:
                           - pdName
                           type: object
                         gitRepo:
-                          description: 'GitRepo represents a git repository at a particular
+                          description: 'gitRepo represents a git repository at a particular
                             revision. DEPRECATED: GitRepo is deprecated. To provision
                             a container with a git repo, mount an EmptyDir into an
                             InitContainer that clones the repo using git, then mount
                             the EmptyDir into the Pod''s container.'
                           properties:
                             directory:
-                              description: Target directory name. Must not contain
-                                or start with '..'.  If '.' is supplied, the volume
-                                directory will be the git repository.  Otherwise,
+                              description: directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied,
+                                the volume directory will be the git repository.  Otherwise,
                                 if specified, the volume will contain the git repository
                                 in the subdirectory with the given name.
                               type: string
                             repository:
-                              description: Repository URL
+                              description: repository is the URL
                               type: string
                             revision:
-                              description: Commit hash for the specified revision.
+                              description: revision is the commit hash for the specified
+                                revision.
                               type: string
                           required:
                           - repository
                           type: object
                         glusterfs:
-                          description: 'Glusterfs represents a Glusterfs mount on
+                          description: 'glusterfs represents a Glusterfs mount on
                             the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                           properties:
                             endpoints:
-                              description: 'EndpointsName is the endpoint name that
-                                details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             path:
-                              description: 'Path is the Glusterfs volume path. More
+                              description: 'path is the Glusterfs volume path. More
                                 info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the Glusterfs
+                              description: 'readOnly here will force the Glusterfs
                                 volume to be mounted with read-only permissions. Defaults
                                 to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: boolean
@@ -4944,7 +4950,7 @@ spec:
                           - path
                           type: object
                         hostPath:
-                          description: 'HostPath represents a pre-existing file or
+                          description: 'hostPath represents a pre-existing file or
                             directory on the host machine that is directly exposed
                             to the container. This is generally used for system agents
                             or other privileged things that are allowed to see the
@@ -4955,68 +4961,71 @@ spec:
                             as read/write.'
                           properties:
                             path:
-                              description: 'Path of the directory on the host. If
+                              description: 'path of the directory on the host. If
                                 the path is a symlink, it will follow the link to
                                 the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                             type:
-                              description: 'Type for HostPath Volume Defaults to ""
+                              description: 'type for HostPath Volume Defaults to ""
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                           required:
                           - path
                           type: object
                         iscsi:
-                          description: 'ISCSI represents an ISCSI Disk resource that
+                          description: 'iscsi represents an ISCSI Disk resource that
                             is attached to a kubelet''s host machine and then exposed
                             to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                           properties:
                             chapAuthDiscovery:
-                              description: whether support iSCSI Discovery CHAP authentication
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
-                              description: whether support iSCSI Session CHAP authentication
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             initiatorName:
-                              description: Custom iSCSI Initiator Name. If initiatorName
-                                is specified with iscsiInterface simultaneously, new
-                                iSCSI interface <target portal>:<volume name> will
-                                be created for the connection.
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name. If initiatorName is specified with iscsiInterface
+                                simultaneously, new iSCSI interface <target portal>:<volume
+                                name> will be created for the connection.
                               type: string
                             iqn:
-                              description: Target iSCSI Qualified Name.
+                              description: iqn is the target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
-                              description: iSCSI Interface Name that uses an iSCSI
-                                transport. Defaults to 'default' (tcp).
+                              description: iscsiInterface is the interface Name that
+                                uses an iSCSI transport. Defaults to 'default' (tcp).
                               type: string
                             lun:
-                              description: iSCSI Target Lun number.
+                              description: lun represents iSCSI Target Lun number.
                               format: int32
                               type: integer
                             portals:
-                              description: iSCSI Target Portal List. The portal is
-                                either an IP or ip_addr:port if the port is other
-                                than default (typically TCP ports 860 and 3260).
+                              description: portals is the iSCSI Target Portal List.
+                                The portal is either an IP or ip_addr:port if the
+                                port is other than default (typically TCP ports 860
+                                and 3260).
                               items:
                                 type: string
                               type: array
                             readOnly:
-                              description: ReadOnly here will force the ReadOnly setting
+                              description: readOnly here will force the ReadOnly setting
                                 in VolumeMounts. Defaults to false.
                               type: boolean
                             secretRef:
-                              description: CHAP Secret for iSCSI target and initiator
-                                authentication
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -5025,9 +5034,10 @@ spec:
                                   type: string
                               type: object
                             targetPortal:
-                              description: iSCSI Target Portal. The Portal is either
-                                an IP or ip_addr:port if the port is other than default
-                                (typically TCP ports 860 and 3260).
+                              description: targetPortal is iSCSI Target Portal. The
+                                Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and
+                                3260).
                               type: string
                           required:
                           - iqn
@@ -5035,24 +5045,24 @@ spec:
                           - targetPortal
                           type: object
                         name:
-                          description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         nfs:
-                          description: 'NFS represents an NFS mount on the host that
+                          description: 'nfs represents an NFS mount on the host that
                             shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           properties:
                             path:
-                              description: 'Path that is exported by the NFS server.
+                              description: 'path that is exported by the NFS server.
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the NFS export
+                              description: 'readOnly here will force the NFS export
                                 to be mounted with read-only permissions. Defaults
                                 to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: boolean
                             server:
-                              description: 'Server is the hostname or IP address of
+                              description: 'server is the hostname or IP address of
                                 the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                           required:
@@ -5060,89 +5070,89 @@ spec:
                           - server
                           type: object
                         persistentVolumeClaim:
-                          description: 'PersistentVolumeClaimVolumeSource represents
+                          description: 'persistentVolumeClaimVolumeSource represents
                             a reference to a PersistentVolumeClaim in the same namespace.
                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             claimName:
-                              description: 'ClaimName is the name of a PersistentVolumeClaim
+                              description: 'claimName is the name of a PersistentVolumeClaim
                                 in the same namespace as the pod using this volume.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               type: string
                             readOnly:
-                              description: Will force the ReadOnly setting in VolumeMounts.
-                                Default false.
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
                               type: boolean
                           required:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: PhotonPersistentDisk represents a PhotonController
+                          description: photonPersistentDisk represents a PhotonController
                             persistent disk attached and mounted on kubelets host
                             machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             pdID:
-                              description: ID that identifies Photon Controller persistent
-                                disk
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: PortworxVolume represents a portworx volume
+                          description: portworxVolume represents a portworx volume
                             attached and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: FSType represents the filesystem type to
+                              description: fSType represents the filesystem type to
                                 mount Must be a filesystem type supported by the host
                                 operating system. Ex. "ext4", "xfs". Implicitly inferred
                                 to be "ext4" if unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
-                              description: VolumeID uniquely identifies a Portworx
+                              description: volumeID uniquely identifies a Portworx
                                 volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
-                          description: Items for all in one resources secrets, configmaps,
-                            and downward API
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
                           properties:
                             defaultMode:
-                              description: Mode bits used to set permissions on created
-                                files by default. Must be an octal value between 0000
-                                and 0777 or a decimal value between 0 and 511. YAML
-                                accepts both octal and decimal values, JSON requires
-                                decimal values for mode bits. Directories within the
-                                path are not affected by this setting. This might
-                                be in conflict with other options that affect the
-                                file mode, like fsGroup, and the result can be other
-                                mode bits set.
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
                               format: int32
                               type: integer
                             sources:
-                              description: list of volume projections
+                              description: sources is the list of volume projections
                               items:
                                 description: Projection that may be projected along
                                   with other supported volume types
                                 properties:
                                   configMap:
-                                    description: information about the configMap data
-                                      to project
+                                    description: configMap information about the configMap
+                                      data to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -5159,27 +5169,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -5195,13 +5205,13 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   downwardAPI:
-                                    description: information about the downwardAPI
-                                      data to project
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
                                     properties:
                                       items:
                                         description: Items is a list of DownwardAPIVolume
@@ -5285,11 +5295,11 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: information about the secret data
-                                      to project
+                                    description: secret information about the secret
+                                      data to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -5306,27 +5316,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -5342,16 +5352,16 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
                                         type: boolean
                                     type: object
                                   serviceAccountToken:
-                                    description: information about the serviceAccountToken
-                                      data to project
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
                                     properties:
                                       audience:
-                                        description: Audience is the intended audience
+                                        description: audience is the intended audience
                                           of the token. A recipient of a token must
                                           identify itself with an identifier specified
                                           in the audience of the token, and otherwise
@@ -5359,7 +5369,7 @@ spec:
                                           to the identifier of the apiserver.
                                         type: string
                                       expirationSeconds:
-                                        description: ExpirationSeconds is the requested
+                                        description: expirationSeconds is the requested
                                           duration of validity of the service account
                                           token. As the token approaches expiration,
                                           the kubelet volume plugin will proactively
@@ -5372,7 +5382,7 @@ spec:
                                         format: int64
                                         type: integer
                                       path:
-                                        description: Path is the path relative to
+                                        description: path is the path relative to
                                           the mount point of the file to project the
                                           token into.
                                         type: string
@@ -5383,35 +5393,35 @@ spec:
                               type: array
                           type: object
                         quobyte:
-                          description: Quobyte represents a Quobyte mount on the host
+                          description: quobyte represents a Quobyte mount on the host
                             that shares a pod's lifetime
                           properties:
                             group:
-                              description: Group to map volume access to Default is
+                              description: group to map volume access to Default is
                                 no group
                               type: string
                             readOnly:
-                              description: ReadOnly here will force the Quobyte volume
+                              description: readOnly here will force the Quobyte volume
                                 to be mounted with read-only permissions. Defaults
                                 to false.
                               type: boolean
                             registry:
-                              description: Registry represents a single or multiple
+                              description: registry represents a single or multiple
                                 Quobyte Registry services specified as a string as
                                 host:port pair (multiple entries are separated with
                                 commas) which acts as the central registry for volumes
                               type: string
                             tenant:
-                              description: Tenant owning the given Quobyte volume
+                              description: tenant owning the given Quobyte volume
                                 in the Backend Used with dynamically provisioned Quobyte
                                 volumes, value is set by the plugin
                               type: string
                             user:
-                              description: User to map volume access to Defaults to
+                              description: user to map volume access to Defaults to
                                 serivceaccount user
                               type: string
                             volume:
-                              description: Volume is a string that references an already
+                              description: volume is a string that references an already
                                 created Quobyte volume by name.
                               type: string
                           required:
@@ -5419,43 +5429,44 @@ spec:
                           - volume
                           type: object
                         rbd:
-                          description: 'RBD represents a Rados Block Device mount
+                          description: 'rbd represents a Rados Block Device mount
                             on the host that shares a pod''s lifetime. More info:
                             https://examples.k8s.io/volumes/rbd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             image:
-                              description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             keyring:
-                              description: 'Keyring is the path to key ring for RBDUser.
+                              description: 'keyring is the path to key ring for RBDUser.
                                 Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             monitors:
-                              description: 'A collection of Ceph monitors. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             pool:
-                              description: 'The rados pool name. Default is rbd. More
-                                info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
+                              description: 'readOnly here will force the ReadOnly
                                 setting in VolumeMounts. Defaults to false. More info:
                                 https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: boolean
                             secretRef:
-                              description: 'SecretRef is name of the authentication
+                              description: 'secretRef is name of the authentication
                                 secret for RBDUser. If provided overrides keyring.
                                 Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               properties:
@@ -5466,35 +5477,36 @@ spec:
                                   type: string
                               type: object
                             user:
-                              description: 'The rados user name. Default is admin.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                           required:
                           - image
                           - monitors
                           type: object
                         scaleIO:
-                          description: ScaleIO represents a ScaleIO persistent volume
+                          description: scaleIO represents a ScaleIO persistent volume
                             attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Default is "xfs".
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                               type: string
                             gateway:
-                              description: The host address of the ScaleIO API Gateway.
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
                               type: string
                             protectionDomain:
-                              description: The name of the ScaleIO Protection Domain
-                                for the configured storage.
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef references to the secret for
+                              description: secretRef references to the secret for
                                 ScaleIO user and other sensitive information. If this
                                 is not provided, Login operation will fail.
                               properties:
@@ -5505,26 +5517,26 @@ spec:
                                   type: string
                               type: object
                             sslEnabled:
-                              description: Flag to enable/disable SSL communication
+                              description: sslEnabled Flag enable/disable SSL communication
                                 with Gateway, default false
                               type: boolean
                             storageMode:
-                              description: Indicates whether the storage for a volume
-                                should be ThickProvisioned or ThinProvisioned. Default
-                                is ThinProvisioned.
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
                               type: string
                             storagePool:
-                              description: The ScaleIO Storage Pool associated with
-                                the protection domain.
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
                               type: string
                             system:
-                              description: The name of the storage system as configured
-                                in ScaleIO.
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
                               type: string
                             volumeName:
-                              description: The name of a volume already created in
-                                the ScaleIO system that is associated with this volume
-                                source.
+                              description: volumeName is the name of a volume already
+                                created in the ScaleIO system that is associated with
+                                this volume source.
                               type: string
                           required:
                           - gateway
@@ -5532,57 +5544,58 @@ spec:
                           - system
                           type: object
                         secret:
-                          description: 'Secret represents a secret that should populate
+                          description: 'secret represents a secret that should populate
                             this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced Secret will be projected
-                                into the volume as a file whose name is the key and
-                                content is the value. If specified, the listed keys
-                                will be projected into the specified paths, and unlisted
-                                keys will not be present. If a key is specified which
-                                is not present in the Secret, the volume setup will
-                                error unless it is marked optional. Paths must be
-                                relative and may not contain the '..' path or start
-                                with '..'.
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
                                 properties:
                                   key:
-                                    description: The key to project.
+                                    description: key is the key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -5590,30 +5603,30 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: Specify whether the Secret or its keys
-                                must be defined
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
                               type: boolean
                             secretName:
-                              description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
                         storageos:
-                          description: StorageOS represents a StorageOS volume attached
+                          description: storageOS represents a StorageOS volume attached
                             and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef specifies the secret to use for
+                              description: secretRef specifies the secret to use for
                                 obtaining the StorageOS API credentials.  If not specified,
                                 default values will be attempted.
                               properties:
@@ -5624,12 +5637,12 @@ spec:
                                   type: string
                               type: object
                             volumeName:
-                              description: VolumeName is the human-readable name of
+                              description: volumeName is the human-readable name of
                                 the StorageOS volume.  Volume names are only unique
                                 within a namespace.
                               type: string
                             volumeNamespace:
-                              description: VolumeNamespace specifies the scope of
+                              description: volumeNamespace specifies the scope of
                                 the volume within StorageOS.  If no namespace is specified
                                 then the Pod's namespace will be used.  This allows
                                 the Kubernetes name scoping to be mirrored within
@@ -5641,25 +5654,26 @@ spec:
                               type: string
                           type: object
                         vsphereVolume:
-                          description: VsphereVolume represents a vSphere volume attached
+                          description: vsphereVolume represents a vSphere volume attached
                             and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             storagePolicyID:
-                              description: Storage Policy Based Management (SPBM)
-                                profile ID associated with the StoragePolicyName.
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
-                              description: Storage Policy Based Management (SPBM)
-                                profile name.
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
                               type: string
                             volumePath:
-                              description: Path that identifies vSphere volume vmdk
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
                               type: string
                           required:
                           - volumePath
@@ -5786,11 +5800,11 @@ spec:
                         run within a pod.
                       properties:
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
                             to a single $, which allows for escaping the $(VAR_NAME)
                             syntax: i.e. "$$(VAR_NAME)" will produce the string literal
                             "$(VAR_NAME)". Escaped references will never be expanded,
@@ -5801,7 +5815,7 @@ spec:
                           type: array
                         command:
                           description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
+                            The container image''s ENTRYPOINT is used if this is not
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
@@ -5977,7 +5991,7 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                             This field is optional to allow higher level config management
                             to default or override container images in workload controllers
                             like Deployments and StatefulSets.'
@@ -6213,8 +6227,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -6421,8 +6435,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -6786,8 +6800,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -7049,11 +7063,11 @@ spec:
                         run within a pod.
                       properties:
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
                             to a single $, which allows for escaping the $(VAR_NAME)
                             syntax: i.e. "$$(VAR_NAME)" will produce the string literal
                             "$(VAR_NAME)". Escaped references will never be expanded,
@@ -7064,7 +7078,7 @@ spec:
                           type: array
                         command:
                           description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
+                            The container image''s ENTRYPOINT is used if this is not
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
@@ -7240,7 +7254,7 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                             This field is optional to allow higher level config management
                             to default or override container images in workload controllers
                             like Deployments and StatefulSets.'
@@ -7476,8 +7490,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -7684,8 +7698,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -8049,8 +8063,8 @@ spec:
                               type: integer
                             grpc:
                               description: GRPC specifies an action involving a GRPC
-                                port. This is an alpha field and requires enabling
-                                GRPCContainerProbe feature gate.
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number
@@ -8601,9 +8615,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -8660,7 +8672,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -8764,9 +8776,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -8821,7 +8831,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -8925,9 +8935,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -8984,7 +8992,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -9088,9 +9096,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -9145,7 +9151,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -9503,6 +9509,12 @@ spec:
                     description: Annotations to be added to the external service
                     type: object
                 type: object
+              reservedPortList:
+                description: Reserved ports
+                items:
+                  format: int32
+                  type: integer
+                type: array
               tls:
                 description: 'TLS is the Pravega security configuration that is passed
                   to the Pravega processes. See the following file for a complete

--- a/pkg/util/pravegacluster.go
+++ b/pkg/util/pravegacluster.go
@@ -138,6 +138,15 @@ func ContainsString(slice []string, str string) bool {
 	return false
 }
 
+func ContainsElement(items []int32, elem int32) bool {
+	for _, item := range items {
+		if item == elem {
+			return true
+		}
+	}
+	return false
+}
+
 func RemoveString(slice []string, str string) (result []string) {
 	for _, item := range slice {
 		if item == str {


### PR DESCRIPTION
### Change log description

While deploying pravega with 12 segmentstore pods, segmentstore service was using one of the ports used by other service `containerd` and was causing conflict
Added new spec field in CRD as `reservedPortList` and while assigning port to service ensure that it is not in reserved port List 

### Purpose of the change

Fixes #674

### What the code does

Assigning port to segment store services which is not in the reserved portList, if it finds conflict next  port will be assigned.

### How to verify it

Verified pravega installation with 12 segmentstore pods and ensured that ports mentioned in reservedportlist are getting skipped. 